### PR TITLE
feat: add Pyodide 0.29.x support alongside 0.27.x

### DIFF
--- a/.github/workflows/pyodide.yml
+++ b/.github/workflows/pyodide.yml
@@ -9,7 +9,18 @@ on:
 jobs:
   pyodide-build:
     runs-on: ubuntu-latest
-    name: Build wheel for Pyodide (WebAssembly)
+    strategy:
+      matrix:
+        include:
+          - pyodide-version: "0.27.3"
+            python-version: "3.12"
+            emscripten-version: "3.1.58"
+            artifact-suffix: "-0.27"
+          - pyodide-version: "0.29.3"
+            python-version: "3.13"
+            emscripten-version: "4.0.9"
+            artifact-suffix: "-0.29"
+    name: Build wheel for Pyodide ${{ matrix.pyodide-version }}
 
     steps:
     - uses: actions/checkout@v4
@@ -19,20 +30,20 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: ${{ matrix.python-version }}
 
     - name: Install Emscripten SDK
       uses: mymindstorm/setup-emsdk@v14
       with:
-        version: '3.1.58'
+        version: ${{ matrix.emscripten-version }}
 
     - name: Install pyodide-build
       run: |
         pip install "wheel<0.44.0"
-        pip install pyodide-build==0.27.3
+        pip install pyodide-build==${{ matrix.pyodide-version }}
 
-    - name: Install Pyodide xbuildenv 0.27.3
-      run: pyodide xbuildenv install 0.27.3
+    - name: Install Pyodide xbuildenv
+      run: pyodide xbuildenv install ${{ matrix.pyodide-version }}
 
     - name: Build wheel for Pyodide
       run: pyodide build --exports whole_archive
@@ -40,14 +51,25 @@ jobs:
     - name: Upload wheel artifact
       uses: actions/upload-artifact@v4
       with:
