### PR TITLE
feat: expose CHS channel metadata as PyArrow field metadata

### DIFF
--- a/src/libxrk/CLAUDE.md
+++ b/src/libxrk/CLAUDE.md
@@ -69,7 +69,7 @@ field = log.channels['Engine RPM'].schema.field('Engine RPM')
 units = field.metadata.get(b'units', b'').decode()  # e.g., "rpm"
 ```
 
-Keys: `b"units"`, `b"dec_pts"`, `b"interpolate"`
+Keys: `b"units"`, `b"dec_pts"`, `b"interpolate"`, `b"source_type"`, `b"source_channel_id"`, `b"device_tag"`, `b"cal_value_1"`, `b"cal_value_2"`, `b"display_range_min"`, `b"display_range_max"`
 
 ## LogFile Methods
 

--- a/src/libxrk/aim_xrk.pyx
+++ b/src/libxrk/aim_xrk.pyx
@@ -56,6 +56,13 @@ class Channel:
     dec_pts: int = 0
     interpolate: bool = False
     unknown: bytes = b""
+    source_type: int = 0
+    source_channel_id: int = 0
+    device_tag: str = ""
+    cal_value_1: float = 0.0
+    cal_value_2: float = 1.0
+    display_range_min: float = 0.0
+    display_range_max: float = 0.0
     group: Optional[GroupRef] = None
     timecodes: object = field(default=None, repr=False)
     sampledata: object = field(default=None, repr=False)
@@ -490,6 +497,14 @@ def _decode_sequence(s, progress=None):
                                     (_ch_name,
                                      ', '.join('[%d]=0x%02x' % (i, b)
                                                for i, b in _nonzero)))
+
+                            data.source_type = dcopy[16]
+                            data.source_channel_id = struct.unpack_from('<H', dcopy, 6)[0]
+                            _dtag = dcopy[76:80]
+                            data.device_tag = _dtag.rstrip(b'\x00').decode('ascii', errors='replace') if any(_dtag) else ''
+                            (data.cal_value_1, data.cal_value_2,
+                             data.display_range_min, data.display_range_max
+                            ) = struct.unpack_from('<4f', dcopy, 96)
 
                             dcopy[0:2] = [0] * 2 # reset index
                             dcopy[24:32] = [0] * 8 # short name
@@ -1090,7 +1105,14 @@ def _channel_to_table(ch):
     metadata = {
         b'units': (ch.units if ch.size != 1 else '').encode('utf-8'),
         b'dec_pts': str(ch.dec_pts).encode('utf-8'),
-        b'interpolate': str(ch.interpolate).encode('utf-8')
+        b'interpolate': str(ch.interpolate).encode('utf-8'),
+        b'source_type': str(ch.source_type).encode('utf-8'),
+        b'source_channel_id': str(ch.source_channel_id).encode('utf-8'),
+        b'device_tag': ch.device_tag.encode('utf-8'),
+        b'cal_value_1': str(ch.cal_value_1).encode('utf-8'),
+        b'cal_value_2': str(ch.cal_value_2).encode('utf-8'),
+        b'display_range_min': str(ch.display_range_min).encode('utf-8'),
+        b'display_range_max': str(ch.display_range_max).encode('utf-8'),
     }
     
     # Determine the appropriate type for values based on the data


### PR DESCRIPTION
## Summary

- Parse newly documented CHS fields (source_type, source_channel_id, device_tag, cal_value_1/2, display_range_min/max) and expose them as per-channel PyArrow field metadata
- Also includes CHS layout documentation (112-byte comment block) and padding validation from the investigation branch

## New metadata keys

| Key | Type | Description |
|-----|------|-------------|
| `b"source_type"` | int | Channel source: 1=internal, 2=RPM, 4=computed, 5=GPS, 9=CAN, etc. |
| `b"source_channel_id"` | int | ID within the source device |
| `b"device_tag"` | str | `"@AIM"` for firmware channels, empty for external |
| `b"cal_value_1"` | float | Calibration parameter 1 (raw ADC / zero-offset) |
| `b"cal_value_2"` | float | Calibration parameter 2 (raw ADC / scale) |
| `b"display_range_min"` | float | Display range minimum from RaceStudio config |
| `b"display_range_max"` | float | Display range maximum from RaceStudio config |

## Test plan

- [x] All 153 existing tests pass
- [x] Manually verified metadata values on SFJ test data (internal, GPS, CAN, sensor channels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)