### PR TITLE
perf: optimize get_channels_as_table() with numpy-based timecode merge

### DIFF
--- a/PROFILING_RESULTS.md
+++ b/PROFILING_RESULTS.md
@@ -1,0 +1,76 @@
+# libxrk Performance Profiling Results
+
+## Summary
+
+Profiling identified `get_channels_as_table()` as the main bottleneck. An optimization was implemented that provides **3.8-6.9x speedup**.
+
+## Before/After Comparison
+
+| File | Size | Before | After | Speedup |
+|------|------|--------|-------|---------|
+| small | 3.0 MB | 0.212s | 0.032s | **6.6x** |
+| medium | 7.9 MB | 0.443s | 0.064s | **6.9x** |
+| large | 39.8 MB | 1.849s | 0.491s | **3.8x** |
+
+## All Operations (After Optimization)
+
+| Operation | small | medium | large |
+|-----------|-------|--------|-------|
+| aim_xrk | 0.032s | 0.066s | 0.113s |
+| get_channels_as_table | 0.032s | 0.064s | 0.491s |
+| resample_to_channel | 0.003s | 0.009s | 0.032s |
+| filter_by_lap | 0.004s | 0.005s | 0.018s |
+
+## Root Cause and Fix
+
+### Problem
+The original k-way merge used Python's `heapq.merge()` with `to_pylist()`:
+
+```python
+# Old implementation (1.45s for large file)
+timecode_iterators = [
+    channel_table.column("timecodes").to_pylist()  # 0.73s
+    for channel_table in self.channels.values()
+]
+merged = heapq.merge(*timecode_iterators)  # 0.72s combined
+unique_timecodes = [k for k, _ in groupby(merged)]
+```
+
+### Solution
+Replaced with numpy-based approach:
+
+```python
+# New implementation (0.21s for large file)
+timecode_arrays = [
+    channel_table.column("timecodes").to_numpy()  # ~0s
+    for channel_table in self.channels.values()
+]
+union_timecodes = pa.array(
+    np.unique(np.concatenate(timecode_arrays)), type=pa.int64()
+)
+```
+
+### Why This Works
+- `to_numpy()` is essentially free (zero-copy from Arrow)
+- `np.concatenate()` + `np.unique()` are optimized C implementations
+- While O(N log N) vs O(N) theoretically, the practical speedup is **6.5x** due to lower constant factors
+
+## Current Bottleneck (After Optimization)
+
+For the large file, the breakdown is now:
+- `np.unique()`: 0.19s (39%)
+- `np.interp()` in resampling: 0.22s (45%)
+- Other: 0.08s (16%)
+
+The remaining time is dominated by C-optimized numpy operations, leaving limited room for further Python-level optimization.
+
+## Profiling Scripts
+
+- `scripts/profile_libxrk.py` - Main profiling script for all operations
+- `scripts/profile_get_channels.py` - Detailed breakdown of `get_channels_as_table()`
+- `scripts/profile_resample.py` - Detailed breakdown of `resample_to_channel()`
+
+Run with:
+```bash
+poetry run python scripts/profile_libxrk.py [--detailed] [--files small medium large]
+```

--- a/poetry.lock
+++ b/poetry.lock
@@ -871,6 +871,27 @@ tomli = ">=1.2.2"
 poetry-plugin = ["poetry (>=1.0,<2.0)"]
 
 [[package]]
+name = "py-spy"
+version = "0.4.1"
+description = ""
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "py_spy-0.4.1-py2.py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:809094208c6256c8f4ccadd31e9a513fe2429253f48e20066879239ba12cd8cc"},
+    {file = "py_spy-0.4.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:1fb8bf71ab8df95a95cc387deed6552934c50feef2cf6456bc06692a5508fd0c"},
+    {file = "py_spy-0.4.1-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ee776b9d512a011d1ad3907ed53ae32ce2f3d9ff3e1782236554e22103b5c084"},
+    {file = "py_spy-0.4.1-py2.py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:532d3525538254d1859b49de1fbe9744df6b8865657c9f0e444bf36ce3f19226"},
+    {file = "py_spy-0.4.1-py2.py3-none-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4972c21890b6814017e39ac233c22572c4a61fd874524ebc5ccab0f2237aee0a"},
+    {file = "py_spy-0.4.1-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6a80ec05eb8a6883863a367c6a4d4f2d57de68466f7956b6367d4edd5c61bb29"},
+    {file = "py_spy-0.4.1-py2.py3-none-win_amd64.whl", hash = "sha256:d92e522bd40e9bf7d87c204033ce5bb5c828fca45fa28d970f58d71128069fdc"},
+    {file = "py_spy-0.4.1.tar.gz", hash = "sha256:e53aa53daa2e47c2eef97dd2455b47bb3a7e7f962796a86cc3e7dbde8e6f4db4"},
+]
+
+[package.extras]
+test = ["numpy"]
+
+[[package]]
 name = "pyarrow"
 version = "22.0.0"
 description = "Python library for Apache Arrow"
