### PR TITLE
chore: bump version to 0.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libxrk"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 license = "MIT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libxrk"
-version = "0.10.0"
+version = "0.10.1"
 description = "Library for reading AIM XRK files from AIM automotive data loggers"
 authors = [
     {name = "Christopher Dewan",email = "chris.dewan@m3rlin.net"}


### PR DESCRIPTION
## Summary
- Bump version to 0.10.1 for patch release
- Includes fixes since v0.10.0:
  - fix: handle VET/RACM "..." placeholders, CHS byte[82], and new tokens from issue #49
  - fix: Rust type parity, interpolation promotion, and GPS lap correction
  - test: add Cython backend + cross-backend tests for issue #49

## Test plan
- [x] `poetry run poe check` passes (black, mypy, all tests)
- CI will run on PR

Closes #49