-        name: pyodide-wheel
+        name: pyodide-wheel${{ matrix.artifact-suffix }}
         path: dist/*.whl
         retention-days: 7
 
   pyodide-test:
     runs-on: ubuntu-latest
     needs: pyodide-build
-    name: Test with Pyodide (WebAssembly)
+    strategy:
+      matrix:
+        include:
+          - pyodide-version: "0.27.3"
+            npm-package: "pyodide-0.27@npm:pyodide@0.27.3"
+            artifact-suffix: "-0.27"
+            version-arg: "0.27"
+          - pyodide-version: "0.29.3"
+            npm-package: "pyodide-0.29@npm:pyodide@0.29.3"
+            artifact-suffix: "-0.29"
+            version-arg: "0.29"
+    name: Test with Pyodide ${{ matrix.pyodide-version }}
 
     steps:
     - uses: actions/checkout@v4
@@ -62,14 +84,14 @@ jobs:
     - name: Download wheel artifact
       uses: actions/download-artifact@v4
       with:
-        name: pyodide-wheel
+        name: pyodide-wheel${{ matrix.artifact-suffix }}
         path: dist/
 
     - name: Install Pyodide
-      run: npm install pyodide@0.27.3
+      run: npm install ${{ matrix.npm-package }}
 
     - name: Run unit tests in Pyodide
-      run: node scripts/run_pyodide_tests.mjs --dist-dir=./dist
+      run: node scripts/run_pyodide_tests.mjs --dist-dir=./dist --pyodide-version=${{ matrix.version-arg }}
 
     - name: Run bytes input tests in Pyodide
-      run: node scripts/run_pyodide_tests_idbfs.mjs --dist-dir=./dist
+      run: node scripts/run_pyodide_tests_idbfs.mjs --dist-dir=./dist --pyodide-version=${{ matrix.version-arg }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,14 @@ Test data: `tests/test_data/` contains real XRK/XRZ files (SFJ and 86 vehicles).
 
 ## Pyodide (WebAssembly) Builds
 
-The library supports running in the browser via Pyodide. Requires Python 3.12+.
+The library supports running in the browser via Pyodide. Two versions are supported:
+
+| Version | Python | Emscripten | ABI Tag |
+|---------|--------|------------|---------|
+| Pyodide 0.27.x | 3.12 | 3.1.58 | `pyodide_2024_0` |
+| Pyodide 0.29.x | 3.13 | 4.0.9 | `pyodide_2025_0` |
+
+### Pyodide 0.27.x (default)
 
 ```bash
 poetry run poe emsdk-setup    # Install Emscripten SDK (first time only)
@@ -52,7 +59,16 @@ poetry run poe pyodide-test   # Build and run tests in Pyodide
 poetry run poe build-all      # Build CPython wheel, sdist, and Pyodide wheel
 ```
 
-Pyodide test scripts are in `scripts/run_pyodide_tests*.mjs`.
+### Pyodide 0.29.x (requires Python 3.13 via pyenv)
+
+```bash
+poetry run poe emsdk-setup-0-29    # Install Emscripten SDK 4.0.9
+poetry run poe pyodide-setup-0-29  # Install Pyodide 0.29.x npm package
+poetry run poe pyodide-build-0-29  # Build Pyodide 0.29.x wheel
+poetry run poe pyodide-test-0-29   # Build and run tests in Pyodide 0.29.x
+```
+
+Pyodide test scripts are in `scripts/run_pyodide_tests*.mjs`. They accept `--pyodide-version=0.27` or `--pyodide-version=0.29` to select the version.
 
 ## Architecture Notes
 

--- a/README.md
+++ b/README.md
@@ -160,11 +160,14 @@ You can test the library in a WebAssembly environment using Pyodide.
 This requires Node.js to be installed.
 
 ```bash
-# Build and run tests in Pyodide (installs Emscripten SDK to build/emsdk if needed)
+# Build and run tests in Pyodide 0.27.x (Python 3.12)
 poetry run poe pyodide-test
+
+# Build and run tests in Pyodide 0.29.x (Python 3.13, requires pyenv)
+poetry run poe pyodide-test-0-29
 ```
 
-Note: Pyodide tests run automatically in CI via GitHub Actions.
+Note: Pyodide tests for both 0.27.x and 0.29.x run automatically in CI via GitHub Actions.
 
 ### Building
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,34 @@
   "packages": {
     "": {
       "dependencies": {
-        "pyodide": "^0.27.3"
+        "pyodide-0.27": "npm:pyodide@^0.27.3",
+        "pyodide-0.29": "npm:pyodide@^0.29.3"
       }
     },
-    "node_modules/pyodide": {
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q=="
+    },
+    "node_modules/pyodide-0.27": {
+      "name": "pyodide",
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.27.3.tgz",
       "integrity": "sha512-6NwKEbPk0M3Wic2T1TCZijgZH9VE4RkHp1VGljS1sou0NjGdsmY2R/fG5oLmdDkjTRMI1iW7WYaY9pofX8gg1g==",
       "dependencies": {
+        "ws": "^8.5.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/pyodide-0.29": {
+      "name": "pyodide",
+      "version": "0.29.3",
+      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.29.3.tgz",
+      "integrity": "sha512-22UBuhOJawj7vKUnS7/F3xK+515LJdjiMAHoCfuS6/PbHiOrSQVnYwDe+2sbVwiOZ3sMMexdXICew6NqOMQGgA==",
+      "dependencies": {
+        "@types/emscripten": "^1.41.4",
         "ws": "^8.5.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "pyodide": "^0.27.3"
+    "pyodide-0.27": "npm:pyodide@^0.27.3",
+    "pyodide-0.29": "npm:pyodide@^0.29.3"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,15 +165,59 @@ interpreter = "bash"
 help = "Install Emscripten SDK to build/emsdk"
 
 [tool.poe.tasks.pyodide-setup]
-shell = "npm install pyodide@0.27.3"
+shell = "npm install pyodide-0.27@npm:pyodide@0.27.3"
 interpreter = "bash"
-help = "Install Pyodide npm package for WebAssembly testing"
+help = "Install Pyodide 0.27.x npm package for WebAssembly testing"
 
 [tool.poe.tasks.pyodide-test]
-shell = "rm -f src/libxrk/*.so dist/*.whl && source ./build/emsdk/emsdk_env.sh && pyodide build --exports whole_archive && node scripts/run_pyodide_tests.mjs --dist-dir=./dist && node scripts/run_pyodide_tests_idbfs.mjs --dist-dir=./dist && poetry install --only-root"
+shell = "rm -f src/libxrk/*.so dist/*pyodide_2024*.whl && source ./build/emsdk/emsdk_env.sh && pyodide build --exports whole_archive && node scripts/run_pyodide_tests.mjs --dist-dir=./dist --pyodide-version=0.27 && node scripts/run_pyodide_tests_idbfs.mjs --dist-dir=./dist --pyodide-version=0.27 && poetry install --only-root"
 interpreter = "bash"
-help = "Build and run tests in Pyodide (WebAssembly)"
+help = "Build and run tests in Pyodide 0.27.x (WebAssembly)"
 deps = ["emsdk-setup", "pyodide-setup"]
+
+[tool.poe.tasks.emsdk-setup-0-29]
+shell = """
+export PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" && \
+pip install pyodide-build==0.29.3 "wheel<0.44" && \
+EMSDK_VERSION=$(pyodide config get emscripten_version) && \
+mkdir -p build/emsdk-0.29 && \
+([ -d build/emsdk-0.29/.git ] || git clone https://github.com/emscripten-core/emsdk.git build/emsdk-0.29) && \
+cd build/emsdk-0.29 && git config core.autocrlf false && git checkout -- . && \
+./emsdk install $EMSDK_VERSION && ./emsdk activate $EMSDK_VERSION
+"""
+interpreter = "bash"
+help = "Install Emscripten SDK for Pyodide 0.29.x (requires Python 3.13 via pyenv)"
+
+[tool.poe.tasks.pyodide-setup-0-29]
+shell = "npm install pyodide-0.29@npm:pyodide@0.29.3"
+interpreter = "bash"
+help = "Install Pyodide 0.29.x npm package"
+
+[tool.poe.tasks.pyodide-build-0-29]
+shell = """
+export PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" && \
+pip install pyodide-build==0.29.3 "wheel<0.44" && \
+source ./build/emsdk-0.29/emsdk_env.sh && \
+pyodide build --exports whole_archive
+"""
+interpreter = "bash"
+help = "Build Pyodide 0.29.x wheel (requires Python 3.13 via pyenv)"
+deps = ["emsdk-setup-0-29"]
+
+[tool.poe.tasks.pyodide-test-0-29]
+shell = """
+export PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" && \
+rm -f src/libxrk/*.so dist/*pyodide_2025*.whl && \
+pip install pyodide-build==0.29.3 "wheel<0.44" && \
+source ./build/emsdk-0.29/emsdk_env.sh && \
+pyodide build --exports whole_archive && \
+node scripts/run_pyodide_tests.mjs --dist-dir=./dist --pyodide-version=0.29 && \
+node scripts/run_pyodide_tests_idbfs.mjs --dist-dir=./dist --pyodide-version=0.29 && \
+poetry install --only-root
+"""
+interpreter = "bash"
+help = "Build and test with Pyodide 0.29.x (requires Python 3.13 via pyenv)"
+deps = ["emsdk-setup-0-29", "pyodide-setup-0-29"]
 
 [tool.poe.tasks.build-all]
 shell = "rm -rf dist/ && poetry build && source ./build/emsdk/emsdk_env.sh && pyodide build --exports whole_archive && ls -la dist/"

--- a/scripts/run_pyodide_tests.mjs
+++ b/scripts/run_pyodide_tests.mjs
@@ -1,10 +1,9 @@
 /**
  * Run libxrk tests in Pyodide (WebAssembly) environment.
- * 
- * Usage: node scripts/run_pyodide_tests.mjs [--dist-dir=./dist]
+ *
+ * Usage: node scripts/run_pyodide_tests.mjs [--dist-dir=./dist] [--pyodide-version=0.27]
  */
 