@@ -1611,4 +1632,4 @@ test = ["parameterized", "pytest"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "fc12fb607cf22190656e4f3e0bd9c19b069d16561464407ee593fc327e9eff11"
+content-hash = "b9e1f78065d9b59ff6686ffdbf762cfe5ef22f13cb9162d4ac4df1beeba3770c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ mypy = "^1.18.2"
 poethepoet = "^0.24.0"
 pyodide-build = {version = "^0.27.3", python = ">=3.12"}
 parameterized = "^0.9.0"
+py-spy = "^0.4.1"
 
 [tool.black]
 line-length = 100

--- a/scripts/profile_get_channels.py
+++ b/scripts/profile_get_channels.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Focused profiling of get_channels_as_table() to understand the bottleneck."""
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import os
+
+os.chdir(Path(__file__).parent.parent)
+
+from libxrk import aim_xrk
+import heapq
+from itertools import groupby
+import pyarrow as pa
+import numpy as np
+
+
+# Large file for profiling
+TEST_FILE = "tests/test_data/86/CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrk"
+
+
+def profile_timecode_extraction(log):
+    """Profile different ways to extract timecodes from channels."""
+    print("\n=== Timecode Extraction Methods ===")
+
+    # Method 1: Current approach (to_pylist)
+    start = time.perf_counter()
+    for _ in range(3):
+        timecode_iterators = [
+            channel_table.column("timecodes").to_pylist() for channel_table in log.channels.values()
+        ]
+    elapsed1 = (time.perf_counter() - start) / 3
+    print(f"to_pylist() x {len(log.channels)}: {elapsed1:.3f}s")
+
+    # Method 2: to_numpy
+    start = time.perf_counter()
+    for _ in range(3):
+        timecode_arrays = [
+            channel_table.column("timecodes").to_numpy() for channel_table in log.channels.values()
+        ]
+    elapsed2 = (time.perf_counter() - start) / 3
+    print(f"to_numpy() x {len(log.channels)}: {elapsed2:.3f}s")
+
+    # Method 3: combine_chunks().to_numpy()
+    start = time.perf_counter()
+    for _ in range(3):
+        timecode_arrays = [
+            channel_table.column("timecodes").combine_chunks().to_numpy()
+            for channel_table in log.channels.values()
+        ]
+    elapsed3 = (time.perf_counter() - start) / 3
+    print(f"combine_chunks().to_numpy() x {len(log.channels)}: {elapsed3:.3f}s")
+
+    return timecode_iterators, timecode_arrays
+
+
+def profile_k_way_merge_approaches(log):
+    """Profile different approaches to k-way merge."""
+    print("\n=== K-way Merge Approaches ===")
+
+    # Get numpy arrays for all timecodes
+    timecode_arrays = [
+        channel_table.column("timecodes").to_numpy() for channel_table in log.channels.values()
+    ]
+
+    # Also get lists for heapq
+    timecode_lists = [arr.tolist() for arr in timecode_arrays]
+
+    total_samples = sum(len(arr) for arr in timecode_arrays)
+    print(f"Total samples to merge: {total_samples:,}")
+
+    # Method 1: heapq.merge (current approach)
+    start = time.perf_counter()
+    merged = heapq.merge(*timecode_lists)
+    unique_timecodes_1 = [k for k, _ in groupby(merged)]
+    elapsed1 = time.perf_counter() - start
+    print(f"heapq.merge + groupby: {elapsed1:.3f}s -> {len(unique_timecodes_1):,} unique")
+
+    # Method 2: numpy concatenate + unique (sorted=True gives us sorted result)
+    start = time.perf_counter()
+    concatenated = np.concatenate(timecode_arrays)
+    unique_timecodes_2 = np.unique(concatenated)
+    elapsed2 = time.perf_counter() - start
+    print(f"np.concatenate + np.unique: {elapsed2:.3f}s -> {len(unique_timecodes_2):,} unique")
+
+    # Method 3: PyArrow approach
+    start = time.perf_counter()
+    chunks = [channel_table.column("timecodes") for channel_table in log.channels.values()]
+    combined = pa.chunked_array(chunks)
+    # PyArrow unique returns deduplicated but not sorted
+    unique_arr = pa.compute.unique(combined)
+    # Need to sort
+    sorted_arr = pa.compute.sort_indices(unique_arr)
+    unique_timecodes_3 = unique_arr.take(sorted_arr)
+    elapsed3 = time.perf_counter() - start
+    print(f"PyArrow unique + sort: {elapsed3:.3f}s -> {len(unique_timecodes_3):,} unique")
+
+    # Method 4: numpy union1d reduce (uses sorting internally)
+    start = time.perf_counter()
+    from functools import reduce
+
+    unique_timecodes_4 = reduce(np.union1d, timecode_arrays)
+    elapsed4 = time.perf_counter() - start
+    print(f"reduce(np.union1d): {elapsed4:.3f}s -> {len(unique_timecodes_4):,} unique")
+
+    # Method 5: heapq.merge with numpy arrays directly (iter)
+    start = time.perf_counter()
+    merged = heapq.merge(*[iter(arr) for arr in timecode_arrays])
+    unique_timecodes_5 = [k for k, _ in groupby(merged)]
+    elapsed5 = time.perf_counter() - start
+    print(f"heapq.merge(iter(numpy)): {elapsed5:.3f}s -> {len(unique_timecodes_5):,} unique")
+
+    return unique_timecodes_2
+
+
+def profile_full_get_channels_as_table(log):
+    """Profile the full get_channels_as_table with detailed timing."""
+    print("\n=== Full get_channels_as_table() Breakdown ===")
+
+    # Step 1: Timecode extraction
+    start = time.perf_counter()
+    timecode_iterators = [
+        channel_table.column("timecodes").to_pylist() for channel_table in log.channels.values()
+    ]
+    step1_time = time.perf_counter() - start
+    print(f"1. to_pylist() extraction: {step1_time:.3f}s")
+
+    # Step 2: K-way merge
+    start = time.perf_counter()
+    merged = heapq.merge(*timecode_iterators)
+    unique_timecodes = [k for k, _ in groupby(merged)]
+    step2_time = time.perf_counter() - start
+    print(f"2. heapq.merge + groupby: {step2_time:.3f}s -> {len(unique_timecodes):,} unique")
+
+    # Step 3: Convert to PyArrow array
+    start = time.perf_counter()
+    union_timecodes = pa.array(unique_timecodes, type=pa.int64())
+    step3_time = time.perf_counter() - start
+    print(f"3. pa.array creation: {step3_time:.3f}s")
+
+    # Step 4: Resampling
+    start = time.perf_counter()
+    resampled = log.resample_to_timecodes(union_timecodes)
+    step4_time = time.perf_counter() - start
+    print(f"4. resample_to_timecodes: {step4_time:.3f}s")
+
+    # Step 5: Build merged table
+    start = time.perf_counter()
+    channel_names = sorted(resampled.channels.keys())
+    channel_metadata = {}
+    for name in channel_names:
+        field = resampled.channels[name].schema.field(name)
+        if field.metadata:
+            channel_metadata[name] = field.metadata
+    columns_dict = {"timecodes": union_timecodes}
+    for name in channel_names:
+        columns_dict[name] = resampled.channels[name].column(name)
+    result = pa.table(columns_dict)
+    step5_time = time.perf_counter() - start
+    print(f"5. Build result table: {step5_time:.3f}s")
+
+    # Step 6: Restore metadata
+    start = time.perf_counter()
+    if channel_metadata:
+        new_fields = []
+        for field in result.schema:
+            if field.name in channel_metadata:
+                new_fields.append(field.with_metadata(channel_metadata[field.name]))
+            else:
+                new_fields.append(field)
+        new_schema = pa.schema(new_fields)
+        result = result.cast(new_schema)
+    step6_time = time.perf_counter() - start
+    print(f"6. Restore metadata: {step6_time:.3f}s")
+
+    total = step1_time + step2_time + step3_time + step4_time + step5_time + step6_time
+    print(f"\nTotal breakdown: {total:.3f}s")
+    print(
+        f"  Timecode merge (1+2+3): {step1_time + step2_time + step3_time:.3f}s ({(step1_time + step2_time + step3_time)/total*100:.1f}%)"
+    )
+    print(f"  Resampling (4): {step4_time:.3f}s ({step4_time/total*100:.1f}%)")
+    print(
+        f"  Table building (5+6): {step5_time + step6_time:.3f}s ({(step5_time + step6_time)/total*100:.1f}%)"
+    )
+
+
+def main():
+    print("Loading test file...")
+    log = aim_xrk(TEST_FILE)
+    print(
+        f"Loaded: {len(log.channels)} channels, {sum(t.num_rows for t in log.channels.values()):,} total samples"
+    )
+
+    # Run profiling
+    profile_timecode_extraction(log)
+    profile_k_way_merge_approaches(log)
+    profile_full_get_channels_as_table(log)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profile_libxrk.py
+++ b/scripts/profile_libxrk.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Profile libxrk operations to identify performance bottlenecks.
+
+This script profiles the main operations in libxrk:
+- aim_xrk() - File parsing (includes Cython binary parsing)
+- get_channels_as_table() - Channel merging with resampling
+- resample_to_channel() - Resampling to reference timebase
+- filter_by_lap() - Lap filtering
+
+Usage:
+    poetry run python scripts/profile_libxrk.py [--detailed]
+
+The --detailed flag enables per-line profiling for specific functions.
+"""
+
+import argparse
+import cProfile
+import io
+import os
+import pstats
+import sys
+import time
+from pathlib import Path
+
+# Add src to path for development
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from libxrk import aim_xrk
+
+
+# Test files with different sizes
+TEST_FILES = {
+    "small": "tests/test_data/aim_official/test.xrk",
+    "medium": "tests/test_data/SFJ/CMD_SFJ_Fuji GP Sh_Generic testing_a_0033.xrk",
+    "large": "tests/test_data/86/CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrk",
+}
+
+
+def get_file_size_mb(path: str) -> float:
+    """Get file size in MB."""
+    return os.path.getsize(path) / (1024 * 1024)
+
+
+def profile_operation(name: str, func, *args, **kwargs):
+    """Profile a single operation and return timing + profile stats."""
+    # Warm-up run (to avoid cold cache effects)
+    try:
+        func(*args, **kwargs)
+    except Exception:
+        pass  # Ignore errors in warmup
+
+    # Timed run
+    start = time.perf_counter()
+    result = func(*args, **kwargs)
+    elapsed = time.perf_counter() - start
+
+    # Profiled run
+    profiler = cProfile.Profile()
+    profiler.enable()
+    func(*args, **kwargs)
+    profiler.disable()
+
+    return result, elapsed, profiler
+
+
+def format_profile_stats(profiler: cProfile.Profile, top_n: int = 20) -> str:
+    """Format profile stats as a string."""
+    stream = io.StringIO()
+    stats = pstats.Stats(profiler, stream=stream)
+    stats.strip_dirs()
+    stats.sort_stats("cumulative")
+    stats.print_stats(top_n)
+    return stream.getvalue()
+
+
+def profile_file(file_path: str, file_label: str) -> dict:
+    """Profile all operations on a single file."""
+    results = {}
+    file_size = get_file_size_mb(file_path)
+
+    print(f"\n{'=' * 70}")
+    print(f"FILE: {file_label} ({file_size:.1f} MB)")
+    print(f"Path: {file_path}")
+    print("=" * 70)
+
+    # 1. Profile aim_xrk() - File parsing
+    print("\n--- aim_xrk() (File Parsing) ---")
+    log, elapsed, profiler = profile_operation("aim_xrk", aim_xrk, file_path)
+    results["aim_xrk"] = {"time": elapsed, "profiler": profiler}
+    print(f"Time: {elapsed:.3f}s")
+    print(f"Channels: {len(log.channels)}")
+    print(f"Laps: {len(log.laps)}")
+    total_samples = sum(t.num_rows for t in log.channels.values())
+    print(f"Total samples: {total_samples:,}")
+
+    # 2. Profile get_channels_as_table() - Channel merging
+    print("\n--- get_channels_as_table() (Channel Merging) ---")
+    _, elapsed, profiler = profile_operation("get_channels_as_table", log.get_channels_as_table)
+    results["get_channels_as_table"] = {"time": elapsed, "profiler": profiler}
+    print(f"Time: {elapsed:.3f}s")
+
+    # 3. Profile resample_to_channel() - Resampling
+    # Find a good reference channel (GPS Speed is common at 25Hz)
+    ref_channel = None
+    for name in ["GPS Speed", "Engine RPM"]:
+        if name in log.channels:
+            ref_channel = name
+            break
+
+    if ref_channel:
+        print(f"\n--- resample_to_channel('{ref_channel}') ---")
+        ref_samples = log.channels[ref_channel].num_rows
+        print(f"Reference channel samples: {ref_samples:,}")
+        _, elapsed, profiler = profile_operation(
+            "resample_to_channel", log.resample_to_channel, ref_channel
+        )
+        results["resample_to_channel"] = {"time": elapsed, "profiler": profiler}
+        print(f"Time: {elapsed:.3f}s")
+    else:
+        print("\n--- resample_to_channel() SKIPPED (no suitable reference channel) ---")
+
+    # 4. Profile filter_by_lap() - Lap filtering
+    if len(log.laps) > 0:
+        lap_nums = log.laps.column("num").to_pylist()
+        # Pick a middle lap if available
+        test_lap = lap_nums[len(lap_nums) // 2] if lap_nums else lap_nums[0]
+        print(f"\n--- filter_by_lap({test_lap}) ---")
+        _, elapsed, profiler = profile_operation("filter_by_lap", log.filter_by_lap, test_lap)
+        results["filter_by_lap"] = {"time": elapsed, "profiler": profiler}
+        print(f"Time: {elapsed:.3f}s")
+    else:
+        print("\n--- filter_by_lap() SKIPPED (no laps in file) ---")
+
+    return results
+
+
+def print_detailed_profiles(all_results: dict, top_n: int = 20):
+    """Print detailed profile stats for each operation."""
+    print("\n" + "=" * 70)
+    print("DETAILED PROFILE STATS (Top {} by cumulative time)".format(top_n))
+    print("=" * 70)
+
+    for file_label, results in all_results.items():
+        print(f"\n{'#' * 70}")
+        print(f"# FILE: {file_label}")
+        print("#" * 70)
+
+        for op_name, data in results.items():
+            print(f"\n--- {op_name} ---")
+            print(format_profile_stats(data["profiler"], top_n))
+
+
+def print_summary_table(all_results: dict):
+    """Print a summary table of all timings."""
+    print("\n" + "=" * 70)
+    print("SUMMARY TABLE (times in seconds)")
+    print("=" * 70)
+
+    # Get all operation names
+    all_ops = set()
+    for results in all_results.values():
+        all_ops.update(results.keys())
+    ops = sorted(all_ops)
+
+    # Header
+    header = f"{'Operation':<25}"
+    for file_label in all_results.keys():
+        header += f"{file_label:>12}"
+    print(header)
+    print("-" * len(header))
+
+    # Rows
+    for op in ops:
+        row = f"{op:<25}"
+        for file_label, results in all_results.items():
+            if op in results:
+                row += f"{results[op]['time']:>12.3f}"
+            else:
+                row += f"{'N/A':>12}"
+        print(row)
+
+
+def analyze_bottlenecks(all_results: dict):
+    """Analyze and highlight the main bottlenecks."""
+    print("\n" + "=" * 70)
+    print("BOTTLENECK ANALYSIS")
+    print("=" * 70)
+
+    for file_label, results in all_results.items():
+        print(f"\n--- {file_label} ---")
+
+        # Sort operations by time
+        sorted_ops = sorted(results.items(), key=lambda x: x[1]["time"], reverse=True)
+
+        total_time = sum(r["time"] for r in results.values())
+        print(f"Total profiled time: {total_time:.3f}s")
+
+        for op_name, data in sorted_ops:
+            pct = (data["time"] / total_time) * 100 if total_time > 0 else 0
+            print(f"  {op_name}: {data['time']:.3f}s ({pct:.1f}%)")
+
+            # Show top 5 functions for this operation
+            stream = io.StringIO()
+            stats = pstats.Stats(data["profiler"], stream=stream)
+            stats.strip_dirs()
+            stats.sort_stats("cumulative")
+
+            # Get top functions
+            print("    Top functions:")
+            func_list = []
+            for func, (cc, nc, tt, ct, callers) in stats.stats.items():  # type: ignore[attr-defined]
+                func_list.append((func, ct))
+            func_list.sort(key=lambda x: x[1], reverse=True)
+
+            for func, ct in func_list[:5]:
+                filename, lineno, funcname = func
+                # Skip built-in and standard library functions
+                if funcname.startswith("<") or "site-packages" in filename:
+                    continue
+                print(f"      {funcname} ({filename}:{lineno}): {ct:.3f}s")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Profile libxrk operations")
+    parser.add_argument(
+        "--detailed",
+        action="store_true",
+        help="Show detailed profile stats for each operation",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=20,
+        help="Number of top functions to show in detailed output (default: 20)",
+    )
+    parser.add_argument(
+        "--files",
+        nargs="+",
+        choices=list(TEST_FILES.keys()),
+        default=list(TEST_FILES.keys()),
+        help="Which test files to profile (default: all)",
+    )
+    args = parser.parse_args()
+
+    # Change to repo root
+    repo_root = Path(__file__).parent.parent
+    os.chdir(repo_root)
+
+    # Check that test files exist
+    for label in args.files:
+        path = TEST_FILES[label]
+        if not os.path.exists(path):
+            print(f"WARNING: Test file not found: {path}")
+            args.files.remove(label)
+
+    if not args.files:
+        print("ERROR: No test files available")
+        sys.exit(1)
+
+    print("libxrk Performance Profiling")
+    print(f"Python: {sys.version}")
+    print(f"Working directory: {os.getcwd()}")
+
+    # Profile each file
+    all_results = {}
+    for label in args.files:
+        path = TEST_FILES[label]
+        all_results[label] = profile_file(path, label)
+
+    # Print summary
+    print_summary_table(all_results)
+
+    # Print bottleneck analysis
+    analyze_bottlenecks(all_results)
+
+    # Print detailed profiles if requested
+    if args.detailed:
+        print_detailed_profiles(all_results, args.top)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profile_native.py
+++ b/scripts/profile_native.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Script for native profiling of Cython code with py-spy."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import os
+
+os.chdir(Path(__file__).parent.parent)
+
+from libxrk import aim_xrk
+
+# Profile the large file parsing multiple times
+TEST_FILE = "tests/test_data/86/CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrk"
+
+print(f"Profiling {TEST_FILE}")
+print("Running 5 iterations...")
+
+for i in range(5):
+    log = aim_xrk(TEST_FILE)
+    print(f"  Iteration {i+1}: {len(log.channels)} channels loaded")
+
+print("Done")

--- a/scripts/profile_resample.py
+++ b/scripts/profile_resample.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Focused profiling of resample_to_channel() to understand its performance."""
+
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import os
+
+os.chdir(Path(__file__).parent.parent)
+
+from libxrk import aim_xrk
+import numpy as np
+import pyarrow as pa
+
+
+TEST_FILE = "tests/test_data/86/CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrk"
+
+
+def profile_resample_breakdown(log, ref_channel="GPS Speed"):
+    """Profile resample_to_channel with detailed timing."""
+    print(f"\n=== resample_to_channel('{ref_channel}') Breakdown ===")
+
+    ref_timecodes = log.channels[ref_channel].column("timecodes").combine_chunks()
+    target_timecodes_np = ref_timecodes.to_numpy()
+    print(f"Target samples: {len(target_timecodes_np):,}")
+    print(f"Source channels: {len(log.channels)}")
+
+    # Count interpolated vs forward-fill channels
+    interp_channels = []
+    ffill_channels = []
+    for name, channel_table in log.channels.items():
+        field = channel_table.schema.field(name)
+        should_interpolate = False
+        if field.metadata:
+            interpolate_value = field.metadata.get(b"interpolate", b"").decode("utf-8")
+            should_interpolate = interpolate_value == "True"
+        if should_interpolate:
+            interp_channels.append(name)
+        else:
+            ffill_channels.append(name)
+
+    print(f"Interpolated channels: {len(interp_channels)}")
+    print(f"Forward-fill channels: {len(ffill_channels)}")
+
+    # Time the full operation
+    start = time.perf_counter()
+    resampled = log.resample_to_channel(ref_channel)
+    total_time = time.perf_counter() - start
+    print(f"\nTotal time: {total_time:.4f}s")
+
+    # Now break down the internals
+    print("\n--- Internal Breakdown ---")
+
+    # 1. to_numpy conversions
+    start = time.perf_counter()
+    for name, channel_table in log.channels.items():
+        _ = channel_table.column("timecodes").to_numpy()
+        _ = channel_table.column(name).to_numpy(zero_copy_only=False)
+    numpy_time = time.perf_counter() - start
+    print(f"to_numpy() conversions: {numpy_time:.4f}s ({numpy_time/total_time*100:.1f}%)")
+
+    # 2. np.interp for interpolated channels
+    start = time.perf_counter()
+    for name in interp_channels:
+        channel_table = log.channels[name]
+        channel_timecodes = channel_table.column("timecodes").to_numpy()
+        channel_values = channel_table.column(name).to_numpy(zero_copy_only=False)
+        _ = np.interp(target_timecodes_np, channel_timecodes, channel_values)
+    interp_time = time.perf_counter() - start
+    print(
+        f"np.interp ({len(interp_channels)} channels): {interp_time:.4f}s ({interp_time/total_time*100:.1f}%)"
+    )
+
+    # 3. searchsorted for forward-fill channels
+    start = time.perf_counter()
+    for name in ffill_channels:
+        channel_table = log.channels[name]
+        channel_timecodes = channel_table.column("timecodes").to_numpy()
+        channel_values = channel_table.column(name).to_numpy(zero_copy_only=False)
+        indices = np.searchsorted(channel_timecodes, target_timecodes_np, side="right") - 1
+        indices = np.clip(indices, 0, len(channel_values) - 1)
+        _ = channel_values[indices]
+    ffill_time = time.perf_counter() - start
+    print(
+        f"searchsorted ({len(ffill_channels)} channels): {ffill_time:.4f}s ({ffill_time/total_time*100:.1f}%)"
+    )
+
+    # 4. PyArrow table creation (simulate with dummy resampled data)
+    start = time.perf_counter()
+    for name, channel_table in log.channels.items():
+        field = channel_table.schema.field(name)
+        # Create dummy resampled values of correct size
+        dummy_values = np.zeros(len(target_timecodes_np), dtype=np.float64)
+        new_table = pa.table(
+            {
+                "timecodes": ref_timecodes,
+                name: pa.array(dummy_values),
+            }
+        )
+        if field.metadata:
+            new_field = new_table.schema.field(name).with_metadata(field.metadata)
+            new_schema = pa.schema([new_table.schema.field("timecodes"), new_field])
+            new_table = new_table.cast(new_schema)
+    table_time = time.perf_counter() - start
+    print(f"PyArrow table creation: {table_time:.4f}s ({table_time/total_time*100:.1f}%)")
+
+
+def profile_different_reference_sizes(log):
+    """Profile resampling with different target sizes."""
+    print("\n=== Resampling to Different Target Sizes ===")
+
+    # Find channels with different sample rates
+    channels_by_size = {}
+    for name, table in log.channels.items():
+        size = table.num_rows
+        if size not in channels_by_size:
+            channels_by_size[size] = name
+
+    # Sort by size
+    sizes = sorted(channels_by_size.keys())
+
+    print(f"{'Reference Channel':<30} {'Samples':>10} {'Time':>10}")
+    print("-" * 52)
+
+    for size in sizes[:10]:  # Top 10 different sizes
+        ref_name = channels_by_size[size]
+        start = time.perf_counter()
+        _ = log.resample_to_channel(ref_name)
+        elapsed = time.perf_counter() - start
+        print(f"{ref_name:<30} {size:>10,} {elapsed:>10.4f}s")
+
+
+def profile_batch_interp_potential(log, ref_channel="GPS Speed"):
+    """Check if batching np.interp calls could help."""
+    print("\n=== Batch Interpolation Analysis ===")
+
+    ref_timecodes = log.channels[ref_channel].column("timecodes").to_numpy()
+
+    # Get all interpolated channels
+    interp_data = []
+    for name, channel_table in log.channels.items():
+        field = channel_table.schema.field(name)
+        if field.metadata and field.metadata.get(b"interpolate", b"").decode("utf-8") == "True":
+            tc = channel_table.column("timecodes").to_numpy()
+            vals = channel_table.column(name).to_numpy(zero_copy_only=False)
+            interp_data.append((name, tc, vals))
+
+    print(f"Interpolated channels: {len(interp_data)}")
+
+    # Current approach: individual np.interp calls
+    start = time.perf_counter()
+    for name, tc, vals in interp_data:
+        _ = np.interp(ref_timecodes, tc, vals)
+    individual_time = time.perf_counter() - start
+    print(f"Individual np.interp: {individual_time:.4f}s")
+
+    # Check if channels share timecodes (could batch them)
+    unique_timecode_shapes: dict[tuple[int, int, int], list[str]] = {}
+    for name, tc, vals in interp_data:
+        key = (len(tc), tc[0] if len(tc) > 0 else 0, tc[-1] if len(tc) > 0 else 0)
+        if key not in unique_timecode_shapes:
+            unique_timecode_shapes[key] = []
+        unique_timecode_shapes[key].append(name)
+
+    print(f"\nUnique timecode patterns: {len(unique_timecode_shapes)}")
+    for key, names in sorted(unique_timecode_shapes.items(), key=lambda x: -len(x[1]))[:5]:
+        print(f"  {key[0]:,} samples ({key[1]}-{key[2]}): {len(names)} channels")
+
+
+def main():
+    print("Loading test file...")
+    log = aim_xrk(TEST_FILE)
+    print(
+        f"Loaded: {len(log.channels)} channels, {sum(t.num_rows for t in log.channels.values()):,} total samples"
+    )
+
+    profile_resample_breakdown(log)
+    profile_different_reference_sizes(log)
+    profile_batch_interp_potential(log)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/libxrk/base.py
+++ b/src/libxrk/base.py
@@ -2,8 +2,6 @@
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-import heapq
-from itertools import groupby
 import sys
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -59,15 +57,12 @@ class LogFile:
             # Return an empty table with just timecodes column if no channels
             return pa.table({"timecodes": pa.array([], type=pa.int64())})
 
-        # Compute union of all channel timecodes using k-way merge (O(N) vs O(N log N) for sort)
-        # Each channel's timecodes are already sorted, so we merge and deduplicate in one pass
-        timecode_iterators = [
-            channel_table.column("timecodes").to_pylist()
-            for channel_table in self.channels.values()
+        # Compute union of all channel timecodes using numpy concatenate + unique
+        # This is faster than k-way merge with heapq due to optimized C implementation
+        timecode_arrays = [
+            channel_table.column("timecodes").to_numpy() for channel_table in self.channels.values()
         ]
-        merged = heapq.merge(*timecode_iterators)
-        unique_timecodes = [k for k, _ in groupby(merged)]
-        union_timecodes = pa.array(unique_timecodes, type=pa.int64())
+        union_timecodes = pa.array(np.unique(np.concatenate(timecode_arrays)), type=pa.int64())
 
         # Resample all channels to the union timecodes
         resampled = self.resample_to_timecodes(union_timecodes)


### PR DESCRIPTION
## Summary

- Replace `heapq.merge` + `to_pylist()` with `np.concatenate` + `np.unique` for computing union of channel timecodes
- Provides **3.8-6.9x speedup** for `get_channels_as_table()`
- Add profiling scripts and documentation

## Performance Results

| File | Size | Before | After | Speedup |
|------|------|--------|-------|---------|
| small | 3.0 MB | 0.212s | 0.032s | **6.6x** |
| medium | 7.9 MB | 0.443s | 0.064s | **6.9x** |
| large | 39.8 MB | 1.849s | 0.491s | **3.8x** |

## Root Cause

The previous implementation used Python's `heapq.merge()` with `to_pylist()`:

```python
# Old (1.45s for large file)
timecode_iterators = [t.column("timecodes").to_pylist() for t in channels.values()]
merged = heapq.merge(*timecode_iterators)
unique = [k for k, _ in groupby(merged)]
```

The new implementation uses numpy:

```python
# New (0.21s for large file)
arrays = [t.column("timecodes").to_numpy() for t in channels.values()]
unique = np.unique(np.concatenate(arrays))
```

Key improvements:
- `to_numpy()` is zero-copy from Arrow (vs `to_pylist()` creating Python objects)
- `np.unique` uses optimized C implementation (vs Python heapq/groupby)

## Test plan

- [x] All 137 tests pass
- [x] `poetry run poe check` passes (lint, typecheck, test)
- [x] Profiling confirms speedup on all test file sizes

🤖 Generated with [Claude Code](https://claude.ai/code)