### PR TITLE
Add channel filtering and resampling methods to LogFile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,3 +61,22 @@ Pyodide test scripts are in `scripts/run_pyodide_tests*.mjs`.
 - `get_channels_as_table()` merges via full outer join with interpolation/forward-fill
 - Channel metadata stored in PyArrow field.metadata (bytes keys: `b"units"`, `b"dec_pts"`, `b"interpolate"`)
 - GPS timing fix auto-corrects 65533ms gaps (AIM firmware bug)
+- All filtering/resampling methods return new `LogFile` instances (immutable pattern)
+- `resample_to_timecodes()` is the core resampling logic, other methods delegate to it
+
+## LogFile Methods
+
+- `select_channels(names)` - Return LogFile with only specified channels
+- `filter_by_time_range(start, end, channels?)` - Filter to time range [start, end)
+- `filter_by_lap(lap_num, channels?)` - Filter to specific lap's time range
+- `resample_to_timecodes(timecodes, channels?)` - Resample all channels to target timebase
+- `resample_to_channel(ref_channel, channels?)` - Resample to reference channel's timebase
+- `get_channels_as_table()` - Merge all channels into single table
+
+## Documentation Requirements
+
+When changing the public API:
+1. Update docstrings with Google-style format (Args, Returns, Raises, Example)
+2. Update `README.md` usage examples
+3. Update `src/libxrk/CLAUDE.md` API reference
+4. Update type stubs if needed (`.pyi` files)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,44 @@ for i in range(log.laps.num_rows):
 print(log.metadata)
 ```
 
+### Filtering and Resampling
+
+```python
+from libxrk import aim_xrk
+
+log = aim_xrk('session.xrk')
+
+# Select specific channels
+gps_log = log.select_channels(['GPS Latitude', 'GPS Longitude', 'GPS Speed'])
+
+# Filter to a time range (milliseconds, inclusive start, exclusive end)
+segment = log.filter_by_time_range(60000, 120000)
+
+# Filter to a specific lap
+lap5 = log.filter_by_lap(5)
+
+# Combine filtering and channel selection
+lap5_gps = log.filter_by_lap(5, channel_names=['GPS Latitude', 'GPS Longitude'])
+
+# Resample all channels to match a reference channel's timebase
+aligned = log.resample_to_channel('GPS Speed')
+
+# Resample to a custom timebase
+import pyarrow as pa
+target = pa.array(range(0, 100000, 100), type=pa.int64())  # 10 Hz
+resampled = log.resample_to_timecodes(target)
+
+# Chain operations for analysis workflows
+df = (log
+    .filter_by_lap(5)
+    .select_channels(['Engine RPM', 'GPS Speed'])
+    .resample_to_channel('GPS Speed')
+    .get_channels_as_table()
+    .to_pandas())
+```
+
+All filtering and resampling methods return new `LogFile` instances (immutable pattern), enabling method chaining for complex analysis workflows.
+
 ## Development
 
 ### Quick Check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libxrk"
-version = "0.4.0"
+version = "0.5.0"
 description = "Library for reading AIM XRK files from AIM automotive data loggers"
 authors = [
     {name = "Christopher Dewan",email = "chris.dewan@m3rlin.net"}

--- a/src/libxrk/CLAUDE.md
+++ b/src/libxrk/CLAUDE.md
@@ -36,6 +36,49 @@ units = field.metadata.get(b'units', b'').decode()  # e.g., "rpm"
 
 Keys: `b"units"`, `b"dec_pts"`, `b"interpolate"`
 
+## LogFile Methods
+
+### Channel Selection
+```python
+log.select_channels(['GPS Speed', 'Engine RPM'])  # Returns new LogFile
+```
+
+### Time Filtering
+```python
+log.filter_by_time_range(60000, 120000)  # [start, end) in ms
+log.filter_by_time_range(60000, 120000, channel_names=['GPS Speed'])
+```
+
+### Lap Filtering
+```python
+log.filter_by_lap(5)  # Filter to lap 5's time range
+log.filter_by_lap(5, channel_names=['GPS Speed'])
+```
+
+### Resampling
+```python
+# Resample to a reference channel's timebase
+log.resample_to_channel('GPS Speed')
+
+# Resample to custom timebase
+target = pa.array(range(0, 100000, 100), type=pa.int64())
+log.resample_to_timecodes(target)
+```
+
+### Merging Channels
+```python
+log.get_channels_as_table()  # Returns pa.Table with all channels merged
+```
+
+All methods return new `LogFile` instances, enabling chaining:
+```python
+df = (log
+    .filter_by_lap(5)
+    .select_channels(['Engine RPM', 'GPS Speed'])
+    .get_channels_as_table()
+    .to_pandas())
+```
+
 ## GPS Timing Fix
 
 Some AIM loggers have a firmware bug causing 65533ms timestamp gaps in GPS data (16-bit overflow). This is automatically corrected when loading files - no action needed.
@@ -53,4 +96,8 @@ df = log.get_channels_as_table().to_pandas()
 
 # Load from bytes/BytesIO
 log = aim_xrk(file_bytes)
+
+# Filter and analyze a specific lap
+lap5 = log.filter_by_lap(5, ['GPS Speed', 'Engine RPM'])
+df = lap5.get_channels_as_table().to_pandas()
 ```

--- a/src/libxrk/base.py
+++ b/src/libxrk/base.py
@@ -1,8 +1,10 @@
 # Copyright 2024, Scott Smith.  MIT License (see LICENSE).
 
+from collections.abc import Sequence
 from dataclasses import dataclass
+import heapq
+from itertools import groupby
 import sys
-import typing
 import pyarrow as pa
 import pyarrow.compute as pc
 import numpy as np
