### PR TITLE
fix: handle truncated XRZ files gracefully

### DIFF
--- a/src/libxrk/aim_xrk.pyx
+++ b/src/libxrk/aim_xrk.pyx
@@ -865,8 +865,13 @@ def _decompress_if_zlib(data):
     second_byte = data[1] if isinstance(data[1], int) else ord(data[1])
     
     if first_byte == 0x78 and second_byte in (0x01, 0x9C, 0xDA):
-        return zlib.decompress(bytes(data))
-    
+        deco = zlib.decompressobj()
+        try:
+            return deco.decompress(bytes(data))
+        except zlib.error:
+            # Truncated stream - recover partial data
+            return deco.flush()
+
     return data
 
 
@@ -906,7 +911,12 @@ class _open_xrk:
             self._mmap = mmap.mmap(self._file.fileno(), 0, access=mmap.ACCESS_READ)
             # Check if zlib compressed - if so, decompress and use bytes instead of mmap
             if len(self._mmap) >= 2 and self._mmap[0] == 0x78 and self._mmap[1] in (0x01, 0x9C, 0xDA):
-                self._data = zlib.decompress(self._mmap[:])
+                deco = zlib.decompressobj()
+                try:
+                    self._data = deco.decompress(self._mmap[:])
+                except zlib.error:
+                    # Truncated stream - recover partial data
+                    self._data = deco.flush()
                 self._mmap.close()
                 self._mmap = None
                 return self._data

--- a/tests/test_gps_timing.py
+++ b/tests/test_gps_timing.py
@@ -358,13 +358,8 @@ class TestGpsTimingGapFixIntegration(unittest.TestCase):
         # Load the XRK file (fix is automatically applied)
         cls.log_xrk = aim_xrk(str(cls.SFJ_0101_XRK))
 
-        # Try to load XRZ file, but it may be corrupted/truncated
-        cls.log_xrz = None
-        if cls.SFJ_0101_XRZ.exists():
-            try:
-                cls.log_xrz = aim_xrk(str(cls.SFJ_0101_XRZ))
-            except Exception:
-                pass  # XRZ file may be corrupted
+        # Load XRZ file (truncated files are now handled gracefully)
+        cls.log_xrz = aim_xrk(str(cls.SFJ_0101_XRZ))
 
     def test_0101_file_exists(self):
         """Verify the test data file exists."""
@@ -422,9 +417,6 @@ class TestGpsTimingGapFixIntegration(unittest.TestCase):
 
     def test_xrk_and_xrz_produce_same_gps_timecodes(self):
         """Verify XRK and XRZ files produce the same GPS timecodes after fix."""
-        if self.log_xrz is None:
-            self.skipTest("XRZ file not available or corrupted")
-
         xrk_time = self.log_xrk.channels["GPS Speed"].column("timecodes").to_numpy()
         xrz_time = self.log_xrz.channels["GPS Speed"].column("timecodes").to_numpy()
 
@@ -434,9 +426,6 @@ class TestGpsTimingGapFixIntegration(unittest.TestCase):
 
     def test_gps_values_preserved(self):
         """Verify GPS values are not modified by the timing fix."""
-        if self.log_xrz is None:
-            self.skipTest("XRZ file not available or corrupted")
-
         # The values should be the same between XRK and XRZ (only timecodes were fixed)
         xrk_speed = self.log_xrk.channels["GPS Speed"].column("GPS Speed").to_numpy()
         xrz_speed = self.log_xrz.channels["GPS Speed"].column("GPS Speed").to_numpy()


### PR DESCRIPTION
## Summary
- Use `zlib.decompressobj()` instead of `zlib.decompress()` to recover partial data from truncated zlib streams
- XRZ files cut off mid-write (e.g., logger turned off while vehicle moving) can now be opened and parsed up to the truncation point
- Removed defensive try/except and skip conditions from tests that were working around this limitation

## Test plan
- [x] `poetry run pytest tests/test_gps_timing.py::TestGpsTimingGapFixIntegration -v` - all 9 tests pass (2 were previously skipping)
- [x] `poetry run poe check` - lint and typecheck pass, 133/135 tests pass (2 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)