### PR TITLE
investigate: analyze CHS unknown bytes (112-byte layout)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,10 @@ poetry run poe pyodide-test-0-29   # Build and run tests in Pyodide 0.29.x
 
 Pyodide test scripts are in `scripts/run_pyodide_tests*.mjs`. They accept `--pyodide-version=0.27` or `--pyodide-version=0.29` to select the version.
 
+## Cython Rebuild
+
+After modifying `src/libxrk/aim_xrk.pyx`, you **must** run `poetry install` to recompile the Cython extension before running tests. Stale `.so` files will cause incorrect test results without any obvious error.
+
 ## Architecture Notes
 
 - Each channel is a PyArrow table with `timecodes` + value columns

--- a/scripts/investigate_missing_data/INVESTIGATION_REPORT.md
+++ b/scripts/investigate_missing_data/INVESTIGATION_REPORT.md
@@ -498,6 +498,162 @@ And filters out internal channels (Master Clk, StrtRec).
 
 ---
 
+## Phase 7: CHS Unknown Bytes Analysis
+
+**Date:** 2026-02-08
+**Method:** Byte-level analysis of all 548 CHS messages across 8 test files (5 XRK + 3 XRZ)
+
+### Complete CHS Layout (112 bytes)
+
+Analysis of 548 CHS messages across all test files reveals the following complete layout. Calibration fields (bytes 96-103) were **confirmed** by cross-referencing with CAL message analysis in Phase 6.
+
+| Offset | Size | Type | Field | Status | Evidence |
+|--------|------|------|-------|--------|----------|
+| 0-1 | 2 | uint16 LE | `index` | KNOWN | Channel index |
+| 2-3 | 2 | | *padding* | **IDENTIFIED** | Always zero |
+| 4-5 | 2 | uint16 LE | `hardware_id` | **IDENTIFIED** | Only non-zero for GPS decoder 8 (value 0x0846); likely hardware/CAN bus address |
+| 6-7 | 2 | uint16 LE | `source_channel_id` | **IDENTIFIED** | Sequential ID within the source device; GPS-derived channels use 800+ range |
+| 8-9 | 2 | uint16 LE | `hardware_ref_1` | **IDENTIFIED** | Only non-zero for GPS decoder 8 (value 0xF084); likely GPS hardware reference |
+| 10-11 | 2 | uint16 LE | `hardware_ref_2` | **IDENTIFIED** | Only non-zero for GPS decoder 8 (value 0x0084); pairs with bytes 8-9 |
+| 12 | 1 | uint8 | `unit_type` (full byte) | KNOWN+ | Lower 7 bits = unit type for `_unit_map`; **high bit = "signed/calibrated" flag** (set for CAN channels, shock pots, analog inputs, etc.) |
+| 13 | 1 | uint8 | `maybe_display_format` | **IDENTIFIED** | Varies per channel; 25 unique values; purpose unclear — possibly decimal places or display widget type |
+| 14-15 | 2 | uint16 LE | `maybe_config_flags` | **IDENTIFIED** | Channel configuration; non-zero for channels with special input config (shock pots: 1286/1158/774/646, wheel speed: 519, Reset Odometer: 64/192/320/448); encoding unknown |
+| 16 | 1 | uint8 | `source_type` | **IDENTIFIED** | Values: 1=internal simple, 2=RPM/encoder, 4=AIM computed/timer, 5=GPS raw, 9=CAN bus, 10=CAN group, 12=expansion |
+| 17-19 | 3 | | *padding* | **IDENTIFIED** | Always zero |
+| 20 | 1 | uint8 | `decoder_type` | KNOWN | Decoder function selector |
+| 21-23 | 3 | | *padding* | **IDENTIFIED** | Always zero |
+| 24-31 | 8 | char[8] | `short_name` | KNOWN | Null-terminated ASCII |
+| 32-55 | 24 | char[24] | `long_name` | KNOWN | Null-terminated ASCII |
+| 56-63 | 8 | | *padding* | **IDENTIFIED** | Always zero |
+| 64-67 | 4 | uint32 LE | `sample_period_us` | KNOWN | Microseconds per sample |
+| 68-69 | 2 | uint16 LE | `data_offset` | **IDENTIFIED** | Byte offset into packed channel data; consecutive channels pack at `offset + data_size` |
+| 70-71 | 2 | | *padding* | **IDENTIFIED** | Always zero |
+| 72 | 1 | uint8 | `data_size` | KNOWN | Bytes per sample |
+| 73-75 | 3 | | *padding* | **IDENTIFIED** | Always zero |
+| 76-79 | 4 | char[4] | `device_tag` | **IDENTIFIED** | Only two values observed: "@AIM" (0x40,0x41,0x49,0x4D) for internal AIM firmware channels, or all zeros for CAN bus/expansion/sensor channels |
+| 80 | 1 | uint8 | `device_node_id` | **IDENTIFIED** | Source device node: 0=CAN bus, 1=AIM timer, 2=AIM sensor, 3=AIM computed, 6=AIM IMU |
+| 81 | 1 | uint8 | `maybe_device_flags` | **IDENTIFIED** | Only 3 values seen: 0x00=normal, 0x02=alarm/switch type, 0x10=master clock only |
+| 82-83 | 2 | | *padding* | **IDENTIFIED** | Always zero |
+| 84 | 1 | uint8 | `maybe_output_type` | **IDENTIFIED** | 4 values seen: 1=simple value, 4=CAN decoded, 6=IMU/filtered, 0xFF=virtual/computed; grouping is clean but semantics are inferred |
+| 85-87 | 3 | | *padding* | **IDENTIFIED** | Always zero |
+| 88-91 | 4 | uint32 LE | `display_index` | **IDENTIFIED** | Sequential display/calibration slot index (0,2,4,6...); 0xFFFFFFFF for virtual/GPS-derived channels with no data storage |
+| 92 | 1 | uint8 | `maybe_output_size` | **IDENTIFIED** | Values: 0, 2, 4, 8; loosely correlates with decoded data width but doesn't always match data_size; 0 for virtual channels |
+| 93-95 | 3 | | *padding* | **IDENTIFIED** | Always zero |
+| 96-99 | 4 | float32 LE | `cal_value_1` | **CONFIRMED** | Calibration parameter 1. For 2-point linear (CAL type 1): raw ADC reading at cal point 1. For IMU (CAL type 20): zero-offset bias. Duplicated in CAL message offset 24-27. Most channels = 0.0 |
+| 100-103 | 4 | float32 LE | `cal_value_2` | **CONFIRMED** | Calibration parameter 2. For 2-point linear: raw ADC reading at cal point 2. For IMU: scale factor (always 1.0). Duplicated in CAL message offset 28-31. Most channels = 1.0 |
+| 104-107 | 4 | float32 LE | `display_range_min` | **IDENTIFIED** | Minimum display range: -1e30 (auto-range), 0.0 (zero-based), or specific min value |
+| 108-111 | 4 | float32 LE | `display_range_max` | **IDENTIFIED** | Maximum display range: +1e30 (auto-range), +inf, 99999.9, or specific max value |
+
+### Key Findings
+
+#### 1. Calibration Fields (bytes 96-103) — CONFIRMED via CAL cross-reference
+
+The Phase 6 CAL message analysis independently confirmed these fields. CHS bytes 96-99 and 100-103 are **exact duplicates** of CAL message offsets 24-27 and 28-31 respectively. This was verified for all channels that have both CHS and CAL entries:
+
+| Channel | CHS f32[96] | CHS f32[100] | CAL type | Confirmed meaning |
+|---------|-------------|--------------|----------|-------------------|
+| steering | 1669.06 | -3314.92 | 1 (2-point) | Raw ADC readings at -180° and +180° |
+| ACCEL | -4.85 | 80.03 | 1 (2-point) | Raw ADC readings at 50mm and 0mm pedal travel |
+| LF_Shock_Pot | -68.45 | 80.03 | 1 (2-point) | Raw ADC readings at two calibration points |
+| InlineAcc | 0.049 | 1.0 | 20 (IMU) | Zero-offset bias and scale (factory calibration) |
+| LateralAcc | 0.018 | 1.0 | 20 (IMU) | Zero-offset bias and scale |
+| YawRate | -1.021 | 1.0 | 20 (IMU) | Zero-offset bias and scale |
+
+Channels without CAL messages have identity values (0.0, 1.0), meaning calibration is handled internally by the decoder.
+
+Note: these are NOT `offset` and `scale` in the `value = raw * scale + offset` sense. For type 1 calibration, they are the two raw ADC readings at the two user-defined calibration points. The actual output values at those points are in the CAL message at offsets 32-35 and 36-39 (not duplicated in CHS).
+
+#### 2. Byte 12 High Bit (Previously Masked Out)
+
+The current parser uses `dcopy[12] & 127` to extract unit_type, discarding the high bit. Analysis shows the high bit is set for ~32% of channels (177/548), specifically:
+- All CAN bus channels (decoder 6/15)
+- Shock pot channels
+- Analog input channels with calibration
+- GPS-derived computed channels
+- Timer/odometer channels
+
+This bit likely indicates "has extended calibration" or "signed data" — channels where the raw data needs the cal_value fields to produce meaningful values.
+
+#### 3. Data Offset (bytes 68-69)
+
+This uint16 LE field is a **byte offset into packed channel data**. When channels are sorted by this offset, consecutive channels pack tightly:
+
+```
+offset=  0, size= 4: Master Clk     (gap=0)
+offset=  4, size=20: Lap Time       (gap=4)
+offset= 24, size= 4: Predictive Time (gap=20)
+offset= 28, size= 4: Best Run Diff  (gap=4)
+...
+```
+
+Each channel's data starts at `data_offset` and occupies `data_size` bytes. This is used internally by AIM software for direct data addressing.
+
+#### 4. Source Channel ID (bytes 6-7)
+
+This field identifies the channel's source within its hardware device:
+- Internal AIM channels: small sequential numbers (0-50)
+- CAN bus channels: CAN signal ID / message offset (0-1011)
+- GPS-derived channels: 800+ range (800=GPS_LateralAcc, 801=GPS_InlineAcc, etc.)
+
+#### 5. Display Range (bytes 104-111)
+
+Two float32 fields define the display range in AIM RaceStudio software:
+- `display_range_min` (bytes 104-107): -1e30 = auto-range, 0.0 = zero-based
+- `display_range_max` (bytes 108-111): +1e30 = auto-range, +inf = unbounded, 99999.9 = specific max
+
+#### 6. Device Tag (bytes 76-79)
+
+Only two values were observed across all 548 CHS messages:
+- `40 41 49 4d` = "@AIM" (177 messages) — channels originating from the AIM logger's firmware (Master Clk, computed timers, odometers, expansion device alarms)
+- `00 00 00 00` = null (371 messages) — CAN bus, sensor, and expansion channels
+
+No other device tag values were seen in any test file.
+
+#### 7. Virtual Channels
+
+GPS-derived channels (GPS_LateralAcc, GPS_InlineAcc, GPS_Yaw_Rate, GPS_Hours, GPS_Date, GPS_Time) have distinctive signatures:
+- `output_type` = 0xFF
+- `display_index` = 0xFFFFFFFF
+- `output_size` = 0
+
+These are computed by AIM firmware from GPS data and don't have their own raw data storage.
+
+#### 8. Always-Zero Regions (Confirmed Padding)
+
+The following byte ranges are confirmed padding (always zero across all 548 messages):
+- Bytes 2-3
+- Bytes 17-19
+- Bytes 21-23
+- Bytes 56-63
+- Bytes 70-71
+- Bytes 73-75
+- Bytes 82-83
+- Bytes 85-87
+- Bytes 93-95
+
+Total: 30 of 112 bytes are padding (27%).
+
+The parser now validates these padding bytes and prints a warning with a link to the issue tracker if any are non-zero, to help identify new fields in future XRK files.
+
+### Cross-File Stability
+
+119 channels appear across multiple files. For the vast majority, **all unknown bytes are identical across files** — confirming these are channel definition properties, not session-specific data. The few that differ:
+- `data_offset` (bytes 68-69): Varies because different files have different numbers of channels, so the packing order changes
+- `display_index` (bytes 88-91): Sequential index varies with file channel count
+- `device_tag` (bytes 76-79): Differs between AIM logger models (present on some, absent on others for the same channel)
+
+### Practical Impact
+
+The identified fields have limited impact on libxrk's core functionality:
+- **Calibration values**: Already applied before data is stored in XRK. Informational only — useful for diagnostics/verification (see Phase 6 CAL analysis).
+- **CDE offset / display_index**: Internal AIM addressing; not needed for data extraction.
+- **Display range**: Only useful for visualization defaults; not needed for data extraction.
+- **Source channel ID / device tag**: Useful for debugging channel provenance but not needed for data parsing.
+
+The byte 12 high bit could potentially be exposed as metadata, but since the current masking works correctly for `_unit_map` lookup, changing it is low priority.
+
+---
+
 ## Next Steps
 
 1. **Run DLL comparison** - Use Wine to compare GPS derived channels from DLL