@@ -34,9 +36,9 @@ class LogFile:
         >>> log.get_channels_as_table().to_pandas()  # All merged
     """
 
-    channels: typing.Dict[str, pa.Table]
+    channels: dict[str, pa.Table]
     laps: pa.Table
-    metadata: typing.Dict[str, str]
+    metadata: dict[str, str]
     file_name: str
 
     def get_channels_as_table(self) -> pa.Table:
@@ -57,114 +59,37 @@ class LogFile:
             # Return an empty table with just timecodes column if no channels
             return pa.table({"timecodes": pa.array([], type=pa.int64())})
 
-        # Collect metadata from all channels before joining
-        # PyArrow join() doesn't preserve field metadata, so we need to save and restore it
+        # Compute union of all channel timecodes using k-way merge (O(N) vs O(N log N) for sort)
+        # Each channel's timecodes are already sorted, so we merge and deduplicate in one pass
+        timecode_iterators = [
+            channel_table.column("timecodes").to_pylist()
+            for channel_table in self.channels.values()
+        ]
+        merged = heapq.merge(*timecode_iterators)
+        unique_timecodes = [k for k, _ in groupby(merged)]
+        union_timecodes = pa.array(unique_timecodes, type=pa.int64())
+
+        # Resample all channels to the union timecodes
+        resampled = self.resample_to_timecodes(union_timecodes)
+
+        # Build merged table from resampled channels (simple horizontal concatenation)
+        channel_names = sorted(resampled.channels.keys())
+
+        # Collect metadata for restoration
         channel_metadata = {}
-        for channel_name, channel_table in self.channels.items():
-            field = channel_table.schema.field(channel_name)
+        for name in channel_names:
+            field = resampled.channels[name].schema.field(name)
             if field.metadata:
-                channel_metadata[channel_name] = field.metadata
+                channel_metadata[name] = field.metadata
 
-        # Start with the first channel
-        channel_names = sorted(self.channels.keys())
-        result = self.channels[channel_names[0]]
+        # Build the result table
+        columns_dict = {"timecodes": union_timecodes}
+        for name in channel_names:
+            columns_dict[name] = resampled.channels[name].column(name)
 
-        # Perform full outer joins with remaining channels
-        for channel_name in channel_names[1:]:
-            channel_table = self.channels[channel_name]
-
-            # Perform full outer join on timecodes
-            result = result.join(
-                channel_table, keys="timecodes", right_keys="timecodes", join_type="full outer"
-            )
-
-        # Sort by timecodes to maintain temporal order
-        result = result.sort_by([("timecodes", "ascending")])
-
-        # Restore column metadata that was lost during join operations
-        if channel_metadata:
-            new_fields = []
-            for field in result.schema:
-                if field.name in channel_metadata:
-                    # Restore the metadata for this channel
-                    new_fields.append(field.with_metadata(channel_metadata[field.name]))
-                else:
-                    new_fields.append(field)
-            new_schema = pa.schema(new_fields)
-            result = result.cast(new_schema)
-
-        # Fill nulls based on interpolate metadata
-        # Process each channel column (skip timecodes)
-        columns_dict = {}
-        columns_dict["timecodes"] = result.column("timecodes")
-
-        timecodes_np = result.column("timecodes").to_numpy()
-
-        for field in result.schema:
-            if field.name == "timecodes":
-                continue
-
-            column = result.column(field.name)
-
-            # Check if we should interpolate
-            should_interpolate = False
-            if field.metadata:
-                interpolate_value = field.metadata.get(b"interpolate", b"").decode("utf-8")
-                should_interpolate = interpolate_value == "True"
-
-            if should_interpolate:
-                # Linear interpolation using numpy for efficiency
-                column_np = column.to_numpy(zero_copy_only=False)
-
-                # Find non-null indices
-                valid_mask = (
-                    ~np.isnan(column_np)
-                    if np.issubdtype(column_np.dtype, np.floating)
-                    else column is not None
-                )
-
-                if isinstance(valid_mask, bool):
-                    # All values are null or non-null
-                    columns_dict[field.name] = column
-                else:
-                    valid_indices = np.where(valid_mask)[0]
-
-                    if len(valid_indices) > 0:
-                        # Perform linear interpolation
-                        # Use numpy.interp which handles extrapolation by extending edge values
-                        interpolated = np.interp(
-                            timecodes_np,
-                            timecodes_np[valid_indices],
-                            column_np[valid_indices],
-                        )
-                        columns_dict[field.name] = pa.array(interpolated, type=field.type)
-                    else:
-                        # All nulls, keep as is
-                        columns_dict[field.name] = column
-            else:
-                # Forward fill (use previous non-null value)
-                # PyArrow's fill_null with forward fill
-                filled = pc.fill_null_forward(column)
-                columns_dict[field.name] = filled
-
-        # Reconstruct table with filled values
         result = pa.table(columns_dict)
 
-        # Backward fill any remaining leading nulls (nulls before first value in each column)
-        columns_dict_final = {}
-        columns_dict_final["timecodes"] = result.column("timecodes")
-        for field in result.schema:
-            if field.name == "timecodes":
-                continue
-            column = result.column(field.name)
-            # Backward fill to handle leading nulls
-            filled = pc.fill_null_backward(column)
-            columns_dict_final[field.name] = filled
-
-        # Reconstruct table after backward fill
-        result = pa.table(columns_dict_final)
-
-        # Restore schema with metadata (fill operations lose metadata)
+        # Restore schema with metadata
         if channel_metadata:
             new_fields = []
             for field in result.schema:
@@ -176,3 +101,237 @@ class LogFile:
             result = result.cast(new_schema)
 
         return result
+
+    def select_channels(self, channel_names: Sequence[str]) -> "LogFile":
+        """
+        Create a new LogFile with only the specified channels.
+
+        Args:
+            channel_names: Sequence of channel names to include.
+
+        Returns:
+            New LogFile containing only the specified channels.
+
+        Raises:
+            KeyError: If any channel name is not found.
+
+        Example:
+            >>> log = aim_xrk('session.xrk')
+            >>> gps_log = log.select_channels(['GPS Latitude', 'GPS Longitude', 'GPS Speed'])
+            >>> print(gps_log.channels.keys())
+        """
+        missing = set(channel_names) - set(self.channels.keys())
+        if missing:
+            raise KeyError(f"Channels not found: {sorted(missing)}")
+
+        new_channels = {name: self.channels[name] for name in channel_names}
+        return LogFile(
+            channels=new_channels,
+            laps=self.laps,
+            metadata=self.metadata,
+            file_name=self.file_name,
+        )
+
+    def filter_by_time_range(
+        self,
+        start_time: int,
+        end_time: int,
+        channel_names: Sequence[str] | None = None,
+    ) -> "LogFile":
+        """
+        Filter channels to a time range [start_time, end_time) at native sample rates.
+
+        Args:
+            start_time: Start time in milliseconds (inclusive).
+            end_time: End time in milliseconds (exclusive).
+            channel_names: Optional sequence of channel names to include. If None, all channels.
+
+        Returns:
+            New LogFile with channels filtered to the time range.
+
+        Example:
+            >>> log = aim_xrk('session.xrk')
+            >>> segment = log.filter_by_time_range(60000, 120000)
+            >>> print(segment.channels['Engine RPM'].num_rows)
+        """
+        source = self.select_channels(channel_names) if channel_names is not None else self
+
+        new_channels = {}
+        for name, channel_table in source.channels.items():
+            timecodes = channel_table.column("timecodes")
+
+            # Filter to [start_time, end_time)
+            mask = pc.and_(
+                pc.greater_equal(timecodes, start_time),
+                pc.less(timecodes, end_time),
+            )
+            new_channels[name] = channel_table.filter(mask)
+
+        # Filter laps to only those overlapping with the time range
+        laps_start = self.laps.column("start_time")
+        laps_end = self.laps.column("end_time")
+
+        # A lap overlaps if: lap_start < end_time AND lap_end > start_time
+        laps_mask = pc.and_(
+            pc.less(laps_start, end_time),
+            pc.greater(laps_end, start_time),
+        )
+        new_laps = self.laps.filter(laps_mask)
+
+        return LogFile(
+            channels=new_channels,
+            laps=new_laps,
+            metadata=self.metadata,
+            file_name=self.file_name,
+        )
+
+    def filter_by_lap(
+        self,
+        lap_num: int,
+        channel_names: Sequence[str] | None = None,
+    ) -> "LogFile":
+        """
+        Filter channels to a specific lap's time range.
+
+        Args:
+            lap_num: The lap number to filter to.
+            channel_names: Optional sequence of channel names to include. If None, all channels.
+
+        Returns:
+            New LogFile with channels filtered to the lap's time range.
+
+        Raises:
+            ValueError: If lap_num is not found in the laps table.
+
+        Example:
+            >>> log = aim_xrk('session.xrk')
+            >>> lap5 = log.filter_by_lap(5, ['GPS Speed', 'Engine RPM'])
+            >>> df = lap5.get_channels_as_table().to_pandas()
+        """
+        lap_nums = self.laps.column("num").to_pylist()
+        if lap_num not in lap_nums:
+            raise ValueError(f"Lap {lap_num} not found. Available laps: {lap_nums}")
+
+        lap_idx = lap_nums.index(lap_num)
+        start_time = self.laps.column("start_time")[lap_idx].as_py()
+        end_time = self.laps.column("end_time")[lap_idx].as_py()
+
+        return self.filter_by_time_range(int(start_time), int(end_time), channel_names)
+
+    def resample_to_timecodes(
+        self,
+        timecodes: pa.Array,
+        channel_names: Sequence[str] | None = None,
+    ) -> "LogFile":
+        """
+        Resample all channels to a target timebase.
+
+        For channels with interpolate="True" metadata, performs linear interpolation.
+        For other channels, uses forward-fill then backward-fill for leading nulls.
+
+        Args:
+            timecodes: Target timecodes array (int64, milliseconds) to resample to.
+            channel_names: Optional sequence of channel names to include. If None, all channels.
+
+        Returns:
+            New LogFile with all channels resampled to the target timecodes.
+
+        Example:
+            >>> log = aim_xrk('session.xrk')
+            >>> target = pa.array(range(0, 100000, 100), type=pa.int64())
+            >>> resampled = log.resample_to_timecodes(target)
+        """
+        source = self.select_channels(channel_names) if channel_names is not None else self
+
+        target_timecodes_np = timecodes.to_numpy()
+        new_channels = {}
+
+        for name, channel_table in source.channels.items():
+            field = channel_table.schema.field(name)
+            channel_timecodes = channel_table.column("timecodes").to_numpy()
+            channel_values = channel_table.column(name).to_numpy(zero_copy_only=False)
+
+            # Check if we should interpolate
+            should_interpolate = False
+            if field.metadata:
+                interpolate_value = field.metadata.get(b"interpolate", b"").decode("utf-8")
+                should_interpolate = interpolate_value == "True"
+
+            if should_interpolate:
+                # Linear interpolation using numpy
+                # np.interp handles extrapolation by extending edge values
+                resampled_values = np.interp(
+                    target_timecodes_np,
+                    channel_timecodes,
+                    channel_values,
+                )
+            else:
+                # Forward-fill approach using searchsorted
+                # Find the index of the largest timecode <= each target timecode
+                indices = np.searchsorted(channel_timecodes, target_timecodes_np, side="right") - 1
+
+                # Handle leading nulls: where target is before first source timecode
+                leading_mask = indices < 0
+
+                # Clamp indices to valid range
+                indices = np.clip(indices, 0, len(channel_values) - 1)
+
+                resampled_values = channel_values[indices]
+
+                # For leading values (before first source timecode), backward fill
+                if np.any(leading_mask):
+                    resampled_values = resampled_values.copy()
+                    resampled_values[leading_mask] = channel_values[0]
+
+            # Build new channel table preserving metadata
+            new_table = pa.table(
+                {
+                    "timecodes": timecodes,
+                    name: pa.array(resampled_values, type=field.type),
+                }
+            )
+
+            # Restore metadata
+            if field.metadata:
+                new_field = new_table.schema.field(name).with_metadata(field.metadata)
+                new_schema = pa.schema([new_table.schema.field("timecodes"), new_field])
+                new_table = new_table.cast(new_schema)
+
+            new_channels[name] = new_table
+
+        return LogFile(
+            channels=new_channels,
+            laps=self.laps,
+            metadata=self.metadata,
+            file_name=self.file_name,
+        )
+
+    def resample_to_channel(
+        self,
+        reference_channel: str,
+        channel_names: Sequence[str] | None = None,
+    ) -> "LogFile":
+        """
+        Resample all channels to match a reference channel's timebase.
+
+        Args:
+            reference_channel: Name of the channel whose timecodes will be used.
+            channel_names: Optional sequence of channel names to include. If None, all channels.
+
+        Returns:
+            New LogFile with all channels resampled to the reference channel's timecodes.
+
+        Raises:
+            KeyError: If reference_channel is not found.
+
+        Example:
+            >>> log = aim_xrk('session.xrk')
+            >>> aligned = log.resample_to_channel('GPS Speed')
+            >>> df = aligned.get_channels_as_table().to_pandas()
+        """
+        if reference_channel not in self.channels:
+            raise KeyError(f"Reference channel not found: {reference_channel}")
+
+        ref_timecodes = self.channels[reference_channel].column("timecodes").combine_chunks()
+
+        return self.resample_to_timecodes(ref_timecodes, channel_names)

--- a/tests/test_logfile_methods.py
+++ b/tests/test_logfile_methods.py
@@ -1,0 +1,496 @@
+"""Unit tests for LogFile filtering and resampling methods."""
+
+import unittest
+import pyarrow as pa
+from libxrk.base import LogFile
+
+
+def create_channel_with_metadata(
+    timecodes: list,
+    values: list,
+    name: str,
+    units: str = "",
+    dec_pts: str = "",
+    interpolate: str = "",
+) -> pa.Table:
+    """Helper to create a channel table with metadata."""
+    table = pa.table(
+        {
+            "timecodes": pa.array(timecodes, type=pa.int64()),
+            name: pa.array(values, type=pa.float32()),
+        }
+    )
+
+    metadata = {}
+    if units:
+        metadata[b"units"] = units.encode()
+    if dec_pts:
+        metadata[b"dec_pts"] = dec_pts.encode()
+    if interpolate:
+        metadata[b"interpolate"] = interpolate.encode()
+
+    if metadata:
+        field = table.schema.field(name)
+        new_field = field.with_metadata(metadata)
+        new_schema = pa.schema([table.schema.field("timecodes"), new_field])
+        table = table.cast(new_schema)
+
+    return table
+
+
+def create_test_logfile(
+    channels: dict[str, pa.Table],
+    laps: list[tuple[int, int, int]] | None = None,
+) -> LogFile:
+    """Helper to create a test LogFile."""
+    if laps is None:
+        laps_table = pa.table({"num": [], "start_time": [], "end_time": []})
+    else:
+        laps_table = pa.table(
+            {
+                "num": [lap[0] for lap in laps],
+                "start_time": [float(lap[1]) for lap in laps],
+                "end_time": [float(lap[2]) for lap in laps],
+            }
+        )
+
+    return LogFile(
+        channels=channels,
+        laps=laps_table,
+        metadata={},
+        file_name="test.xrk",
+    )
+
+
+class TestSelectChannels(unittest.TestCase):
+    """Tests for LogFile.select_channels()."""
+
+    def test_select_channels_basic(self):
+        """Test selecting a subset of channels."""
+        channels = {
+            "ChannelA": create_channel_with_metadata([0, 100], [1.0, 2.0], "ChannelA"),
+            "ChannelB": create_channel_with_metadata([0, 100], [10.0, 20.0], "ChannelB"),
+            "ChannelC": create_channel_with_metadata([0, 100], [100.0, 200.0], "ChannelC"),
+        }
+        log = create_test_logfile(channels)
+
+        result = log.select_channels(["ChannelA", "ChannelC"])
+
+        self.assertEqual(set(result.channels.keys()), {"ChannelA", "ChannelC"})
+        self.assertEqual(result.channels["ChannelA"].num_rows, 2)
+        self.assertEqual(result.channels["ChannelC"].num_rows, 2)
+
+    def test_select_channels_missing_raises(self):
+        """Test that selecting missing channels raises KeyError."""
+        channels = {
+            "ChannelA": create_channel_with_metadata([0, 100], [1.0, 2.0], "ChannelA"),
+        }
+        log = create_test_logfile(channels)
+
+        with self.assertRaises(KeyError) as ctx:
+            log.select_channels(["ChannelA", "NotExist"])
+
+        self.assertIn("NotExist", str(ctx.exception))
+
+    def test_select_channels_preserves_metadata(self):
+        """Test that selecting channels preserves their metadata."""
+        channels = {
+            "ChannelA": create_channel_with_metadata(
+                [0, 100], [1.0, 2.0], "ChannelA", units="m/s", dec_pts="2", interpolate="True"
+            ),
+        }
+        log = create_test_logfile(channels)
+
+        result = log.select_channels(["ChannelA"])
+
+        field = result.channels["ChannelA"].schema.field("ChannelA")
+        self.assertEqual(field.metadata.get(b"units"), b"m/s")
+        self.assertEqual(field.metadata.get(b"dec_pts"), b"2")
+        self.assertEqual(field.metadata.get(b"interpolate"), b"True")
+
+
+class TestFilterByTimeRange(unittest.TestCase):
+    """Tests for LogFile.filter_by_time_range()."""
+
+    def test_filter_by_time_range_basic(self):
+        """Test basic time range filtering."""
+        channels = {
+            "ChannelA": create_channel_with_metadata(
+                [0, 50, 100, 150, 200], [1.0, 2.0, 3.0, 4.0, 5.0], "ChannelA"
+            ),
+        }
+        log = create_test_logfile(channels)
+
+        result = log.filter_by_time_range(50, 150)
+
+        # Should include 50 and 100, but not 150 (exclusive end)
+        self.assertEqual(result.channels["ChannelA"].num_rows, 2)
+        timecodes = result.channels["ChannelA"].column("timecodes").to_pylist()
+        self.assertEqual(timecodes, [50, 100])
+
+    def test_filter_by_time_range_with_channel_selection(self):
+        """Test filtering with specific channel names."""
+        channels = {
+            "ChannelA": create_channel_with_metadata([0, 100, 200], [1.0, 2.0, 3.0], "ChannelA"),
+            "ChannelB": create_channel_with_metadata([0, 100, 200], [10.0, 20.0, 30.0], "ChannelB"),
+        }
+        log = create_test_logfile(channels)
+
+        result = log.filter_by_time_range(0, 150, channel_names=["ChannelA"])
+
+        self.assertEqual(set(result.channels.keys()), {"ChannelA"})
+        self.assertEqual(result.channels["ChannelA"].num_rows, 2)
+
+    def test_filter_by_time_range_preserves_metadata(self):
+        """Test that filtering preserves channel metadata."""
+        channels = {
+            "ChannelA": create_channel_with_metadata(
+                [0, 100, 200], [1.0, 2.0, 3.0], "ChannelA", units="rpm", interpolate="True"
+            ),
+        }
+        log = create_test_logfile(channels)
+
+        result = log.filter_by_time_range(0, 150)
+
+        field = result.channels["ChannelA"].schema.field("ChannelA")
+        self.assertEqual(field.metadata.get(b"units"), b"rpm")
+        self.assertEqual(field.metadata.get(b"interpolate"), b"True")
+
+    def test_filter_by_time_range_empty_result(self):
+        """Test filtering that results in empty channels."""
+        channels = {
+            "ChannelA": create_channel_with_metadata([0, 100, 200], [1.0, 2.0, 3.0], "ChannelA"),
+        }
+        log = create_test_logfile(channels)
+
+        result = log.filter_by_time_range(500, 600)
+
+        self.assertEqual(result.channels["ChannelA"].num_rows, 0)
+
+    def test_filter_by_time_range_filters_laps(self):
+        """Test that laps are filtered to overlapping ones."""
+        channels = {
+            "ChannelA": create_channel_with_metadata(
+                [0, 100, 200, 300], [1.0, 2.0, 3.0, 4.0], "ChannelA"
+            ),
+        }
+        laps = [
+            (0, 0, 100),
+            (1, 100, 200),
+            (2, 200, 300),
+        ]
+        log = create_test_logfile(channels, laps)
+
+        result = log.filter_by_time_range(50, 150)
+
+        # Laps 0 and 1 overlap with [50, 150)
+        self.assertEqual(result.laps.num_rows, 2)
+        lap_nums = result.laps.column("num").to_pylist()
+        self.assertEqual(lap_nums, [0, 1])
+
+    def test_filter_by_time_range_missing_channel_raises(self):
+        """Test that filtering with missing channels raises KeyError."""
+        channels = {
+            "ChannelA": create_channel_with_metadata([0, 100], [1.0, 2.0], "ChannelA"),
+        }
+        log = create_test_logfile(channels)
+
+        with self.assertRaises(KeyError):
+            log.filter_by_time_range(0, 100, channel_names=["NotExist"])
+
+
+class TestFilterByLap(unittest.TestCase):
+    """Tests for LogFile.filter_by_lap()."""
+
+    def test_filter_by_lap_basic(self):
+        """Test filtering by a specific lap."""
+        channels = {
+            "ChannelA": create_channel_with_metadata(
+                [0, 50, 100, 150, 200, 250], [1.0, 2.0, 3.0, 4.0, 5.0, 6.0], "ChannelA"
+            ),
+        }
+        laps = [
+            (0, 0, 100),
+            (1, 100, 200),
+            (2, 200, 300),
+        ]
+        log = create_test_logfile(channels, laps)
+
+        result = log.filter_by_lap(1)
+
+        # Lap 1 is [100, 200)
+        timecodes = result.channels["ChannelA"].column("timecodes").to_pylist()
+        self.assertEqual(timecodes, [100, 150])
+
+    def test_filter_by_lap_invalid_raises(self):
+        """Test that filtering by invalid lap raises ValueError."""
+        channels = {
+            "ChannelA": create_channel_with_metadata([0, 100], [1.0, 2.0], "ChannelA"),
+        }
+        laps = [(0, 0, 100)]
+        log = create_test_logfile(channels, laps)
+
+        with self.assertRaises(ValueError) as ctx:
+            log.filter_by_lap(99)
+
+        self.assertIn("99", str(ctx.exception))
+        self.assertIn("not found", str(ctx.exception))
+
+    def test_filter_by_lap_with_channel_names(self):
+        """Test filtering by lap with specific channel names."""
+        channels = {
+            "ChannelA": create_channel_with_metadata([0, 100, 200], [1.0, 2.0, 3.0], "ChannelA"),
+            "ChannelB": create_channel_with_metadata([0, 100, 200], [10.0, 20.0, 30.0], "ChannelB"),
+        }
+        laps = [(0, 0, 150)]
+        log = create_test_logfile(channels, laps)
+
+        result = log.filter_by_lap(0, channel_names=["ChannelA"])
+
+        self.assertEqual(set(result.channels.keys()), {"ChannelA"})
+
+
+class TestResampleToTimecodes(unittest.TestCase):
+    """Tests for LogFile.resample_to_timecodes()."""
+
+    def test_resample_to_timecodes_interpolation(self):
+        """Test linear interpolation for channels with interpolate=True."""
+        channels = {
+            "ChannelA": create_channel_with_metadata(
+                [0, 100, 200], [0.0, 10.0, 20.0], "ChannelA", interpolate="True"
+            ),
+        }
+        log = create_test_logfile(channels)
+
+        target = pa.array([0, 50, 100, 150, 200], type=pa.int64())
+        result = log.resample_to_timecodes(target)
+
+        values = result.channels["ChannelA"].column("ChannelA").to_pylist()
+        # 0 -> 0.0, 50 -> 5.0 (interpolated), 100 -> 10.0, 150 -> 15.0, 200 -> 20.0
+        self.assertAlmostEqual(values[0], 0.0, places=5)
+        self.assertAlmostEqual(values[1], 5.0, places=5)
+        self.assertAlmostEqual(values[2], 10.0, places=5)
+        self.assertAlmostEqual(values[3], 15.0, places=5)
+        self.assertAlmostEqual(values[4], 20.0, places=5)
+
+    def test_resample_to_timecodes_forward_fill(self):
+        """Test forward-fill for channels without interpolate=True."""
+        channels = {
+            "ChannelA": create_channel_with_metadata(
+                [0, 100, 200], [1.0, 2.0, 3.0], "ChannelA", interpolate="False"
+            ),
+        }
+        log = create_test_logfile(channels)
+
+        target = pa.array([0, 50, 100, 150, 200], type=pa.int64())
+        result = log.resample_to_timecodes(target)
+
+        values = result.channels["ChannelA"].column("ChannelA").to_pylist()
+        # 0 -> 1.0, 50 -> 1.0 (forward fill), 100 -> 2.0, 150 -> 2.0 (forward fill), 200 -> 3.0
+        self.assertEqual(values, [1.0, 1.0, 2.0, 2.0, 3.0])
+
+    def test_resample_to_timecodes_backward_fill_leading(self):
+        """Test backward-fill for target timecodes before source data."""
+        channels = {
+            "ChannelA": create_channel_with_metadata(
+                [100, 200], [10.0, 20.0], "ChannelA", interpolate="False"
+            ),
+        }
+        log = create_test_logfile(channels)
+
+        target = pa.array([0, 50, 100, 150, 200], type=pa.int64())
+        result = log.resample_to_timecodes(target)
+
+        values = result.channels["ChannelA"].column("ChannelA").to_pylist()
+        # 0 -> 10.0 (backward fill), 50 -> 10.0 (backward fill), 100 -> 10.0, 150 -> 10.0, 200 -> 20.0
+        self.assertEqual(values, [10.0, 10.0, 10.0, 10.0, 20.0])
+
+    def test_resample_to_timecodes_preserves_metadata(self):
+        """Test that resampling preserves channel metadata."""
+        channels = {
+            "ChannelA": create_channel_with_metadata(
+                [0, 100], [1.0, 2.0], "ChannelA", units="m/s", dec_pts="2", interpolate="True"
+            ),
+        }
+        log = create_test_logfile(channels)
+
+        target = pa.array([0, 50, 100], type=pa.int64())
+        result = log.resample_to_timecodes(target)
+
+        field = result.channels["ChannelA"].schema.field("ChannelA")
+        self.assertEqual(field.metadata.get(b"units"), b"m/s")
+        self.assertEqual(field.metadata.get(b"dec_pts"), b"2")
+        self.assertEqual(field.metadata.get(b"interpolate"), b"True")
+
+    def test_resample_to_timecodes_with_channel_names(self):
+        """Test resampling specific channels only."""
+        channels = {
+            "ChannelA": create_channel_with_metadata([0, 100], [1.0, 2.0], "ChannelA"),
+            "ChannelB": create_channel_with_metadata([0, 100], [10.0, 20.0], "ChannelB"),
+        }
+        log = create_test_logfile(channels)
+
+        target = pa.array([0, 50, 100], type=pa.int64())
+        result = log.resample_to_timecodes(target, channel_names=["ChannelA"])
+
+        self.assertEqual(set(result.channels.keys()), {"ChannelA"})
+
+    def test_resample_to_timecodes_missing_channel_raises(self):
+        """Test that resampling with missing channels raises KeyError."""
+        channels = {
+            "ChannelA": create_channel_with_metadata([0, 100], [1.0, 2.0], "ChannelA"),
+        }
+        log = create_test_logfile(channels)
+
+        target = pa.array([0, 50, 100], type=pa.int64())
+        with self.assertRaises(KeyError):
+            log.resample_to_timecodes(target, channel_names=["NotExist"])
+
+
+class TestResampleToChannel(unittest.TestCase):
+    """Tests for LogFile.resample_to_channel()."""
+
+    def test_resample_to_channel_delegates(self):
+        """Test that resample_to_channel delegates to resample_to_timecodes."""
+        channels = {
+            "Reference": create_channel_with_metadata([0, 50, 100], [1.0, 2.0, 3.0], "Reference"),
+            "Other": create_channel_with_metadata(
+                [0, 100], [10.0, 20.0], "Other", interpolate="True"
+            ),
+        }
+        log = create_test_logfile(channels)
+
+        result = log.resample_to_channel("Reference")
+
+        # Other should be resampled to Reference's timecodes
+        other_timecodes = result.channels["Other"].column("timecodes").to_pylist()
+        self.assertEqual(other_timecodes, [0, 50, 100])
+
+        other_values = result.channels["Other"].column("Other").to_pylist()
+        # Interpolated: 0 -> 10.0, 50 -> 15.0, 100 -> 20.0
+        self.assertAlmostEqual(other_values[0], 10.0, places=5)
+        self.assertAlmostEqual(other_values[1], 15.0, places=5)
+        self.assertAlmostEqual(other_values[2], 20.0, places=5)
+
+    def test_resample_to_channel_missing_raises(self):
+        """Test that resample_to_channel with missing reference raises KeyError."""
+        channels = {
+            "ChannelA": create_channel_with_metadata([0, 100], [1.0, 2.0], "ChannelA"),
+        }
+        log = create_test_logfile(channels)
+
+        with self.assertRaises(KeyError) as ctx:
+            log.resample_to_channel("NotExist")
+
+        self.assertIn("NotExist", str(ctx.exception))
+
+
+class TestGetChannelsAsTableRefactored(unittest.TestCase):
+    """Tests to verify refactored get_channels_as_table behavior matches original."""
+
+    def test_get_channels_as_table_single_channel(self):
+        """Test that single channel works correctly."""
+        channels = {
+            "ChannelA": create_channel_with_metadata([0, 100, 200], [1.0, 2.0, 3.0], "ChannelA"),
+        }
+        log = create_test_logfile(channels)
+
+        result = log.get_channels_as_table()
+
+        self.assertEqual(result.num_columns, 2)
+        self.assertEqual(result.column_names, ["timecodes", "ChannelA"])
+        self.assertEqual(result.column("ChannelA").to_pylist(), [1.0, 2.0, 3.0])
+
+    def test_get_channels_as_table_merges_timecodes(self):
+        """Test that channels with different timecodes are merged."""
+        channels = {
+            "ChannelA": create_channel_with_metadata([0, 100, 200], [1.0, 2.0, 3.0], "ChannelA"),
+            "ChannelB": create_channel_with_metadata([50, 150], [10.0, 20.0], "ChannelB"),
+        }
+        log = create_test_logfile(channels)
+
+        result = log.get_channels_as_table()
+
+        # Should have union of timecodes
+        timecodes = result.column("timecodes").to_pylist()
+        self.assertEqual(timecodes, [0, 50, 100, 150, 200])
+
+    def test_get_channels_as_table_preserves_metadata(self):
+        """Test that metadata is preserved in merged table."""
+        channels = {
+            "ChannelA": create_channel_with_metadata(
+                [0, 100], [1.0, 2.0], "ChannelA", units="m/s", interpolate="True"
+            ),
+        }
+        log = create_test_logfile(channels)
+
+        result = log.get_channels_as_table()
+
+        field = result.schema.field("ChannelA")
+        self.assertEqual(field.metadata.get(b"units"), b"m/s")
+        self.assertEqual(field.metadata.get(b"interpolate"), b"True")
+
+    def test_get_channels_as_table_empty(self):
+        """Test that empty channels returns empty table."""
+        log = create_test_logfile({})
+
+        result = log.get_channels_as_table()
+
+        self.assertEqual(result.num_columns, 1)
+        self.assertEqual(result.num_rows, 0)
+        self.assertIn("timecodes", result.column_names)
+
+
+class TestMethodChaining(unittest.TestCase):
+    """Tests for method chaining pattern."""
+
+    def test_filter_and_select_chain(self):
+        """Test chaining filter_by_time_range and select_channels."""
+        channels = {
+            "ChannelA": create_channel_with_metadata(
+                [0, 100, 200, 300], [1.0, 2.0, 3.0, 4.0], "ChannelA"
+            ),
+            "ChannelB": create_channel_with_metadata(
+                [0, 100, 200, 300], [10.0, 20.0, 30.0, 40.0], "ChannelB"
+            ),
+        }
+        log = create_test_logfile(channels)
+
+        result = log.filter_by_time_range(50, 250).select_channels(["ChannelA"])
+
+        self.assertEqual(set(result.channels.keys()), {"ChannelA"})
+        timecodes = result.channels["ChannelA"].column("timecodes").to_pylist()
+        self.assertEqual(timecodes, [100, 200])
+
+    def test_filter_resample_chain(self):
+        """Test chaining filter and resample operations."""
+        channels = {
+            "ChannelA": create_channel_with_metadata(
+                [0, 100, 200, 300], [0.0, 10.0, 20.0, 30.0], "ChannelA", interpolate="True"
+            ),
+            "ChannelB": create_channel_with_metadata(
+                [0, 50, 100, 150, 200, 250, 300],
+                [0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0],
+                "ChannelB",
+            ),
+        }
+        log = create_test_logfile(channels)
+
+        result = log.filter_by_time_range(0, 200).resample_to_channel("ChannelB")
+
+        # ChannelA should be resampled to ChannelB's filtered timecodes
+        a_values = result.channels["ChannelA"].column("ChannelA").to_pylist()
+        # After filter [0, 200):
+        #   ChannelA has timecodes [0, 100] with values [0.0, 10.0] (200 excluded)
+        #   ChannelB has timecodes [0, 50, 100, 150]
+        # ChannelA interpolated to ChannelB's timecodes:
+        #   0 -> 0.0, 50 -> 5.0, 100 -> 10.0, 150 -> 10.0 (extrapolated edge value)
+        self.assertEqual(len(a_values), 4)
+        self.assertAlmostEqual(a_values[0], 0.0, places=5)
+        self.assertAlmostEqual(a_values[1], 5.0, places=5)
+        self.assertAlmostEqual(a_values[2], 10.0, places=5)
+        self.assertAlmostEqual(a_values[3], 10.0, places=5)  # np.interp extrapolates edge value
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sfj_xrk.py
+++ b/tests/test_sfj_xrk.py
@@ -305,6 +305,72 @@ class TestSFJXRK(unittest.TestCase):
                 f"Channel '{channel_name}' interpolate mismatch",
             )
 
+    @parameterized.expand(FILE_VARIANTS)
+    def test_filter_by_lap_with_real_data(self, name, file_path):
+        """Test filter_by_lap with known lap boundaries from SFJ test data."""
+        log = aim_xrk(str(file_path), progress=None)
+
+        # Filter to lap 1 (known boundaries: 193611.0 to 320961.0)
+        lap1 = log.filter_by_lap(1)
+
+        # Verify the filtered laps table only contains lap 1
+        self.assertEqual(lap1.laps.num_rows, 1)
+        self.assertEqual(lap1.laps.column("num")[0].as_py(), 1)
+
+        # Verify channel data is within lap 1 time range
+        rpm_channel = lap1.channels["RPM"]
+        timecodes = rpm_channel.column("timecodes").to_pylist()
+
+        # All timecodes should be within lap 1 boundaries [193611, 320961)
+        for tc in timecodes:
+            self.assertGreaterEqual(tc, 193611, "Timecode before lap start")
+            self.assertLess(tc, 320961, "Timecode at or after lap end")
+
+        # Verify we got some data (lap 1 should have RPM samples)
+        self.assertGreater(len(timecodes), 0, "No RPM data in lap 1")
+
+    @parameterized.expand(FILE_VARIANTS)
+    def test_filter_by_lap_with_channel_selection(self, name, file_path):
+        """Test filter_by_lap with specific channel selection."""
+        log = aim_xrk(str(file_path), progress=None)
+
+        # Filter to lap 5 with only GPS channels
+        lap5 = log.filter_by_lap(5, channel_names=["GPS Speed", "GPS Latitude", "GPS Longitude"])
+
+        # Verify only specified channels are present
+        self.assertEqual(
+            set(lap5.channels.keys()),
+            {"GPS Speed", "GPS Latitude", "GPS Longitude"},
+        )
+
+        # Verify timecodes are within lap 5 boundaries [688126, 819303)
+        gps_timecodes = lap5.channels["GPS Speed"].column("timecodes").to_pylist()
+        for tc in gps_timecodes:
+            self.assertGreaterEqual(tc, 688126)
+            self.assertLess(tc, 819303)
+
+    @parameterized.expand(FILE_VARIANTS)
+    def test_resample_to_channel_with_real_data(self, name, file_path):
+        """Test resample_to_channel with real data."""
+        log = aim_xrk(str(file_path), progress=None)
+
+        # Filter to a short segment to keep test fast
+        segment = log.filter_by_time_range(200000, 250000, channel_names=["RPM", "GPS Speed"])
+
+        # Resample RPM to GPS Speed's timebase
+        resampled = segment.resample_to_channel("GPS Speed")
+
+        # Both channels should now have the same timecodes
+        rpm_timecodes = resampled.channels["RPM"].column("timecodes").to_pylist()
+        gps_timecodes = resampled.channels["GPS Speed"].column("timecodes").to_pylist()
+        self.assertEqual(rpm_timecodes, gps_timecodes)
+
+        # RPM values should still be reasonable (not corrupted by resampling)
+        rpm_values = resampled.channels["RPM"].column("RPM").to_pylist()
+        for val in rpm_values:
+            self.assertGreaterEqual(val, 0, "RPM should not be negative")
+            self.assertLess(val, 20000, "RPM seems unreasonably high")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Add new methods to `LogFile` for filtering and resampling telemetry data:
  - `select_channels()` - select subset of channels
  - `filter_by_time_range()` - filter to [start, end) time range  
  - `filter_by_lap()` - filter to specific lap's time range
  - `resample_to_timecodes()` - resample channels to target timebase
  - `resample_to_channel()` - resample to reference channel's timebase
- All methods return new `LogFile` instances (immutable pattern) enabling method chaining
- Refactored `get_channels_as_table()` to use `resample_to_timecodes()` internally
- Optimized timecode merging with `heapq.merge()` for O(N log k) vs O(N log N)
- Bump version to 0.5.0

## Example Usage

```python
df = (log
    .filter_by_lap(5)
    .select_channels(['Engine RPM', 'GPS Speed'])
    .resample_to_channel('GPS Speed')
    .get_channels_as_table()
    .to_pandas())
```

## Test plan

- [x] Unit tests in `tests/test_logfile_methods.py` (22 new tests)
- [x] Integration tests in `tests/test_sfj_xrk.py` with real XRK data
- [x] All existing tests pass
- [x] `poetry run poe check` passes (lint, typecheck, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)