### PR TITLE
feat: add logger model and ID to LogFile metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ for i in range(log.laps.num_rows):
 
 # Access metadata
 print(log.metadata)
+# Includes: Driver, Vehicle, Venue, Log Date/Time, Logger ID, Logger Model, Device Name, etc.
 ```
 
 ### Filtering and Resampling

--- a/src/libxrk/CLAUDE.md
+++ b/src/libxrk/CLAUDE.md
@@ -16,8 +16,28 @@ df = log.get_channels_as_table().to_pandas()
 ```python
 log.channels   # Dict[str, pa.Table] - channel name -> PyArrow table
 log.laps       # pa.Table - columns: num, start_time, end_time (ms)
-log.metadata   # Dict[str, str] - session info
+log.metadata   # Dict[str, Any] - session info
 ```
+
+## Metadata Fields
+
+Standard metadata fields extracted from XRK files:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| Driver | str | Driver name |
+| Vehicle | str | Vehicle name |
+| Venue | str | Track/venue name |
+| Log Date | str | Date of log (DD/MM/YYYY) |
+| Log Time | str | Time of log (HH:MM:SS) |
+| Series | str | Series/competition name |
+| Session | str | Session type |
+| Long Comment | str | User notes |
+| Logger ID | int | Unique logger serial number |
+| Logger Model ID | int | Numeric model code |
+| Logger Model | str or None | Human-readable model name (e.g., "MXP 1.3", "MXm") |
+| Device Name | str | User-configured device name |
+| Odo/* | various | Odometer readings |
 
 ## Channel Tables
 

--- a/src/libxrk/aim_xrk.pyx
+++ b/src/libxrk/aim_xrk.pyx
@@ -118,6 +118,13 @@ _decoders = {
     24: Decoder('i'), # Best Run Diff?
 }
 
+# Logger model ID to name mapping
+# These values are from the idn message in XRK files
+_logger_models = {
+    649: "MXP 1.3",
+    793: "MXm",
+}
+
 _unit_map = {
     1:  ('%', 2),
     3:  ('G', 2),
@@ -438,6 +445,27 @@ def _decode_sequence(s, progress=None):
                                      _tokdec('DBUN'), _tokdec('DBUT'), _tokdec('DVER'), _tokdec('MANL'), _tokdec('MODL'), _tokdec('MANI'),
                                      _tokdec('MODI'), _tokdec('HWNF'), _tokdec('PDLT'), _tokdec('NTE')):
                             data = _nullterm_string(data)
+                        elif tok == _tokdec('idn'):
+                            # idn message: 56-byte payload with logger info
+                            # Offset +0: model ID (16-bit LE)
+                            # Offset +6: logger ID (32-bit LE)
+                            if len(data) >= 10:
+                                model_id = struct.unpack('<H', data[0:2])[0]
+                                logger_id = struct.unpack('<I', data[6:10])[0]
+                                data = {'model_id': model_id, 'logger_id': logger_id}
+                        elif tok == _tokdec('SRC'):
+                            # SRC message contains embedded idn data
+                            # Format: 3-byte token + 1-byte version + 2-byte length + payload
+                            if len(data) >= 62 and data[:3] == b'idn':
+                                # Parse the embedded idn payload (skip 6-byte header)
+                                idn_payload = data[6:62]
+                                model_id = struct.unpack('<H', idn_payload[0:2])[0]
+                                logger_id = struct.unpack('<I', idn_payload[6:10])[0]
+                                # Store as idn message type for metadata extraction
+                                idn_msg = Message(_tokdec('idn'), 1, {'model_id': model_id, 'logger_id': logger_id})
+                                if _tokdec('idn') not in messages:
+                                    messages[_tokdec('idn')] = []
+                                messages[_tokdec('idn')].append(idn_msg)
                         elif tok == _tokdec('ENF'):
                             data = _decode_sequence(data).messages
                         elif tok == _tokdec('TRK'):
@@ -629,6 +657,16 @@ def _get_metadata(msg_by_type):
             ret['Odo/%s Time' % name] = '%d:%02d:%02d' % (stats['time'] // 3600,
                                                           stats['time'] // 60 % 60,
                                                           stats['time'] % 60)
+    # Logger info from idn message
+    if _tokdec('idn') in msg_by_type:
+        idn_data = msg_by_type[_tokdec('idn')][-1].content
+        if isinstance(idn_data, dict):
+            ret['Logger ID'] = idn_data['logger_id']
+            ret['Logger Model ID'] = idn_data['model_id']
+            ret['Logger Model'] = _logger_models.get(idn_data['model_id'])
+    # Device name from NDV message
+    if _tokdec('NDV') in msg_by_type:
+        ret['Device Name'] = msg_by_type[_tokdec('NDV')][-1].content
     return ret
 
 def _bg_gps_laps(gpsmsg, msg_by_type, time_offset, last_time):

--- a/tests/test_86_xrk.py
+++ b/tests/test_86_xrk.py
@@ -64,6 +64,10 @@ class Test86XRK(unittest.TestCase):
             "Odo/Usr 3 Time": "79:29:53",
             "Odo/Usr 4 Distance (km)": 5313.42,
             "Odo/Usr 4 Time": "79:29:53",
+            "Logger ID": 6701209,
+            "Logger Model ID": 649,
+            "Logger Model": "MXP 1.3",
+            "Device Name": "Inferno 86 v2",
         }
 
         # Check core fields present in both formats

--- a/tests/test_data/test_data.md
+++ b/tests/test_data/test_data.md
@@ -64,13 +64,17 @@ The SFJ Folder contains data from a run by a beginner in a Super FJ Junior formu
 * Steering Wheel Position (steering)
 * Performance metrics (Best Run Diff, Best Today Diff, Predictive Time, etc.)
 
-**File-Level Metadata:** 18 entries
+**File-Level Metadata:** 22 entries
 
 | Key | Value |
 |-----|-------|
+| Device Name | MXm ID airs |
 | Driver | CMD |
 | Log Date | 11/04/2025 |
 | Log Time | 15:50:07 |
+| Logger ID | 6603435 |
+| Logger Model | MXm |
+| Logger Model ID | 793 |
 | Long Comment | (empty) |
 | Odo/System Distance (km) | 165.858 |
 | Odo/System Time | 1:25:05 |
@@ -223,13 +227,17 @@ Contains data from a run by an intermediate driver in a Toyota 86.
 * Environment: AmbientTemp, LoggerTemp, Luminosity, External Voltage
 * Performance metrics: Best Run Diff, Best Today Diff, Predictive Time, Prev Lap Diff, Ref Lap Diff, SpeedAverage
 
-**File-Level Metadata:** 18 entries
+**File-Level Metadata:** 22 entries
 
 | Key | Value |
 |-----|-------|
+| Device Name | Inferno 86 v2 |
 | Driver | CMD |
 | Log Date | 11/01/2025 |
 | Log Time | 10:39:06 |
+| Logger ID | 6701209 |
+| Logger Model | MXP 1.3 |
+| Logger Model ID | 649 |
 | Long Comment | Front 15, 2/2<br/>Rear 20 3/3<br/>A052 Used |
 | Odo/System Distance (km) | 5313.42 |
 | Odo/System Time | 79:29:53 |

--- a/tests/test_sfj_xrk.py
+++ b/tests/test_sfj_xrk.py
@@ -62,6 +62,10 @@ class TestSFJXRK(unittest.TestCase):
             "Odo/Usr 3 Time": "1:25:05",
             "Odo/Usr 4 Distance (km)": 165.858,
             "Odo/Usr 4 Time": "1:25:05",
+            "Logger ID": 6603435,
+            "Logger Model ID": 793,
+            "Logger Model": "MXm",
+            "Device Name": "MXm ID airs",
         }
 
         # Check core fields present in both formats


### PR DESCRIPTION
## Summary
- Parse `idn` message embedded in `SRC` to extract logger identification info
- Add `Logger ID` (unique serial number), `Logger Model ID` (numeric code), `Logger Model` (human-readable name), and `Device Name` to metadata
- Add model lookup table for known AIM loggers: MXP 1.3 (649), MXm (793)

## Test plan
- [x] All existing tests pass (`poetry run poe check`)
- [x] New metadata assertions added to test_86_xrk.py and test_sfj_xrk.py
- [x] Manual verification of extracted values matches expected:
  - 86 file: Logger ID=6701209, Model=MXP 1.3, Device Name=Inferno 86 v2
  - SFJ file: Logger ID=6603435, Model=MXm, Device Name=MXm ID airs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)