### PR TITLE
chore: release v0.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libxrk"
-version = "0.8.0"
+version = "0.9.0"
 description = "Library for reading AIM XRK files from AIM automotive data loggers"
 authors = [
     {name = "Christopher Dewan",email = "chris.dewan@m3rlin.net"}


### PR DESCRIPTION
## Summary

Bump version to 0.9.0 for release.

### Highlights

- **Critical fix: 500 Hz channel data recovery** — The parser was reading only a single byte from CHS records for the sample period, causing a key collision between 500 Hz and 20 Hz channels. This silently dropped ~95% of high-frequency samples (e.g. shock pots: 46,990 extracted vs ~1,080,650 actual). Now reads the full uint32 sample period.

### Features
- GPS accuracy channels (satellites, position/velocity accuracy)
- GPS derived channels (inline/lateral acceleration, yaw rate)
- GPS Fix and pDOP channels from NAV-SOL payload
- GPS receiver type from GPSR message in metadata
- ENF expansion device metadata
- RACM, VET, iSLV, and CAL metadata
- CHS channel metadata (source_type, device_tag, calibration, display range)
- Validation warnings for unexpected message field values
- Pyodide 0.29.x support alongside 0.27.x
- Missing decoder types (8, 22, 26, 27, 31-39)

### Fixes
- Correct ch_size offset in CHS parsing (56 → 72)
- Read full uint32 sample period from CHS offset 64
- Resolve mypy type errors in investigation scripts

## Test plan
- [x] `poetry run poe check` passes (lint, typecheck, 153 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)