--- a/scripts/investigate_missing_data/chs_byte_analysis.py
+++ b/scripts/investigate_missing_data/chs_byte_analysis.py
@@ -1,0 +1,669 @@
+#!/usr/bin/env python3
+"""
+CHS (Channel Definition) Unknown Bytes Analyzer.
+
+Analyzes the 112-byte CHS messages across all XRK files to identify
+patterns in the ~72 unknown bytes that aren't currently decoded.
+
+Known CHS layout (112 bytes):
+  [0:2]   uint16 LE - channel index
+  [2:12]  ???
+  [12]    unit_type (lower 7 bits)
+  [13]    ???
+  [14:20] ???
+  [20]    decoder_type
+  [21:24] ???
+  [24:32] short_name (null-terminated ASCII)
+  [32:56] long_name (null-terminated ASCII)
+  [56:64] ???
+  [64:68] uint32 LE - sample_period_us
+  [68:72] ???
+  [72]    data_size (bytes per sample)
+  [73:112] ???
+"""
+
+import math
+import struct
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+from message_scanner import decompress_if_needed, tokdec, tokenc
+
+
+CHS_SIZE = 112
+
+# Known byte ranges (offset, length, name)
+KNOWN_FIELDS = [
+    (0, 2, "index"),
+    (12, 1, "unit_type"),
+    (20, 1, "decoder_type"),
+    (24, 8, "short_name"),
+    (32, 24, "long_name"),
+    (64, 4, "sample_period_us"),
+    (72, 1, "data_size"),
+]
+
+# Unknown byte ranges to investigate
+UNKNOWN_RANGES = [
+    (2, 10, "unk_02_11"),
+    (13, 1, "unk_13"),
+    (14, 6, "unk_14_19"),
+    (21, 3, "unk_21_23"),
+    (56, 8, "unk_56_63"),
+    (68, 4, "unk_68_71"),
+    (73, 39, "unk_73_111"),
+]
+
+
+def extract_chs_messages(file_path: Path) -> list[dict]:
+    """Extract all CHS messages from an XRK file, including inside CNF containers."""
+    with open(file_path, "rb") as f:
+        raw_data = f.read()
+
+    data = decompress_if_needed(raw_data)
+    messages = []
+
+    def scan_for_chs(data: bytes, source: str):
+        pos = 0
+        ord_lt = ord("<")
+        ord_gt = ord(">")
+
+        while pos < len(data):
+            if pos + 2 > len(data):
+                break
+
+            b0, b1 = data[pos], data[pos + 1]
+
+            if b0 == ord_lt and b1 == ord("h"):
+                if pos + 12 > len(data):
+                    pos += 1
+                    continue
+
+                tok = struct.unpack_from("<I", data, pos + 2)[0]
+                hlen = struct.unpack_from("<i", data, pos + 6)[0]
+                cl = data[pos + 11]
+
+                if cl != ord_gt:
+                    pos += 1
+                    continue
+
+                if (tok >> 24) == 32:
+                    tok -= 32 << 24
+
+                token_str = tokenc(tok)
+
+                if pos + 12 + hlen + 8 > len(data):
+                    pos += 1
+                    continue
+
+                ftr_pos = pos + 12 + hlen
+                ftr_tok = struct.unpack_from("<I", data, ftr_pos + 1)[0]
+                ftr_cl = data[ftr_pos + 7]
+
+                if ftr_tok != tok or ftr_cl != ord_gt:
+                    pos += 1
+                    continue
+
+                msg_data = data[pos + 12 : pos + 12 + hlen]
+
+                if token_str == "CNF":
+                    scan_for_chs(msg_data, f"{source}/CNF")
+
+                if token_str == "ENF":
+                    scan_for_chs(msg_data, f"{source}/ENF")
+
+                if token_str == "CHS" and len(msg_data) >= CHS_SIZE:
+                    raw = bytes(msg_data[:CHS_SIZE])
+                    ch_index = struct.unpack_from("<H", raw, 0)[0]
+                    short_name = raw[24:32].split(b"\x00")[0].decode("ascii", errors="replace")
+                    long_name = raw[32:56].split(b"\x00")[0].decode("ascii", errors="replace")
+                    unit_type = raw[12] & 127
+                    unit_high_bit = (raw[12] >> 7) & 1
+                    decoder_type = raw[20]
+                    sample_period_us = struct.unpack_from("<I", raw, 64)[0]
+                    data_size = raw[72]
+
+                    messages.append(
+                        {
+                            "file": str(file_path.name),
+                            "source": source,
+                            "raw": raw,
+                            "index": ch_index,
+                            "short_name": short_name,
+                            "long_name": long_name,
+                            "unit_type": unit_type,
+                            "unit_high_bit": unit_high_bit,
+                            "decoder_type": decoder_type,
+                            "sample_period_us": sample_period_us,
+                            "data_size": data_size,
+                        }
+                    )
+
+                pos = ftr_pos + 8
+                continue
+
+            pos += 1
+
+    scan_for_chs(data, str(file_path.name))
+    return messages
+
+
+def entropy(values: list[int]) -> float:
+    """Shannon entropy of a list of byte values."""
+    if not values:
+        return 0.0
+    counts = Counter(values)
+    total = len(values)
+    ent = 0.0
+    for count in counts.values():
+        p = count / total
+        if p > 0:
+            ent -= p * math.log2(p)
+    return ent
+
+
+def per_byte_analysis(all_msgs: list[dict]):
+    """Analyze each byte position across all CHS messages."""
+    print("=" * 100)
+    print("PER-BYTE ANALYSIS (112 bytes)")
+    print("=" * 100)
+    print()
+
+    n = len(all_msgs)
+
+    # Build known-byte set for highlighting
+    known_bytes = set()
+    for offset, length, _ in KNOWN_FIELDS:
+        for i in range(offset, offset + length):
+            known_bytes.add(i)
+
+    print(f"Total CHS messages analyzed: {n}")
+    print()
+    print(
+        f"{'Offset':>6}  {'Status':8}  {'Always0':>7}  {'Const':>5}  "
+        f"{'Unique':>6}  {'Min':>5}  {'Max':>5}  {'Entropy':>7}  "
+        f"{'Most Common (count)':30}  Notes"
+    )
+    print("-" * 130)
+
+    for byte_pos in range(CHS_SIZE):
+        values = [m["raw"][byte_pos] for m in all_msgs]
+        counts = Counter(values)
+        unique = len(counts)
+        most_common = counts.most_common(5)
+        ent = entropy(values)
+        min_v = min(values)
+        max_v = max(values)
+        all_zero = all(v == 0 for v in values)
+        constant = unique == 1
+
+        status = "KNOWN" if byte_pos in known_bytes else "???"
+        mc_str = ", ".join(f"0x{v:02x}({c})" for v, c in most_common[:3])
+
+        notes = []
+        if all_zero:
+            notes.append("ALWAYS ZERO")
+        elif constant:
+            notes.append(f"CONSTANT=0x{values[0]:02x}")
+        elif unique <= 3:
+            notes.append(f"LOW VARIETY ({unique} vals)")
+
+        print(
+            f"  [{byte_pos:3d}]  {status:8}  {'yes' if all_zero else 'no':>7}  "
+            f"{'yes' if constant else 'no':>5}  {unique:>6}  "
+            f"0x{min_v:02x}  0x{max_v:02x}  {ent:>7.3f}  "
+            f"{mc_str:30}  {'; '.join(notes)}"
+        )
+
+    print()
+
+
+def unknown_range_analysis(all_msgs: list[dict]):
+    """Detailed analysis of each unknown byte range."""
+    print("=" * 100)
+    print("UNKNOWN RANGE ANALYSIS")
+    print("=" * 100)
+
+    for offset, length, name in UNKNOWN_RANGES:
+        print()
+        print(f"--- {name}: bytes [{offset}:{offset + length}] ({length} bytes) ---")
+        print()
+
+        # Extract raw bytes for this range
+        ranges = [m["raw"][offset : offset + length] for m in all_msgs]
+
+        # Check if always zero
+        if all(all(b == 0 for b in r) for r in ranges):
+            print("  => ALL ZEROS across all channels/files")
+            continue
+
+        # Check if constant
+        unique_ranges = set(r for r in ranges)
+        if len(unique_ranges) == 1:
+            val = ranges[0]
+            print(f"  => CONSTANT: {val.hex()}")
+            continue
+
+        print(f"  Unique patterns: {len(unique_ranges)} / {len(ranges)} total")
+
+        # Try multi-type interpretations
+        print()
+        print("  Multi-type interpretations:")
+
+        # uint16 LE pairs
+        if length >= 2 and length % 2 == 0:
+            for sub_off in range(0, length, 2):
+                abs_off = offset + sub_off
+                vals = [struct.unpack_from("<H", m["raw"], abs_off)[0] for m in all_msgs]
+                svals = [struct.unpack_from("<h", m["raw"], abs_off)[0] for m in all_msgs]
+                unique_u = sorted(set(vals))
+                unique_s = sorted(set(svals))
+                if len(unique_u) == 1 and unique_u[0] == 0:
+                    print(f"    uint16 LE [{abs_off}:{abs_off+2}]: always 0")
+                else:
+                    print(
+                        f"    uint16 LE [{abs_off}:{abs_off+2}]: "
+                        f"{len(unique_u)} unique, range [{min(vals)}, {max(vals)}]"
+                        f" | top: {Counter(vals).most_common(5)}"
+                    )
+                    if any(v < 0 for v in svals):
+                        print(
+                            f"    int16  LE [{abs_off}:{abs_off+2}]: "
+                            f"range [{min(svals)}, {max(svals)}]"
+                        )
+
+        # uint32 LE
+        if length >= 4 and length % 4 == 0:
+            for sub_off in range(0, length, 4):
+                abs_off = offset + sub_off
+                vals = [struct.unpack_from("<I", m["raw"], abs_off)[0] for m in all_msgs]
+                fvals = [struct.unpack_from("<f", m["raw"], abs_off)[0] for m in all_msgs]
+                unique_u = sorted(set(vals))
+                if len(unique_u) == 1 and unique_u[0] == 0:
+                    print(f"    uint32 LE [{abs_off}:{abs_off+4}]: always 0")
+                else:
+                    print(
+                        f"    uint32 LE [{abs_off}:{abs_off+4}]: "
+                        f"{len(unique_u)} unique, range [{min(vals)}, {max(vals)}]"
+                        f" | top: {Counter(vals).most_common(5)}"
+                    )
+
+                # float32 - only show if values look reasonable (not NaN/inf)
+                valid_floats = [v for v in fvals if not (math.isnan(v) or math.isinf(v))]
+                if valid_floats and not (len(unique_u) == 1 and unique_u[0] == 0):
+                    print(
+                        f"    float32 LE [{abs_off}:{abs_off+4}]: "
+                        f"range [{min(valid_floats):.6g}, {max(valid_floats):.6g}]"
+                        f" | top: {Counter(fvals).most_common(5)}"
+                    )
+
+        # ASCII interpretation
+        raw_concat = b"".join(ranges)
+        printable_ratio = sum(1 for b in raw_concat if 32 <= b < 127) / max(len(raw_concat), 1)
+        if printable_ratio > 0.5:
+            print(f"    ASCII (printable ratio {printable_ratio:.0%}):")
+            seen = set()
+            for m in all_msgs:
+                s = m["raw"][offset : offset + length].decode("ascii", errors="replace")
+                if s not in seen:
+                    seen.add(s)
+                    print(f"      '{s}' ({m['long_name']})")
+                    if len(seen) >= 10:
+                        print(f"      ... and {len(unique_ranges) - 10} more")
+                        break
+
+        # Show values grouped by channel name
+        print()
+        print("  Values by channel (sample):")
+        by_name = defaultdict(list)
+        for m in all_msgs:
+            by_name[m["long_name"]].append(m["raw"][offset : offset + length])
+
+        shown = 0
+        for ch_name, vals in sorted(by_name.items()):
+            if shown >= 20:
+                print(f"  ... and {len(by_name) - shown} more channels")
+                break
+            unique_for_ch = set(v.hex() for v in vals)
+            if len(unique_for_ch) == 1:
+                print(f"    {ch_name:30s}: {vals[0].hex(sep=' ')}")
+            else:
+                print(f"    {ch_name:30s}: {len(unique_for_ch)} different across files")
+                for v in sorted(unique_for_ch)[:3]:
+                    print(f"      {v}")
+            shown += 1
+
+    print()
+
+
+def group_by_analysis(all_msgs: list[dict]):
+    """Analyze unknown bytes grouped by decoder_type and unit_type."""
+    print("=" * 100)
+    print("GROUP-BY ANALYSIS")
+    print("=" * 100)
+
+    # Group by decoder_type
+    print()
+    print("--- By decoder_type ---")
+    by_decoder = defaultdict(list)
+    for m in all_msgs:
+        by_decoder[m["decoder_type"]].append(m)
+
+    for dt, msgs in sorted(by_decoder.items()):
+        ch_names = sorted(set(m["long_name"] for m in msgs))
+        print(
+            f"\n  Decoder {dt} ({len(msgs)} channels: {', '.join(ch_names[:5])}"
+            f"{'...' if len(ch_names) > 5 else ''})"
+        )
+
+        for offset, length, name in UNKNOWN_RANGES:
+            ranges = [m["raw"][offset : offset + length] for m in msgs]
+            unique = set(r.hex() for r in ranges)
+            if len(unique) == 1:
+                val = ranges[0]
+                if all(b == 0 for b in val):
+                    print(f"    {name:15s}: constant (all zeros)")
+                else:
+                    print(f"    {name:15s}: constant = {val.hex(sep=' ')}")
+            else:
+                print(f"    {name:15s}: {len(unique)} unique patterns")
+
+    # Group by unit_type
+    print()
+    print("--- By unit_type ---")
+    by_unit = defaultdict(list)
+    for m in all_msgs:
+        by_unit[m["unit_type"]].append(m)
+
+    for ut, msgs in sorted(by_unit.items()):
+        ch_names = sorted(set(m["long_name"] for m in msgs))
+        print(
+            f"\n  Unit type {ut} ({len(msgs)} channels: {', '.join(ch_names[:5])}"
+            f"{'...' if len(ch_names) > 5 else ''})"
+        )
+
+        for offset, length, name in UNKNOWN_RANGES:
+            ranges = [m["raw"][offset : offset + length] for m in msgs]
+            unique = set(r.hex() for r in ranges)
+            if len(unique) == 1:
+                val = ranges[0]
+                if all(b == 0 for b in val):
+                    print(f"    {name:15s}: constant (all zeros)")
+                else:
+                    print(f"    {name:15s}: constant = {val.hex(sep=' ')}")
+            else:
+                print(f"    {name:15s}: {len(unique)} unique patterns")
+
+    print()
+
+
+def correlation_analysis(all_msgs: list[dict]):
+    """Check if unknown bytes correlate with known properties."""
+    print("=" * 100)
+    print("CORRELATION ANALYSIS")
+    print("=" * 100)
+    print()
+
+    # For each unknown range, check if its value is fully determined by decoder_type
+    for offset, length, name in UNKNOWN_RANGES:
+        all_zero = all(all(b == 0 for b in m["raw"][offset : offset + length]) for m in all_msgs)
+        if all_zero:
+            continue
+
+        print(f"--- {name} [{offset}:{offset+length}] ---")
+
+        # Check correlation with decoder_type
+        by_decoder = defaultdict(set)
+        for m in all_msgs:
+            by_decoder[m["decoder_type"]].add(m["raw"][offset : offset + length].hex())
+
+        all_unique_in_decoder = all(len(v) == 1 for v in by_decoder.values())
+        if all_unique_in_decoder:
+            print(f"  FULLY DETERMINED by decoder_type!")
+            for dt, vals in sorted(by_decoder.items()):
+                print(f"    decoder {dt}: {list(vals)[0]}")
+        else:
+            varying = {dt: vals for dt, vals in by_decoder.items() if len(vals) > 1}
+            print(f"  Varies within decoder_type for: " f"{sorted(varying.keys())}")
+
+        # Check correlation with unit_type
+        by_unit = defaultdict(set)
+        for m in all_msgs:
+            by_unit[m["unit_type"]].add(m["raw"][offset : offset + length].hex())
+
+        all_unique_in_unit = all(len(v) == 1 for v in by_unit.values())
+        if all_unique_in_unit:
+            print(f"  FULLY DETERMINED by unit_type!")
+            for ut, vals in sorted(by_unit.items()):
+                print(f"    unit {ut}: {list(vals)[0]}")
+        else:
+            varying = {ut: vals for ut, vals in by_unit.items() if len(vals) > 1}
+            print(f"  Varies within unit_type for: " f"{sorted(varying.keys())}")
+
+        # Check correlation with (decoder_type, unit_type) pair
+        by_pair = defaultdict(set)
+        for m in all_msgs:
+            key = (m["decoder_type"], m["unit_type"])
+            by_pair[key].add(m["raw"][offset : offset + length].hex())
+
+        all_unique_in_pair = all(len(v) == 1 for v in by_pair.values())
+        if all_unique_in_pair and not all_unique_in_decoder:
+            print(f"  FULLY DETERMINED by (decoder_type, unit_type) pair!")
+
+        # Check correlation with data_size
+        by_size = defaultdict(set)
+        for m in all_msgs:
+            by_size[m["data_size"]].add(m["raw"][offset : offset + length].hex())
+
+        all_unique_in_size = all(len(v) == 1 for v in by_size.values())
+        if all_unique_in_size and not all_unique_in_decoder:
+            print(f"  FULLY DETERMINED by data_size!")
+            for ds, vals in sorted(by_size.items()):
+                print(f"    size {ds}: {list(vals)[0]}")
+
+        print()
+
+
+def cross_file_analysis(all_msgs: list[dict]):
+    """Compare unknown bytes for same channel across different files."""
+    print("=" * 100)
+    print("CROSS-FILE COMPARISON")
+    print("=" * 100)
+    print()
+
+    # Group by channel name across files
+    by_name = defaultdict(list)
+    for m in all_msgs:
+        by_name[m["long_name"]].append(m)
+
+    # Only look at channels appearing in multiple files
+    multi_file = {
+        name: msgs for name, msgs in by_name.items() if len(set(m["file"] for m in msgs)) > 1
+    }
+
+    if not multi_file:
+        print("No channels found across multiple files.")
+        return
+
+    print(f"Channels appearing in multiple files: {len(multi_file)}")
+    print()
+
+    for ch_name, msgs in sorted(multi_file.items()):
+        files = sorted(set(m["file"] for m in msgs))
+        print(f"  {ch_name} (in {len(files)} files)")
+
+        # Compare unknown bytes across files
+        all_identical = True
+        for offset, length, name in UNKNOWN_RANGES:
+            ranges = set(m["raw"][offset : offset + length].hex() for m in msgs)
+            if len(ranges) > 1:
+                all_identical = False
+                print(f"    {name}: DIFFERS across files")
+                for m in msgs:
+                    val = m["raw"][offset : offset + length].hex(sep=" ")
+                    print(f"      {m['file'][:40]:40s}: {val}")
+
+        if all_identical:
+            print(f"    All unknown bytes IDENTICAL across files")
+
+    print()
+
+
+def byte_12_high_bit_analysis(all_msgs: list[dict]):
+    """Specifically analyze byte 12 high bit (currently masked out by & 127)."""
+    print("=" * 100)
+    print("BYTE 12 HIGH BIT ANALYSIS")
+    print("=" * 100)
+    print()
+
+    for m in all_msgs:
+        high_bit = m["unit_high_bit"]
+        if high_bit:
+            print(
+                f"  {m['long_name']:30s} unit_type={m['unit_type']:3d} "
+                f"high_bit=1 decoder={m['decoder_type']} "
+                f"file={m['file']}"
+            )
+
+    if not any(m["unit_high_bit"] for m in all_msgs):
+        print("  High bit of byte 12 is NEVER SET across all channels.")
+
+    print()
+
+
+def full_hex_dump(all_msgs: list[dict]):
+    """Dump all CHS messages with annotations for review."""
+    print("=" * 100)
+    print("ANNOTATED HEX DUMP (first 5 unique channels per decoder type)")
+    print("=" * 100)
+
+    by_decoder = defaultdict(list)
+    for m in all_msgs:
+        by_decoder[m["decoder_type"]].append(m)
+
+    for dt, msgs in sorted(by_decoder.items()):
+        print(f"\n--- Decoder type {dt} ---")
+        seen_names = set()
+        for m in msgs:
+            if m["long_name"] in seen_names:
+                continue
+            seen_names.add(m["long_name"])
+            if len(seen_names) > 5:
+                print(f"  ... and {len(set(mm['long_name'] for mm in msgs)) - 5} more")
+                break
+
+            raw = m["raw"]
+            print(
+                f"\n  Channel: {m['long_name']} ({m['short_name']})"
+                f"  idx={m['index']} unit={m['unit_type']} "
+                f"size={m['data_size']} period={m['sample_period_us']}us"
+            )
+            print(f"  File: {m['file']}")
+
+            # Print hex with offset annotations
+            for row_start in range(0, CHS_SIZE, 16):
+                row_end = min(row_start + 16, CHS_SIZE)
+                hex_vals = " ".join(f"{raw[i]:02x}" for i in range(row_start, row_end))
+
+                # Annotate known fields
+                annotations = []
+                for koff, klen, kname in KNOWN_FIELDS:
+                    if row_start <= koff < row_end or row_start < koff + klen <= row_end:
+                        annotations.append(kname)
+
+                ann_str = f"  <- {', '.join(annotations)}" if annotations else ""
+                print(f"    [{row_start:3d}] {hex_vals:48s}{ann_str}")
+
+    print()
+
+
+def summary(all_msgs: list[dict]):
+    """Print a summary of findings."""
+    print("=" * 100)
+    print("SUMMARY OF FINDINGS")
+    print("=" * 100)
+    print()
+
+    # Categorize each unknown range
+    for offset, length, name in UNKNOWN_RANGES:
+        all_zero = all(all(b == 0 for b in m["raw"][offset : offset + length]) for m in all_msgs)
+        if all_zero:
+            status = "ALWAYS ZERO (padding)"
+        else:
+            unique = set(m["raw"][offset : offset + length].hex() for m in all_msgs)
+            if len(unique) == 1:
+                status = f"CONSTANT = {list(unique)[0]}"
+            else:
+                # Check if determined by decoder_type
+                by_dt = defaultdict(set)
+                for m in all_msgs:
+                    by_dt[m["decoder_type"]].add(m["raw"][offset : offset + length].hex())
+                if all(len(v) == 1 for v in by_dt.values()):
+                    status = f"VARIES but determined by decoder_type ({len(unique)} patterns)"
+                else:
+                    # Check by (decoder, unit) pair
+                    by_pair = defaultdict(set)
+                    for m in all_msgs:
+                        key = (m["decoder_type"], m["unit_type"])
+                        by_pair[key].add(m["raw"][offset : offset + length].hex())
+                    if all(len(v) == 1 for v in by_pair.values()):
+                        status = f"VARIES but determined by (decoder_type, unit_type) ({len(unique)} patterns)"
+                    else:
+                        status = f"VARIES per channel ({len(unique)} unique patterns)"
+
+        print(f"  [{offset:3d}:{offset+length:3d}] {name:15s}: {status}")
+
+    print()
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python chs_byte_analysis.py <xrk_file_or_directory>")
+        sys.exit(1)
+
+    target = Path(sys.argv[1])
+
+    if target.is_file():
+        files = [target]
+    elif target.is_dir():
+        files = sorted(target.glob("**/*.xrk")) + sorted(target.glob("**/*.xrz"))
+    else:
+        print(f"Error: {target} not found")
+        sys.exit(1)
+
+    if not files:
+        print(f"No XRK/XRZ files found in {target}")
+        sys.exit(1)
+
+    all_msgs = []
+    for file_path in sorted(files):
+        print(f"Extracting CHS from {file_path}...", file=sys.stderr)
+        msgs = extract_chs_messages(file_path)
+        all_msgs.extend(msgs)
+        print(f"  Found {len(msgs)} CHS messages", file=sys.stderr)
+
+    print(f"\nTotal CHS messages: {len(all_msgs)}", file=sys.stderr)
+    print(
+        f"Unique channels: {len(set(m['long_name'] for m in all_msgs))}",
+        file=sys.stderr,
+    )
+    print(
+        f"Files: {len(set(m['file'] for m in all_msgs))}",
+        file=sys.stderr,
+    )
+    print(file=sys.stderr)
+
+    # Run all analyses
+    per_byte_analysis(all_msgs)
+    unknown_range_analysis(all_msgs)
+    byte_12_high_bit_analysis(all_msgs)
+    group_by_analysis(all_msgs)
+    correlation_analysis(all_msgs)
+    cross_file_analysis(all_msgs)
+    full_hex_dump(all_msgs)
+    summary(all_msgs)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/libxrk/aim_xrk.pyx
+++ b/src/libxrk/aim_xrk.pyx
@@ -429,9 +429,68 @@ def _decode_sequence(s, progress=None):
                                 data.units = ''
                                 data.dec_pts = 0
 