-import { loadPyodide } from "pyodide";
 import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
@@ -44,8 +43,10 @@ function copyDirToFs(pyodide, srcDir, dstDir) {
 
 /**
  * Find the Pyodide-compatible wheel file in the dist directory.
+ * @param {string} distDir - Directory containing wheel files
+ * @param {string} pyodideVersion - Pyodide version (e.g., "0.27" or "0.29")
  */
-function findWheel(distDir) {
+function findWheel(distDir, pyodideVersion) {
   if (!fs.existsSync(distDir)) {
     throw new Error(`Dist directory not found: ${distDir}`);
   }
@@ -55,14 +56,27 @@ function findWheel(distDir) {
     throw new Error(`No wheel files found in ${distDir}`);
   }
 
-  // Prefer pyodide wheel, then emscripten wheel
+  // Determine ABI tag based on version
+  const abiYear = pyodideVersion.startsWith("0.27") ? "2024" : "2025";
+  const abiTag = `pyodide_${abiYear}`;
+
+  // Find wheel matching the ABI tag
+  const matchingWheel = wheels.find((w) => w.includes(abiTag));
+  if (matchingWheel) {
+    return path.join(distDir, matchingWheel);
+  }
+
+  // Fallback: try any pyodide wheel
   const pyodideWheel = wheels.find((w) => w.includes("pyodide"));
   if (pyodideWheel) {
+    console.log(`Warning: No wheel found with ABI tag ${abiTag}, using ${pyodideWheel}`);
     return path.join(distDir, pyodideWheel);
   }
 
+  // Fallback: try emscripten wheel
   const emscriptenWheel = wheels.find((w) => w.includes("emscripten"));
   if (emscriptenWheel) {
+    console.log(`Warning: No Pyodide wheel found, using ${emscriptenWheel}`);
     return path.join(distDir, emscriptenWheel);
   }
 
@@ -75,28 +89,42 @@ function findWheel(distDir) {
 function parseArgs() {
   const args = {
     distDir: path.join(projectRoot, "dist"),
+    pyodideVersion: "0.27",
   };
 
   for (const arg of process.argv.slice(2)) {
     if (arg.startsWith("--dist-dir=")) {
       args.distDir = arg.split("=")[1];
+    } else if (arg.startsWith("--pyodide-version=")) {
+      args.pyodideVersion = arg.split("=")[1];
     }
   }
 
   return args;
 }
 
+/**
+ * Dynamically load the appropriate Pyodide module based on version.
+ * @param {string} version - Pyodide version (e.g., "0.27" or "0.29")
+ */
+async function loadPyodideModule(version) {
+  const majorMinor = version.substring(0, 4); // "0.27" or "0.29"
+  const mod = await import(`pyodide-${majorMinor}`);
+  return mod.loadPyodide;
+}
+
 async function main() {
   const args = parseArgs();
 
-  console.log("Loading Pyodide...");
+  console.log(`Loading Pyodide ${args.pyodideVersion}...`);
+  const loadPyodide = await loadPyodideModule(args.pyodideVersion);
   const pyodide = await loadPyodide();
 
   console.log("Loading packages...");
   await pyodide.loadPackage(["numpy", "pyarrow", "micropip"]);
 
   // Find and install the wheel
-  const wheelPath = findWheel(args.distDir);
+  const wheelPath = findWheel(args.distDir, args.pyodideVersion);
   console.log(`Installing wheel: ${wheelPath}`);
 
   const micropip = pyodide.pyimport("micropip");
@@ -119,12 +147,12 @@ async function main() {
   }
 
   console.log("\nRunning tests...\n");
-  
+
   // Read and execute Python test runner
   const testRunnerPath = path.join(pyodideTestsDir, "run_unit_tests.py");
   const testRunnerCode = fs.readFileSync(testRunnerPath, "utf-8");
   pyodide.FS.writeFile("/pyodide_tests/run_unit_tests.py", testRunnerCode);
-  
+
   const testResult = await pyodide.runPythonAsync(`
 import sys
 sys.path.insert(0, '/pyodide_tests')

--- a/scripts/run_pyodide_tests_idbfs.mjs
+++ b/scripts/run_pyodide_tests_idbfs.mjs
@@ -1,13 +1,12 @@
 /**
  * Test libxrk in Pyodide with IDBFS to simulate JupyterLite's IndexedDB storage.
- * 
+ *
  * JupyterLite uses IDBFS (IndexedDB Filesystem) which doesn't support mmap.
  * This test demonstrates the failure and tests potential fixes.
- * 
- * Usage: node scripts/run_pyodide_tests_idbfs.mjs [--dist-dir=./dist]
+ *
+ * Usage: node scripts/run_pyodide_tests_idbfs.mjs [--dist-dir=./dist] [--pyodide-version=0.27]
  */
 
-import { loadPyodide } from "pyodide";
 import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
@@ -16,42 +15,98 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, "..");
 const pyodideTestsDir = path.join(__dirname, "pyodide_tests");
 
-function findWheel(distDir) {
+/**
+ * Find the Pyodide-compatible wheel file in the dist directory.
+ * @param {string} distDir - Directory containing wheel files
+ * @param {string} pyodideVersion - Pyodide version (e.g., "0.27" or "0.29")
+ */
+function findWheel(distDir, pyodideVersion) {
   if (!fs.existsSync(distDir)) {
     throw new Error(`Dist directory not found: ${distDir}`);
   }
+
   const wheels = fs.readdirSync(distDir).filter((f) => f.endsWith(".whl"));
+  if (wheels.length === 0) {
+    throw new Error(`No wheel files found in ${distDir}`);
+  }
+
+  // Determine ABI tag based on version
+  const abiYear = pyodideVersion.startsWith("0.27") ? "2024" : "2025";
+  const abiTag = `pyodide_${abiYear}`;
+
+  // Find wheel matching the ABI tag
+  const matchingWheel = wheels.find((w) => w.includes(abiTag));
+  if (matchingWheel) {
+    return path.join(distDir, matchingWheel);
+  }
+
+  // Fallback: try any pyodide wheel
   const pyodideWheel = wheels.find((w) => w.includes("pyodide"));
-  if (pyodideWheel) return path.join(distDir, pyodideWheel);
+  if (pyodideWheel) {
+    console.log(`Warning: No wheel found with ABI tag ${abiTag}, using ${pyodideWheel}`);
+    return path.join(distDir, pyodideWheel);
+  }
+
+  // Fallback: try emscripten wheel
   const emscriptenWheel = wheels.find((w) => w.includes("emscripten"));
-  if (emscriptenWheel) return path.join(distDir, emscriptenWheel);
-  throw new Error(`No Pyodide/Emscripten wheel found in ${distDir}`);
+  if (emscriptenWheel) {
+    console.log(`Warning: No Pyodide wheel found, using ${emscriptenWheel}`);
+    return path.join(distDir, emscriptenWheel);
+  }
+
+  throw new Error(`No Pyodide/Emscripten wheel found in ${distDir}. Found: ${wheels.join(", ")}`);
 }
 
+/**
+ * Parse command line arguments.
+ */
 function parseArgs() {
-  const args = { distDir: path.join(projectRoot, "dist") };
+  const args = {
+    distDir: path.join(projectRoot, "dist"),
+    pyodideVersion: "0.27",
+  };
+
   for (const arg of process.argv.slice(2)) {
-    if (arg.startsWith("--dist-dir=")) args.distDir = arg.split("=")[1];
+    if (arg.startsWith("--dist-dir=")) {
+      args.distDir = arg.split("=")[1];
+    } else if (arg.startsWith("--pyodide-version=")) {
+      args.pyodideVersion = arg.split("=")[1];
+    }
   }
+
   return args;
+}
+
+/**
+ * Dynamically load the appropriate Pyodide module based on version.
+ * @param {string} version - Pyodide version (e.g., "0.27" or "0.29")
+ */
+async function loadPyodideModule(version) {
+  const majorMinor = version.substring(0, 4); // "0.27" or "0.29"
+  const mod = await import(`pyodide-${majorMinor}`);
+  return mod.loadPyodide;
 }
 
 async function main() {
   const args = parseArgs();
 
-  console.log("Loading Pyodide...");
+  console.log(`Loading Pyodide ${args.pyodideVersion}...`);
+  const loadPyodide = await loadPyodideModule(args.pyodideVersion);
   const pyodide = await loadPyodide();
 
   console.log("Loading packages...");
   await pyodide.loadPackage(["numpy", "pyarrow", "micropip"]);
 
-  const wheelPath = findWheel(args.distDir);
+  const wheelPath = findWheel(args.distDir, args.pyodideVersion);
   console.log(`Installing wheel: ${wheelPath}`);
   const micropip = pyodide.pyimport("micropip");
   await micropip.install(`file://${path.resolve(wheelPath)}`);
 
   // Read test file as bytes (like pyfetch would do in browser)
-  const testFile = path.join(projectRoot, "tests/test_data/86/CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrk");
+  const testFile = path.join(
+    projectRoot,
+    "tests/test_data/86/CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrk"
+  );
   const fileBytes = new Uint8Array(fs.readFileSync(testFile));
   console.log(`Read test file as bytes: ${fileBytes.length} bytes`);
   pyodide.globals.set("js_file_bytes", fileBytes);


### PR DESCRIPTION
## Summary

- Add support for testing with Pyodide 0.29.3 (Python 3.13) alongside existing 0.27.3 (Python 3.12)
- Both versions now tested in CI via matrix strategy
- Shared test code between versions with minimal duplication

## Version Comparison

| Component | 0.27.x | 0.29.x |
|-----------|--------|--------|
| Pyodide | 0.27.3 | 0.29.3 |
| Python | 3.12 | 3.13 |
| Emscripten | 3.1.58 | 4.0.9 |
| ABI | pyodide_2024_0 | pyodide_2025_0 |

## Changes

- `package.json`: Aliased npm deps (`pyodide-0.27`, `pyodide-0.29`)
- `scripts/run_pyodide_tests*.mjs`: Added `--pyodide-version` arg, dynamic import, ABI-aware wheel finder
- `pyproject.toml`: Added 0.29.x poe tasks (`emsdk-setup-0-29`, `pyodide-test-0-29`, etc.)
- `.github/workflows/pyodide.yml`: Matrix strategy for both versions (4 jobs: 2 builds + 2 tests)
- `CLAUDE.md`, `README.md`: Updated documentation

## Test plan

- [x] Local 0.27.x tests pass: `poetry run poe pyodide-test`
- [x] Local 0.29.x tests pass: `poetry run poe pyodide-test-0-29` (requires Python 3.13 via pyenv)
- [ ] CI matrix shows 4 jobs (all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)