### PR TITLE
fix: require numpy>=2.1 for Python 3.13 to fix Windows crashes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -644,7 +644,7 @@ description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "python_version < \"3.14\""
+markers = "python_version < \"3.13\""
 files = [
     {file = "numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0"},
     {file = "numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a"},
@@ -691,7 +691,7 @@ description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.11"
 groups = ["main"]
-markers = "python_version >= \"3.14\""
+markers = "python_version >= \"3.13\""
 files = [
     {file = "numpy-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0cce2a669e3c8ba02ee563c7835f92c153cf02edff1ae05e1823f1dde21b16a5"},
     {file = "numpy-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:899d2c18024984814ac7e83f8f49d8e8180e2fbe1b2e252f2e7f1d06bea92425"},
@@ -1338,7 +1338,7 @@ description = "C version of reader, parser and emitter for ruamel.yaml derived f
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
-markers = "platform_python_implementation == \"CPython\" and python_version >= \"3.12\" and python_version < \"3.14\""
+markers = "platform_python_implementation == \"CPython\" and python_version <= \"3.13\" and python_version >= \"3.12\""
 files = [
     {file = "ruamel_yaml_clib-0.2.15-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:88eea8baf72f0ccf232c22124d122a7f26e8a24110a0273d9bcddcb0f7e1fa03"},
     {file = "ruamel_yaml_clib-0.2.15-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9b6f7d74d094d1f3a4e157278da97752f16ee230080ae331fcc219056ca54f77"},
@@ -1632,4 +1632,4 @@ test = ["parameterized", "pytest"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "b9e1f78065d9b59ff6686ffdbf762cfe5ef22f13cb9162d4ac4df1beeba3770c"
+content-hash = "5344f6152bb15c8c2ac4a38068a52ed76cb8a549d433ce50c48cf1d50e021342"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-    "numpy>=1.26.0; python_version < '3.14'",
+    "numpy>=1.26.0; python_version < '3.13'",
+    "numpy>=2.1.0; python_version >= '3.13' and python_version < '3.14'",
     "numpy>=2.4.0; python_version >= '3.14'",
     "cython>=3.0.0",
     "pyarrow>=18.1.0; python_version < '3.14'",
@@ -62,7 +63,8 @@ exclude = [
 [tool.poetry.dependencies]
 python = "^3.10"
 numpy = [
-    {version = ">=1.26.0", python = "<3.14"},
+    {version = ">=1.26.0", python = "<3.13"},
+    {version = ">=2.1.0", python = ">=3.13,<3.14"},
     {version = ">=2.4.0", python = ">=3.14"},
 ]
 cython = "^3.0.0"
@@ -201,7 +203,8 @@ requires = [
     "poetry-core>=2.0.0,<3.0.0",
     "setuptools>=68.0.0",
     "cython>=3.0.0",
-    "numpy>=1.26.0; python_version < '3.14'",
+    "numpy>=1.26.0; python_version < '3.13'",
+    "numpy>=2.1.0; python_version >= '3.13' and python_version < '3.14'",
     "numpy>=2.4.0; python_version >= '3.14'",
 ]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary

- Fixes flaky Windows Python 3.13 test failures caused by numpy access violation crashes
- Requires numpy >= 2.1.0 for Python 3.13 (first version with official Python 3.13 support)
- numpy 1.26.x has a known bug on Windows + Python 3.13 in `getlimits.py` during import

## Root Cause

The `windows-latest Python 3.13` CI job was randomly failing with:
```
Windows fatal exception: access violation
  File "...\numpy\core\getlimits.py", line 52 in __init__
  File "...\numpy\core\getlimits.py", line 230 in _register_known_types
```

This is a known numpy issue: https://github.com/numpy/numpy/issues/27894

## Test plan

- [x] Local tests pass
- [ ] CI passes on all platforms including Windows Python 3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)