-                            # [12] unit type (lower 7 bits), used by _unit_map
-                            # [20] decoder type, used by _decoders
-                            # [64:68] sample period in microseconds (uint32 LE). Mms = value // 1000
+                            # CHS layout (112 bytes):
+                            # [0:2]    uint16 LE   channel index
+                            # [2:4]    padding
+                            # [4:6]    uint16 LE   hardware ID (non-zero for GPS only)
+                            # [6:8]    uint16 LE   source channel ID within device
+                            # [8:12]   uint32 LE   hardware reference (GPS-only)
+                            # [12]     uint8       unit type (lower 7 bits); high bit = calibrated flag
+                            # [13]     uint8       maybe_display_format (purpose unclear)
+                            # [14:16]  uint16 LE   maybe_config_flags (encoding unknown)
+                            # [16]     uint8       source type (1=internal, 5=GPS, 9=CAN, etc.)
+                            # [17:20]  padding
+                            # [20]     uint8       decoder type, used by _decoders
+                            # [21:24]  padding
+                            # [24:32]  char[8]     short name
+                            # [32:56]  char[24]    long name
+                            # [56:64]  padding
+                            # [64:68]  uint32 LE   sample period in microseconds; Mms = value // 1000
+                            # [68:70]  uint16 LE   data offset into packed channel data
+                            # [70:72]  padding
+                            # [72]     uint8       data size (bytes per sample)
+                            # [73:76]  padding
+                            # [76:80]  char[4]     device tag ("@AIM" or null)
+                            # [80]     uint8       device node ID
+                            # [81]     uint8       maybe_device_flags (3 values: 0x00, 0x02, 0x10)
+                            # [82:84]  padding
+                            # [84]     uint8       maybe_output_type (1/4/6/0xFF)
+                            # [85:88]  padding
+                            # [88:92]  uint32 LE   display index (0xFFFFFFFF for virtual)
+                            # [92]     uint8       maybe_output_size (0/2/4/8)
+                            # [93:96]  padding
+                            # [96:100] float32 LE  cal_value_1 (= CAL offset 24; confirmed)
+                            # [100:104] float32 LE cal_value_2 (= CAL offset 28; confirmed)
+                            # [104:108] float32 LE display range min
+                            # [108:112] float32 LE display range max
+
+                            # Validate padding bytes - if any are non-zero, this CHS
+                            # layout has unknown fields we haven't seen before.
+                            _chs_padding = (
+                                dcopy[2:4] + dcopy[17:20] + dcopy[21:24] +
+                                dcopy[56:64] + dcopy[70:72] + dcopy[73:76] +
+                                dcopy[82:84] + dcopy[85:88] + dcopy[93:96]
+                            )
+                            if any(_chs_padding):
+                                _ch_name = dcopy[32:56].split(b'\x00')[0].decode(
+                                    'ascii', errors='replace')
+                                _nonzero = [
+                                    (i, b) for i, b in enumerate(dcopy)
+                                    if b != 0 and i in (
+                                        2, 3, 17, 18, 19, 21, 22, 23,
+                                        56, 57, 58, 59, 60, 61, 62, 63,
+                                        70, 71, 73, 74, 75, 82, 83,
+                                        85, 86, 87, 93, 94, 95)
+                                ]
+                                print(
+                                    'CHS padding non-zero for channel %s: %s. '
+                                    'Please report at '
+                                    'https://github.com/m3rlin45/libxrk/issues '
+                                    'with your XRK file.' %
+                                    (_ch_name,
+                                     ', '.join('[%d]=0x%02x' % (i, b)
+                                               for i, b in _nonzero)))
+
                             dcopy[0:2] = [0] * 2 # reset index
                             dcopy[24:32] = [0] * 8 # short name
                             dcopy[32:56] = [0] * 24 # long name


### PR DESCRIPTION
## Summary
- Systematically analyzed all 548 CHS messages across 8 test files to map the full 112-byte channel definition layout
- Identified purpose of ~72 previously unknown bytes: calibration fields (confirmed via CAL cross-reference), data offset, device tag, source type, display range, and 30 bytes of padding
- Added runtime padding validation that warns users if unseen non-zero padding bytes are found
- Added Cython rebuild reminder to CLAUDE.md

Closes #26

**Note:** This PR sits on top of #37 (`investigate-unknown-messages`). Land #37 first, then rebase this.

## Key Findings

| Category | Bytes | Finding |
|----------|-------|---------|
| Calibration | 96-103 | `cal_value_1`/`cal_value_2` — confirmed via CAL message cross-reference |
| Data layout | 68-69 | `data_offset` — byte offset into packed channel data |
| Device info | 76-79 | `device_tag` — "@AIM" or null |
| Source info | 6-7, 16 | `source_channel_id`, `source_type` |
| Display | 104-111 | `display_range_min`/`display_range_max` |
| Padding | 30 bytes | Always zero across all 548 messages |

## Files Changed
- `scripts/investigate_missing_data/chs_byte_analysis.py` — New analysis script
- `scripts/investigate_missing_data/INVESTIGATION_REPORT.md` — Phase 7 documentation
- `src/libxrk/aim_xrk.pyx` — CHS layout comments + padding validation
- `CLAUDE.md` — Cython rebuild reminder

## Test plan
- [x] `poetry run poe check` passes (lint, typecheck, 141 tests)
- [ ] Review Phase 7 findings in INVESTIGATION_REPORT.md
- [ ] Verify padding validation doesn't trigger on any test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)