### PR TITLE
style: add Rust clippy + rustfmt to justfile check pipeline

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,12 +1,18 @@
 # libxrk task runner
 
-# Format code with Black
+# Format code (Python + Rust)
 format:
     uv run black .
+    cargo fmt
 
-# Check formatting with Black
+# Check formatting (Python + Rust)
 lint:
     uv run black --check .
+    cargo fmt --check
+
+# Rust clippy lints
+clippy:
+    cargo clippy --workspace --all-targets -- -W clippy::all
 
 # Type check with mypy
 typecheck:
@@ -20,15 +26,15 @@ test:
 spec-test:
     uv run pytest spec/tests/ -v -n auto
 
-# Run all checks (lint, typecheck, test, spec-test)
-check: lint typecheck test spec-test
+# Run all checks (lint, clippy, typecheck, test, spec-test)
+check: lint clippy typecheck test spec-test
 
 # Generate spec test vectors
 spec-vectors:
     uv run python spec/test_vectors/generate_vectors.py
 
 # Run benchmark
-benchmark:
+benchmark: rust-build
     uv run python scripts/benchmark.py
 
 # Interactive REPL with a loaded XRK file

--- a/rust/src/arrow_bridge.rs
+++ b/rust/src/arrow_bridge.rs
@@ -5,7 +5,10 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use arrow::array::{Array, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, RecordBatch, UInt8Array, UInt16Array, UInt32Array};
+use arrow::array::{
+    Array, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, RecordBatch,
+    UInt16Array, UInt32Array, UInt8Array,
+};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::pyarrow::ToPyArrow;
 use pyo3::prelude::*;
@@ -34,25 +37,37 @@ pub fn build_channel_table(
     let mut metadata = HashMap::new();
     metadata.insert("units".to_string(), units);
     metadata.insert("dec_pts".to_string(), chs.dec_pts().to_string());
-    metadata.insert("interpolate".to_string(), if chs.interpolate() { "True" } else { "False" }.to_string());
+    metadata.insert(
+        "interpolate".to_string(),
+        if chs.interpolate() { "True" } else { "False" }.to_string(),
+    );
     metadata.insert("function".to_string(), chs.function().to_string());
     metadata.insert("source_type".to_string(), chs.source_type.to_string());
-    metadata.insert("source_channel_id".to_string(), chs.source_channel_id.to_string());
+    metadata.insert(
+        "source_channel_id".to_string(),
+        chs.source_channel_id.to_string(),
+    );
     metadata.insert("device_tag".to_string(), chs.device_tag());
     metadata.insert("cal_value_1".to_string(), format_float(chs.cal_value_1));
     metadata.insert("cal_value_2".to_string(), format_float(chs.cal_value_2));
-    metadata.insert("display_range_min".to_string(), format_float(chs.display_range_min));
-    metadata.insert("display_range_max".to_string(), format_float(chs.display_range_max));
+    metadata.insert(
+        "display_range_min".to_string(),
+        format_float(chs.display_range_min),
+    );
+    metadata.insert(
+        "display_range_max".to_string(),
+        format_float(chs.display_range_max),
+    );
 
     // Build typed Arrow array matching the native decoder type (parity with Cython)
     let timecodes = Int64Array::from(ch_data.timecodes);
 
     let (values_col, data_type): (Arc<dyn Array>, DataType) = match ch_data.values {
-        ChannelValues::UInt8(v)   => (Arc::new(UInt8Array::from(v)),   DataType::UInt8),
-        ChannelValues::UInt16(v)  => (Arc::new(UInt16Array::from(v)),  DataType::UInt16),
-        ChannelValues::Int16(v)   => (Arc::new(Int16Array::from(v)),   DataType::Int16),
-        ChannelValues::Int32(v)   => (Arc::new(Int32Array::from(v)),   DataType::Int32),
-        ChannelValues::UInt32(v)  => (Arc::new(UInt32Array::from(v)),  DataType::UInt32),
+        ChannelValues::UInt8(v) => (Arc::new(UInt8Array::from(v)), DataType::UInt8),
+        ChannelValues::UInt16(v) => (Arc::new(UInt16Array::from(v)), DataType::UInt16),
+        ChannelValues::Int16(v) => (Arc::new(Int16Array::from(v)), DataType::Int16),
+        ChannelValues::Int32(v) => (Arc::new(Int32Array::from(v)), DataType::Int32),
+        ChannelValues::UInt32(v) => (Arc::new(UInt32Array::from(v)), DataType::UInt32),
         ChannelValues::Float32(v) => (Arc::new(Float32Array::from(v)), DataType::Float32),
         ChannelValues::Float64(v) => (Arc::new(Float64Array::from(v)), DataType::Float64),
     };
@@ -62,10 +77,8 @@ pub fn build_channel_table(
         Field::new(name, data_type, false).with_metadata(metadata),
     ]);
 
-    let batch = RecordBatch::try_new(
-        Arc::new(schema),
-        vec![Arc::new(timecodes), values_col],
-    ).map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(timecodes), values_col])
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
     // Convert to PyArrow via C Data Interface (zero-copy)
     batch
@@ -77,10 +90,7 @@ pub fn build_channel_table(
 /// Build a PyArrow table for laps.
 ///
 /// Returns a RecordBatch with columns: num (Int32), start_time (Int64), end_time (Int64).
-pub fn build_laps_table(
-    py: Python<'_>,
-    laps: &[ProcessedLap],
-) -> PyResult<Py<PyAny>> {
+pub fn build_laps_table(py: Python<'_>, laps: &[ProcessedLap]) -> PyResult<Py<PyAny>> {
     let nums: Vec<i32> = laps.iter().map(|l| l.num).collect();
     let starts: Vec<i64> = laps.iter().map(|l| l.start_time).collect();
     let ends: Vec<i64> = laps.iter().map(|l| l.end_time).collect();
@@ -98,7 +108,8 @@ pub fn build_laps_table(
             Arc::new(Int64Array::from(starts)),
             Arc::new(Int64Array::from(ends)),
         ],
-    ).map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+    )
+    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
     batch
         .to_pyarrow(py)
@@ -215,7 +226,8 @@ pub fn build_gps_channel_tables(
         inline_acc,
         lateral_acc,
         yaw_rate,
-    ].into_iter();
+    ]
+    .into_iter();
 
     for def in GPS_CHANNEL_DEFS {
         // Timecodes are shared across all 12 GPS channels, so clone is unavoidable
@@ -291,8 +303,11 @@ pub fn arrow_metadata_roundtrip_test(py: Python<'_>) -> PyResult<Py<PyAny>> {
     let timecodes = Int64Array::from(vec![0i64, 100, 200, 300]);
     let values = Float32Array::from(vec![800.0f32, 3200.0, 5600.0, 4100.0]);
 
-    let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(timecodes), Arc::new(values)])
-        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+    let batch = RecordBatch::try_new(
+        Arc::new(schema),
+        vec![Arc::new(timecodes), Arc::new(values)],
+    )
+    .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
     let bound = batch
         .to_pyarrow(py)

--- a/rust/src/decoders.rs
+++ b/rust/src/decoders.rs
@@ -61,42 +61,56 @@ pub fn decode_sample(decoder_type: u8, data: &[u8]) -> Option<SampleValue> {
     match decoder_type {
         // int32 types
         0 | 3 | 8 | 12 | 22 | 24 | 26 | 27 | 31 | 32 | 33 | 37 | 38 | 39 => {
-            if data.len() < 4 { return None; }
+            if data.len() < 4 {
+                return None;
+            }
             let v = i32::from_le_bytes([data[0], data[1], data[2], data[3]]);
             Some(SampleValue::Int32(v))
         }
         // uint16 with interpolation (type 1)
         1 => {
-            if data.len() < 2 { return None; }
+            if data.len() < 2 {
+                return None;
+            }
             let v = u16::from_le_bytes([data[0], data[1]]);
             Some(SampleValue::UInt16(v))
         }
         // int16 types (type 4, 11)
         4 | 11 => {
-            if data.len() < 2 { return None; }
+            if data.len() < 2 {
+                return None;
+            }
             let v = i16::from_le_bytes([data[0], data[1]]);
             Some(SampleValue::Int16(v))
         }
         // float32 (type 6)
         6 => {
-            if data.len() < 4 { return None; }
+            if data.len() < 4 {
+                return None;
+            }
             let v = f32::from_le_bytes([data[0], data[1], data[2], data[3]]);
             Some(SampleValue::Float32(v))
         }
         // uint8 (type 13)
         13 => {
-            if data.len() < 1 { return None; }
+            if data.is_empty() {
+                return None;
+            }
             Some(SampleValue::UInt8(data[0]))
         }
         // uint16 gear lookup (type 15)
         15 => {
-            if data.len() < 2 { return None; }
+            if data.len() < 2 {
+                return None;
+            }
             let v = u16::from_le_bytes([data[0], data[1]]);
             Some(SampleValue::UInt16(gear_lookup(v)))
         }
         // float16 encoded as uint16 (type 20)
         20 => {
-            if data.len() < 2 { return None; }
+            if data.len() < 2 {
+                return None;
+            }
             let bits = u16::from_le_bytes([data[0], data[1]]);
             let f = half_to_f32(bits);
             Some(SampleValue::Float32(f))
@@ -111,8 +125,9 @@ pub fn decode_manual_gear(data: &[u8]) -> Option<SampleValue> {
     if data.len() < 8 {
         return None;
     }
-    let v = u64::from_le_bytes([data[0], data[1], data[2], data[3],
-                                data[4], data[5], data[6], data[7]]);
+    let v = u64::from_le_bytes([
+        data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
+    ]);
     let gear = if v & 0x80000 != 0 {
         0u32
     } else {

--- a/rust/src/gps_processing.rs
+++ b/rust/src/gps_processing.rs
@@ -37,18 +37,90 @@ pub struct GpsChannelDef {
 
 /// All 12 GPS channel definitions in order.
 pub const GPS_CHANNEL_DEFS: &[GpsChannelDef] = &[
-    GpsChannelDef { name: "GPS Speed", units: "m/s", dec_pts: 1, interpolate: true, is_f64: true },
-    GpsChannelDef { name: "GPS Latitude", units: "deg", dec_pts: 4, interpolate: true, is_f64: true },
-    GpsChannelDef { name: "GPS Longitude", units: "deg", dec_pts: 4, interpolate: true, is_f64: true },
-    GpsChannelDef { name: "GPS Altitude", units: "m", dec_pts: 1, interpolate: true, is_f64: true },
-    GpsChannelDef { name: "GPS_Satellites", units: "", dec_pts: 0, interpolate: false, is_f64: false },
-    GpsChannelDef { name: "GPS_Fix", units: "", dec_pts: 0, interpolate: false, is_f64: false },
-    GpsChannelDef { name: "GPS_pDOP", units: "", dec_pts: 2, interpolate: false, is_f64: false },
-    GpsChannelDef { name: "GPS_Position_Accuracy", units: "m", dec_pts: 2, interpolate: true, is_f64: false },
-    GpsChannelDef { name: "GPS_Velocity_Accuracy", units: "m/s", dec_pts: 2, interpolate: true, is_f64: false },
-    GpsChannelDef { name: "GPS_InlineAcc", units: "g", dec_pts: 2, interpolate: true, is_f64: false },
-    GpsChannelDef { name: "GPS_LateralAcc", units: "g", dec_pts: 2, interpolate: true, is_f64: false },
-    GpsChannelDef { name: "GPS_Yaw_Rate", units: "deg/s", dec_pts: 1, interpolate: true, is_f64: false },
+    GpsChannelDef {
+        name: "GPS Speed",
+        units: "m/s",
+        dec_pts: 1,
+        interpolate: true,
+        is_f64: true,
+    },
+    GpsChannelDef {
+        name: "GPS Latitude",
+        units: "deg",
+        dec_pts: 4,
+        interpolate: true,
+        is_f64: true,
+    },
+    GpsChannelDef {
+        name: "GPS Longitude",
+        units: "deg",
+        dec_pts: 4,
+        interpolate: true,
+        is_f64: true,
+    },
+    GpsChannelDef {
+        name: "GPS Altitude",
+        units: "m",
+        dec_pts: 1,
+        interpolate: true,
+        is_f64: true,
+    },
+    GpsChannelDef {
+        name: "GPS_Satellites",
+        units: "",
+        dec_pts: 0,
+        interpolate: false,
+        is_f64: false,
+    },
+    GpsChannelDef {
+        name: "GPS_Fix",
+        units: "",
+        dec_pts: 0,
+        interpolate: false,
+        is_f64: false,
+    },
+    GpsChannelDef {
+        name: "GPS_pDOP",
+        units: "",
+        dec_pts: 2,
+        interpolate: false,
+        is_f64: false,
+    },
+    GpsChannelDef {
+        name: "GPS_Position_Accuracy",
+        units: "m",
+        dec_pts: 2,
+        interpolate: true,
+        is_f64: false,
+    },
+    GpsChannelDef {
+        name: "GPS_Velocity_Accuracy",
+        units: "m/s",
+        dec_pts: 2,
+        interpolate: true,
+        is_f64: false,
+    },
+    GpsChannelDef {
+        name: "GPS_InlineAcc",
+        units: "g",
+        dec_pts: 2,
+        interpolate: true,
+        is_f64: false,
+    },
+    GpsChannelDef {
+        name: "GPS_LateralAcc",
+        units: "g",
+        dec_pts: 2,
+        interpolate: true,
+        is_f64: false,
+    },
+    GpsChannelDef {
+        name: "GPS_Yaw_Rate",
+        units: "deg/s",
+        dec_pts: 1,
+        interpolate: true,
+        is_f64: false,
+    },
 ];
 
 /// Decode GPS NAV-SOL messages into 12 GPS channels.
@@ -60,7 +132,7 @@ pub fn decode_gps(gps_data: &[u8], time_offset: i64) -> Option<GpsDecodeResult> 
     if gps_data.is_empty() {
         return None;
     }
-    if gps_data.len() % 56 != 0 {
+    if !gps_data.len().is_multiple_of(56) {
         return None;
     }
 
@@ -279,13 +351,13 @@ fn fix_timecodes(timecodes: &mut [i32]) {
     // Step 2: fix wrap-arounds (track previous unmodified value)
     let mut prev_masked = timecodes[0];
     let mut cum: i32 = 0;
-    for i in 1..timecodes.len() {
-        let current_masked = timecodes[i];
+    for tc in timecodes.iter_mut().skip(1) {
+        let current_masked = *tc;
         if current_masked < prev_masked {
             cum += 65536;
         }
         prev_masked = current_masked;
-        timecodes[i] += cum;
+        *tc += cum;
     }
 }
 

--- a/rust/src/gps_timing.rs
+++ b/rust/src/gps_timing.rs
@@ -67,13 +67,17 @@ pub fn detect_gps_timing_offset_from_gnfi(
 
     // For direct gaps (60000-70000ms), use gap_size - expected_dt as correction
     // For hidden bugs (detected via GNFI), use OVERFLOW_BUG_MS as correction
-    let correction = if (OVERFLOW_BUG_MS - tolerance..=OVERFLOW_BUG_MS + tolerance).contains(&gap_size) {
-        gap_size - expected_dt_ms as i64
-    } else {
-        OVERFLOW_BUG_MS
-    };
+    let correction =
+        if (OVERFLOW_BUG_MS - tolerance..=OVERFLOW_BUG_MS + tolerance).contains(&gap_size) {
+            gap_size - expected_dt_ms as i64
+        } else {
+            OVERFLOW_BUG_MS
+        };
 
-    vec![GapCorrection { gap_time, correction }]
+    vec![GapCorrection {
+        gap_time,
+        correction,
+    }]
 }
 
 /// Detect and compute GPS timing gap corrections.
@@ -108,11 +112,8 @@ pub fn detect_gap_corrections(
 
     // Method 1: GNFI-based detection (most reliable)
     if !gnfi_timecodes.is_empty() {
-        let corrections = detect_gps_timing_offset_from_gnfi(
-            gps_timecodes,
-            gnfi_timecodes,
-            expected_dt_ms,
-        );
+        let corrections =
+            detect_gps_timing_offset_from_gnfi(gps_timecodes, gnfi_timecodes, expected_dt_ms);
         if !corrections.is_empty() {
             return corrections;
         }
@@ -126,7 +127,10 @@ pub fn detect_gap_corrections(
 
         if (OVERFLOW_GAP_MIN..=OVERFLOW_GAP_MAX).contains(&gap_size) {
             let correction = gap_size - expected_dt_ms as i64;
-            corrections.push(GapCorrection { gap_time, correction });
+            corrections.push(GapCorrection {
+                gap_time,
+                correction,
+            });
         }
     }
     if !corrections.is_empty() {
@@ -184,8 +188,8 @@ mod tests {
     fn test_direct_detection_65533ms_gap() {
         let mut gps_tc: Vec<i64> = (0..50).map(|i| i * 40).collect();
         // Insert a 65533ms gap
-        for i in 25..50 {
-            gps_tc[i] += 65533;
+        for tc in &mut gps_tc[25..50] {
+            *tc += 65533;
         }
         let corrections = detect_gap_corrections(&gps_tc, &[], None, 40.0);
         assert_eq!(corrections.len(), 1);
@@ -203,8 +207,8 @@ mod tests {
 
         // Add a 5-second gap at sample 50 (too small to be detected directly)
         // but also shift all subsequent samples by 65533ms total
-        for i in 50..100 {
-            gps_tc[i] += 65533;
+        for tc in &mut gps_tc[50..100] {
+            *tc += 65533;
         }
 
         let corrections = detect_gps_timing_offset_from_gnfi(&gps_tc, &gnfi_tc, 40.0);

--- a/rust/src/gps_utils.rs
+++ b/rust/src/gps_utils.rs
@@ -65,10 +65,7 @@ pub fn lla2ecef(lat_deg: f64, lon_deg: f64, alt: f64) -> (f64, f64, f64) {
 ///
 /// Input velocities in any consistent unit (e.g., cm/s).
 /// Returns (V_east, V_north) in the same unit.
-pub fn ecef_velocity_to_enu(
-    dx: f64, dy: f64, dz: f64,
-    lat_rad: f64, lon_rad: f64,
-) -> (f64, f64) {
+pub fn ecef_velocity_to_enu(dx: f64, dy: f64, dz: f64, lat_rad: f64, lon_rad: f64) -> (f64, f64) {
     let sin_lat = lat_rad.sin();
     let cos_lat = lat_rad.cos();
     let sin_lon = lon_rad.sin();
@@ -94,11 +91,7 @@ fn dot3(a: &[f64; 3], b: &[f64; 3]) -> f64 {
 ///   marker: (lat, lon) of start/finish in degrees
 ///
 /// Returns: List of lap crossing times (ms, as f64 for sub-sample precision)
-pub fn find_laps(
-    xyz: &[[f64; 3]],
-    timecodes: &[i64],
-    marker: (f64, f64),
-) -> Vec<f64> {
+pub fn find_laps(xyz: &[[f64; 3]], timecodes: &[i64], marker: (f64, f64)) -> Vec<f64> {
     let n = xyz.len();
     if n < 2 {
         return Vec::new();
@@ -117,13 +110,7 @@ pub fn find_laps(
 
     // O[i] = XYZ[i] - SO, D[i] = XYZ[i+1] - XYZ[i]
     let o: Vec<[f64; 3]> = (0..n_seg)
-        .map(|i| {
-            [
-                xyz[i][0] - so[0],
-                xyz[i][1] - so[1],
-                xyz[i][2] - so[2],
-            ]
-        })
+        .map(|i| [xyz[i][0] - so[0], xyz[i][1] - so[1], xyz[i][2] - so[2]])
         .collect();
 
     let d: Vec<[f64; 3]> = (0..n_seg)
@@ -208,8 +195,8 @@ pub fn find_laps(
 
     // Build lap markers
     let mut lap_markers: Vec<f64> = vec![0.0];
-    for i in 0..pick.len() {
-        if !pick[i] {
+    for (i, &picked) in pick.iter().enumerate() {
+        if !picked {
             continue;
         }
         let mut idx = i + 1; // np.nonzero(pick)[0] + 1

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -17,7 +17,10 @@ pub mod tables;
 fn _aim_xrk_rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(aim_xrk, m)?)?;
     m.add_function(wrap_pyfunction!(aim_track_dbg, m)?)?;
-    m.add_function(wrap_pyfunction!(arrow_bridge::arrow_metadata_roundtrip_test, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        arrow_bridge::arrow_metadata_roundtrip_test,
+        m
+    )?)?;
     Ok(())
 }
 
@@ -72,7 +75,11 @@ fn decompress_if_zlib(data: Vec<u8>) -> Vec<u8> {
             Ok(_) => decompressed,
             Err(_) => {
                 // Truncated stream — return whatever we got
-                if decompressed.is_empty() { data } else { decompressed }
+                if decompressed.is_empty() {
+                    data
+                } else {
+                    decompressed
+                }
             }
         }
     } else {
@@ -83,11 +90,7 @@ fn decompress_if_zlib(data: Vec<u8>) -> Vec<u8> {
 /// Parse an AIM XRK/XRZ file and return a LogFile.
 #[pyfunction]
 #[pyo3(signature = (fname, progress=None))]
-fn aim_xrk(
-    py: Python<'_>,
-    fname: Py<PyAny>,
-    progress: Option<Py<PyAny>>,
-) -> PyResult<Py<PyAny>> {
+fn aim_xrk(py: Python<'_>, fname: Py<PyAny>, progress: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
     let fname_bound = fname.bind(py);
 
     // Read raw bytes
@@ -106,19 +109,19 @@ fn aim_xrk(
         closure
     });
 
-    let mut result = parser::parse_xrk(
-        &data,
-        progress_cb.as_ref().map(|cb| cb.as_ref()),
-    );
+    let mut result = parser::parse_xrk(&data, progress_cb.as_ref().map(|cb| cb.as_ref()));
 
     // Compute non-GPS max end time before moving channel_data out
-    let non_gps_max_end_time: Option<i64> = result.channel_data.values()
+    let non_gps_max_end_time: Option<i64> = result
+        .channel_data
+        .values()
         .filter_map(|ch| ch.timecodes.last().copied())
         .max();
 
     // Move channel_data out of result (avoids cloning every channel)
     let channel_data = std::mem::take(&mut result.channel_data);
-    let channel_tables = arrow_bridge::build_all_channel_tables(py, channel_data, &result.channels)?;
+    let channel_tables =
+        arrow_bridge::build_all_channel_tables(py, channel_data, &result.channels)?;
 
     // Build channels dict
     let channels_dict = PyDict::new(py);
@@ -137,20 +140,24 @@ fn aim_xrk(
     // Apply GPS timing fix in Rust (before building Arrow tables)
     if let Some(ref mut gps) = gps_result {
         // Extract GNFI timecodes from raw data
-        let gnfi_timecodes: Vec<i64> = if !result.gnfi_data.is_empty() && result.gnfi_data.len() % 32 == 0 {
-            let n_records = result.gnfi_data.len() / 32;
-            (0..n_records)
-                .map(|i| {
-                    let offset = i * 32;
-                    i32::from_le_bytes([
-                        result.gnfi_data[offset], result.gnfi_data[offset + 1],
-                        result.gnfi_data[offset + 2], result.gnfi_data[offset + 3],
-                    ]) as i64 - result.time_offset
-                })
-                .collect()
-        } else {
-            Vec::new()
-        };
+        let gnfi_timecodes: Vec<i64> =
+            if !result.gnfi_data.is_empty() && result.gnfi_data.len().is_multiple_of(32) {
+                let n_records = result.gnfi_data.len() / 32;
+                (0..n_records)
+                    .map(|i| {
+                        let offset = i * 32;
+                        i32::from_le_bytes([
+                            result.gnfi_data[offset],
+                            result.gnfi_data[offset + 1],
+                            result.gnfi_data[offset + 2],
+                            result.gnfi_data[offset + 3],
+                        ]) as i64
+                            - result.time_offset
+                    })
+                    .collect()
+            } else {
+                Vec::new()
+            };
 
         // Detect and apply corrections to GPS timecodes
         let corrections = gps_timing::detect_gap_corrections(
@@ -177,7 +184,9 @@ fn aim_xrk(
     } else if let Ok(s) = fname_bound.extract::<String>() {
         s
     } else if fname_bound.hasattr("__fspath__")? {
-        fname_bound.call_method0("__fspath__")?.extract::<String>()?
+        fname_bound
+            .call_method0("__fspath__")?
+            .extract::<String>()?
     } else {
         "<unknown>".to_string()
     };
@@ -188,7 +197,10 @@ fn aim_xrk(
     // Validate LAP-message-based laps: some AIM firmware writes relative end_times
     // (≈ duration) instead of absolute session times, producing negative start_times.
     // Fall back to GPS-based detection when this happens.
-    if processed_laps.iter().any(|l| l.start_time < 0 || l.end_time <= l.start_time) {
+    if processed_laps
+        .iter()
+        .any(|l| l.start_time < 0 || l.end_time <= l.start_time)
+    {
         processed_laps.clear();
     }
 
@@ -197,7 +209,10 @@ fn aim_xrk(
         if let Some(trk_marker) = get_trk_marker(&result) {
             if let Some(ref gps) = gps_result {
                 // Convert lat/lon to ECEF for lap detection
-                let xyz: Vec<[f64; 3]> = gps.latitude.iter().zip(gps.longitude.iter())
+                let xyz: Vec<[f64; 3]> = gps
+                    .latitude
+                    .iter()
+                    .zip(gps.longitude.iter())
                     .map(|(&lat, &lon)| {
                         let (x, y, z) = gps_utils::lla2ecef(lat, lon, 0.0);
                         [x, y, z]
@@ -237,12 +252,8 @@ fn aim_xrk(
 
     let base_module = py.import("libxrk.base")?;
     let logfile_class = base_module.getattr("LogFile")?;
-    let logfile = logfile_class.call1((
-        channels_dict,
-        laps_table,
-        metadata_dict.bind(py),
-        file_name,
-    ))?;
+    let logfile =
+        logfile_class.call1((channels_dict, laps_table, metadata_dict.bind(py), file_name))?;
 
     Ok(logfile.unbind())
 }
@@ -292,7 +303,9 @@ fn payload_to_python(py: Python<'_>, payload: &messages::Payload) -> PyResult<Py
             payloads::vet::VetPayload::Mode(s) => Ok(s.into_pyobject(py)?.into_any().unbind()),
             payloads::vet::VetPayload::Value(val) => Ok(val.into_pyobject(py)?.into_any().unbind()),
         },
-        messages::Payload::Unknown(data) => Ok(pyo3::types::PyBytes::new(py, data).into_any().unbind()),
+        messages::Payload::Unknown(data) => {
+            Ok(pyo3::types::PyBytes::new(py, data).into_any().unbind())
+        }
         _ => Ok(py.None()),
     }
 }

--- a/rust/src/messages.rs
+++ b/rust/src/messages.rs
@@ -174,46 +174,122 @@ pub enum Payload {
 pub mod tokens {
     use super::tokdec;
 
-    pub fn gps() -> u32 { tokdec("GPS") }
-    pub fn gps1() -> u32 { tokdec("GPS1") }
-    pub fn gnfi() -> u32 { tokdec("GNFI") }
-    pub fn chs() -> u32 { tokdec("CHS") }
-    pub fn grp() -> u32 { tokdec("GRP") }
-    pub fn lap() -> u32 { tokdec("LAP") }
-    pub fn idn() -> u32 { tokdec("idn") }
-    pub fn trk() -> u32 { tokdec("TRK") }
-    pub fn gpsr() -> u32 { tokdec("GPSR") }
-    pub fn cal() -> u32 { tokdec("CAL") }
-    pub fn odo() -> u32 { tokdec("ODO") }
-    pub fn cnf() -> u32 { tokdec("CNF") }
-    pub fn enf() -> u32 { tokdec("ENF") }
-    pub fn islv() -> u32 { tokdec("iSLV") }
-    pub fn src() -> u32 { tokdec("SRC") }
-    pub fn racm() -> u32 { tokdec("RACM") }
-    pub fn vet() -> u32 { tokdec("VET") }
-    pub fn cde() -> u32 { tokdec("CDE") }
+    pub fn gps() -> u32 {
+        tokdec("GPS")
+    }
+    pub fn gps1() -> u32 {
+        tokdec("GPS1")
+    }
+    pub fn gnfi() -> u32 {
+        tokdec("GNFI")
+    }
+    pub fn chs() -> u32 {
+        tokdec("CHS")
+    }
+    pub fn grp() -> u32 {
+        tokdec("GRP")
+    }
+    pub fn lap() -> u32 {
+        tokdec("LAP")
+    }
+    pub fn idn() -> u32 {
+        tokdec("idn")
+    }
+    pub fn trk() -> u32 {
+        tokdec("TRK")
+    }
+    pub fn gpsr() -> u32 {
+        tokdec("GPSR")
+    }
+    pub fn cal() -> u32 {
+        tokdec("CAL")
+    }
+    pub fn odo() -> u32 {
+        tokdec("ODO")
+    }
+    pub fn cnf() -> u32 {
+        tokdec("CNF")
+    }
+    pub fn enf() -> u32 {
+        tokdec("ENF")
+    }
+    pub fn islv() -> u32 {
+        tokdec("iSLV")
+    }
+    pub fn src() -> u32 {
+        tokdec("SRC")
+    }
+    pub fn racm() -> u32 {
+        tokdec("RACM")
+    }
+    pub fn vet() -> u32 {
+        tokdec("VET")
+    }
+    pub fn cde() -> u32 {
+        tokdec("CDE")
+    }
 
     // String message tokens
-    pub fn rcr() -> u32 { tokdec("RCR") }
-    pub fn veh() -> u32 { tokdec("VEH") }
-    pub fn cmp() -> u32 { tokdec("CMP") }
-    pub fn vty() -> u32 { tokdec("VTY") }
-    pub fn ndv() -> u32 { tokdec("NDV") }
-    pub fn tmd() -> u32 { tokdec("TMD") }
-    pub fn tmt() -> u32 { tokdec("TMT") }
-    pub fn dbun() -> u32 { tokdec("DBUN") }
-    pub fn dbut() -> u32 { tokdec("DBUT") }
-    pub fn dver() -> u32 { tokdec("DVER") }
-    pub fn manl() -> u32 { tokdec("MANL") }
-    pub fn modl() -> u32 { tokdec("MODL") }
-    pub fn mani() -> u32 { tokdec("MANI") }
-    pub fn modi() -> u32 { tokdec("MODI") }
-    pub fn hwnf() -> u32 { tokdec("HWNF") }
-    pub fn pdlt() -> u32 { tokdec("PDLT") }
-    pub fn nte() -> u32 { tokdec("NTE") }
-    pub fn plm() -> u32 { tokdec("+LM") }
-    pub fn man() -> u32 { tokdec("MAN") }
-    pub fn mod_() -> u32 { tokdec("MOD") }
+    pub fn rcr() -> u32 {
+        tokdec("RCR")
+    }
+    pub fn veh() -> u32 {
+        tokdec("VEH")
+    }
+    pub fn cmp() -> u32 {
+        tokdec("CMP")
+    }
+    pub fn vty() -> u32 {
+        tokdec("VTY")
+    }
+    pub fn ndv() -> u32 {
+        tokdec("NDV")
+    }
+    pub fn tmd() -> u32 {
+        tokdec("TMD")
+    }
+    pub fn tmt() -> u32 {
+        tokdec("TMT")
+    }
+    pub fn dbun() -> u32 {
+        tokdec("DBUN")
+    }
+    pub fn dbut() -> u32 {
+        tokdec("DBUT")
+    }
+    pub fn dver() -> u32 {
+        tokdec("DVER")
+    }
+    pub fn manl() -> u32 {
+        tokdec("MANL")
+    }
+    pub fn modl() -> u32 {
+        tokdec("MODL")
+    }
+    pub fn mani() -> u32 {
+        tokdec("MANI")
+    }
+    pub fn modi() -> u32 {
+        tokdec("MODI")
+    }
+    pub fn hwnf() -> u32 {
+        tokdec("HWNF")
+    }
+    pub fn pdlt() -> u32 {
+        tokdec("PDLT")
+    }
+    pub fn nte() -> u32 {
+        tokdec("NTE")
+    }
+    pub fn plm() -> u32 {
+        tokdec("+LM")
+    }
+    pub fn man() -> u32 {
+        tokdec("MAN")
+    }
+    pub fn mod_() -> u32 {
+        tokdec("MOD")
+    }
 }
 
 /// Check if a token is a string message type.
@@ -361,7 +437,9 @@ mod tests {
 
     #[test]
     fn test_tokdec_tokenc_roundtrip() {
-        for s in ["GPS", "CHS", "GRP", "LAP", "idn", "GNFI", "CNF", "ENF", "TRK"] {
+        for s in [
+            "GPS", "CHS", "GRP", "LAP", "idn", "GNFI", "CNF", "ENF", "TRK",
+        ] {
             let encoded = tokdec(s);
             let decoded = tokenc(encoded);
             assert_eq!(s, decoded, "roundtrip failed for {s}");

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -133,7 +133,8 @@ pub fn extract_metadata(py: Python<'_>, result: &ParseResult) -> PyResult<Py<PyA
 
         // Enrich with hardware IDs from iSLV messages (positional match)
         if let Some(islv_msgs) = msgs.get(&tokens::islv()) {
-            let slave_idns: Vec<_> = islv_msgs.iter()
+            let slave_idns: Vec<_> = islv_msgs
+                .iter()
                 .filter_map(|m| {
                     let payload = messages::dispatch_payload(m);
                     if let Payload::EmbeddedIdn(idn) = payload {
@@ -162,10 +163,8 @@ pub fn extract_metadata(py: Python<'_>, result: &ParseResult) -> PyResult<Py<PyA
     if let Some(msg_list) = msgs.get(&tokens::racm()) {
         for msg in msg_list {
             let payload = messages::dispatch_payload(msg);
-            if let Payload::Racm(racm) = payload {
-                if let crate::payloads::racm::RacmPayload::Mode(mode) = racm {
-                    dict.set_item("Race Mode", &mode)?;
-                }
+            if let Payload::Racm(crate::payloads::racm::RacmPayload::Mode(mode)) = payload {
+                dict.set_item("Race Mode", &mode)?;
             }
         }
     }

--- a/rust/src/parser.rs
+++ b/rust/src/parser.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 
-use crate::messages::{self, HeaderMessage, Payload, tokens};
+use crate::messages::{self, tokens, HeaderMessage, Payload};
 use crate::payloads::chs::ChsPayload;
 use crate::payloads::grp::GrpPayload;
 use crate::payloads::lap::LapPayload;
@@ -324,18 +324,22 @@ impl ParserState {
         self.gc_data[3][idx].mms = chs.mms();
 
         // Store channel info
-        self.channels.entry(chs.index).or_insert_with(|| ChannelInfo {
-            chs: chs.clone(),
-            group_index: None,
-            group_offset: None,
-        });
+        self.channels
+            .entry(chs.index)
+            .or_insert_with(|| ChannelInfo {
+                chs: chs.clone(),
+                group_index: None,
+                group_offset: None,
+            });
     }
 
     fn register_grp(&mut self, grp: &GrpPayload) {
         let idx = grp.index as usize;
 
         // Compute group data size from member channels
-        let grp_size: usize = grp.channel_indices.iter()
+        let grp_size: usize = grp
+            .channel_indices
+            .iter()
             .map(|&ch| *self.channel_sizes.get(&ch).unwrap_or(&0) as usize)
             .sum();
 
@@ -356,7 +360,8 @@ impl ParserState {
             }
         }
 
-        self.groups.insert(grp.index, GroupInfo { grp: grp.clone() });
+        self.groups
+            .insert(grp.index, GroupInfo { grp: grp.clone() });
     }
 
     fn finalize(self) -> ParseResult {
@@ -376,10 +381,17 @@ impl ParserState {
             for acc in &self.gc_data[cat_idx] {
                 if !acc.data.is_empty() {
                     let stride = acc.add_helper - if cat_idx < 2 { 3 } else { 8 };
-                    if stride == 0 { continue; }
+                    if stride == 0 {
+                        continue;
+                    }
                     // First timecode
                     if acc.data.len() >= 4 {
-                        let tc = i32::from_le_bytes([acc.data[0], acc.data[1], acc.data[2], acc.data[3]]);
+                        let tc = i32::from_le_bytes([
+                            acc.data[0],
+                            acc.data[1],
+                            acc.data[2],
+                            acc.data[3],
+                        ]);
                         tc_min_candidates.push(tc as i64);
                     }
                     // Last timecode
@@ -388,8 +400,10 @@ impl ParserState {
                         let last_offset = (n_rows - 1) * stride;
                         if last_offset + 4 <= acc.data.len() {
                             let tc = i32::from_le_bytes([
-                                acc.data[last_offset], acc.data[last_offset + 1],
-                                acc.data[last_offset + 2], acc.data[last_offset + 3],
+                                acc.data[last_offset],
+                                acc.data[last_offset + 1],
+                                acc.data[last_offset + 2],
+                                acc.data[last_offset + 3],
                             ]);
                             tc_max_candidates.push(tc as i64);
                         }
@@ -409,13 +423,18 @@ impl ParserState {
         // GPS messages: 56-byte records, first 4 bytes = int32 timecode
         if self.gps_data.len() >= 56 {
             let tc = i32::from_le_bytes([
-                self.gps_data[0], self.gps_data[1], self.gps_data[2], self.gps_data[3],
+                self.gps_data[0],
+                self.gps_data[1],
+                self.gps_data[2],
+                self.gps_data[3],
             ]);
             tc_min_candidates.push(tc as i64);
             let last_offset = self.gps_data.len() - 56;
             let tc = i32::from_le_bytes([
-                self.gps_data[last_offset], self.gps_data[last_offset + 1],
-                self.gps_data[last_offset + 2], self.gps_data[last_offset + 3],
+                self.gps_data[last_offset],
+                self.gps_data[last_offset + 1],
+                self.gps_data[last_offset + 2],
+                self.gps_data[last_offset + 3],
             ]);
             tc_max_candidates.push(tc as i64);
         }
@@ -424,7 +443,8 @@ impl ParserState {
         let last_time = tc_max_candidates.into_iter().max().unwrap_or(0);
 
         // Now decode channels
-        let channel_data = decode_all_channels(&self.gc_data, &self.channels, &self.groups, time_offset);
+        let channel_data =
+            decode_all_channels(&self.gc_data, &self.channels, &self.groups, time_offset);
 
         // Extract and process lap info from LAP messages
         let laps = process_laps(&self.header_messages, time_offset);
@@ -470,7 +490,10 @@ fn prescan(data: &[u8], state: &mut ParserState) -> PrescanResult {
                         let index = u16::from_le_bytes([data[pos + 6], data[pos + 7]]) as usize;
                         if index < state.gc_data[0].len() {
                             let total_size = state.gc_data[0][index].add_helper;
-                            if total_size > 3 && pos + total_size <= len && data[pos + total_size - 1] == b')' {
+                            if total_size > 3
+                                && pos + total_size <= len
+                                && data[pos + total_size - 1] == b')'
+                            {
                                 hints.add_data_bytes(0, index, total_size - 3);
                                 pos += total_size;
                                 continue;
@@ -483,7 +506,10 @@ fn prescan(data: &[u8], state: &mut ParserState) -> PrescanResult {
                         let index = u16::from_le_bytes([data[pos + 6], data[pos + 7]]) as usize;
                         if index < state.gc_data[1].len() {
                             let total_size = state.gc_data[1][index].add_helper;
-                            if total_size > 3 && pos + total_size <= len && data[pos + total_size - 1] == b')' {
+                            if total_size > 3
+                                && pos + total_size <= len
+                                && data[pos + total_size - 1] == b')'
+                            {
                                 hints.add_data_bytes(1, index, total_size - 3);
                                 pos += total_size;
                                 continue;
@@ -516,7 +542,10 @@ fn prescan(data: &[u8], state: &mut ParserState) -> PrescanResult {
                         let index = (channel_field >> 3) as usize;
                         if index < state.gc_data[2].len() {
                             let total_size = state.gc_data[2][index].add_helper;
-                            if total_size > 8 && pos + total_size <= len && data[pos + total_size - 1] == b')' {
+                            if total_size > 8
+                                && pos + total_size <= len
+                                && data[pos + total_size - 1] == b')'
+                            {
                                 hints.add_data_bytes(2, index, total_size - 8);
                                 pos += total_size;
                                 continue;
@@ -556,12 +585,12 @@ fn prescan_header_message(msg: &HeaderMessage, state: &mut ParserState, hints: &
         // Recursively discover channels from CNF payload.
         let mut sub_state = ParserState::new();
         scan_stream(&msg.payload, &mut sub_state, None);
-        for (_, ch_info) in &sub_state.channels {
+        for ch_info in sub_state.channels.values() {
             if !state.channels.contains_key(&ch_info.chs.index) {
                 state.register_chs(&ch_info.chs);
             }
         }
-        for (_, grp_info) in &sub_state.groups {
+        for grp_info in sub_state.groups.values() {
             if !state.groups.contains_key(&grp_info.grp.index) {
                 state.register_grp(&grp_info.grp);
             }
@@ -635,13 +664,10 @@ fn scan_stream(data: &[u8], state: &mut ParserState, progress: Option<&dyn Fn(us
                 }
             }
 
-            match HeaderMessage::parse(data, pos) {
-                Ok((msg, consumed)) => {
-                    handle_header_message(&msg, state);
-                    pos += consumed;
-                    continue;
-                }
-                Err(_) => {}
+            if let Ok((msg, consumed)) = HeaderMessage::parse(data, pos) {
+                handle_header_message(&msg, state);
+                pos += consumed;
+                continue;
             }
         }
 
@@ -736,7 +762,11 @@ fn handle_header_message(msg: &HeaderMessage, state: &mut ParserState) {
                     version: msg.version,
                     payload: msg.payload[6..].to_vec(), // Skip the 6-byte header (idn + ver + len)
                 };
-                state.header_messages.entry(tokens::idn()).or_default().push(synthetic_msg);
+                state
+                    .header_messages
+                    .entry(tokens::idn())
+                    .or_default()
+                    .push(synthetic_msg);
             }
             // Also store under original token for iSLV extraction
             let _ = idn; // used above
@@ -745,29 +775,42 @@ fn handle_header_message(msg: &HeaderMessage, state: &mut ParserState) {
     }
 
     // Store message for metadata extraction
-    state.header_messages.entry(token).or_default().push(msg.clone());
+    state
+        .header_messages
+        .entry(token)
+        .or_default()
+        .push(msg.clone());
 }
 
 /// Try to parse a G (group) message at the given position.
 /// Returns bytes consumed on success.
 fn try_parse_g_message(data: &[u8], pos: usize, state: &mut ParserState) -> Option<usize> {
     // (G + timecode(4) + index(2) + data(N) + )
-    if pos + 9 > data.len() { return None; }
+    if pos + 9 > data.len() {
+        return None;
+    }
 
     let timecode = i32::from_le_bytes([data[pos + 2], data[pos + 3], data[pos + 4], data[pos + 5]]);
     let index = u16::from_le_bytes([data[pos + 6], data[pos + 7]]) as usize;
 
-    if index >= state.gc_data[0].len() { return None; }
+    if index >= state.gc_data[0].len() {
+        return None;
+    }
 
     let total_size = state.gc_data[0][index].add_helper;
-    if pos + total_size > data.len() { return None; }
-    if data[pos + total_size - 1] != b')' { return None; }
+    if pos + total_size > data.len() {
+        return None;
+    }
+    if data[pos + total_size - 1] != b')' {
+        return None;
+    }
 
     let acc = &mut state.gc_data[0][index];
     if timecode > acc.last_timecode {
         acc.last_timecode = timecode;
         // Append timecode + data (skip opcode 2 bytes, include tc+idx+data)
-        acc.data.extend_from_slice(&data[pos + 2..pos + total_size - 1]);
+        acc.data
+            .extend_from_slice(&data[pos + 2..pos + total_size - 1]);
     }
 
     Some(total_size)
@@ -775,21 +818,30 @@ fn try_parse_g_message(data: &[u8], pos: usize, state: &mut ParserState) -> Opti
 
 /// Try to parse an S (single sample) message.
 fn try_parse_s_message(data: &[u8], pos: usize, state: &mut ParserState) -> Option<usize> {
-    if pos + 9 > data.len() { return None; }
+    if pos + 9 > data.len() {
+        return None;
+    }
 
     let timecode = i32::from_le_bytes([data[pos + 2], data[pos + 3], data[pos + 4], data[pos + 5]]);
     let index = u16::from_le_bytes([data[pos + 6], data[pos + 7]]) as usize;
 
-    if index >= state.gc_data[1].len() { return None; }
+    if index >= state.gc_data[1].len() {
+        return None;
+    }
 
     let total_size = state.gc_data[1][index].add_helper;
-    if pos + total_size > data.len() { return None; }
-    if data[pos + total_size - 1] != b')' { return None; }
+    if pos + total_size > data.len() {
+        return None;
+    }
+    if data[pos + total_size - 1] != b')' {
+        return None;
+    }
 
     let acc = &mut state.gc_data[1][index];
     if timecode > acc.last_timecode {
         acc.last_timecode = timecode;
-        acc.data.extend_from_slice(&data[pos + 2..pos + total_size - 1]);
+        acc.data
+            .extend_from_slice(&data[pos + 2..pos + total_size - 1]);
     }
 
     Some(total_size)
@@ -797,21 +849,31 @@ fn try_parse_s_message(data: &[u8], pos: usize, state: &mut ParserState) -> Opti
 
 /// Try to parse an M (multi-sample) message.
 fn try_parse_m_message(data: &[u8], pos: usize, state: &mut ParserState) -> Option<usize> {
-    if pos + 11 > data.len() { return None; }
+    if pos + 11 > data.len() {
+        return None;
+    }
 
     let timecode = i32::from_le_bytes([data[pos + 2], data[pos + 3], data[pos + 4], data[pos + 5]]);
     let index = u16::from_le_bytes([data[pos + 6], data[pos + 7]]) as usize;
     let count = u16::from_le_bytes([data[pos + 8], data[pos + 9]]) as usize;
 
-    if index >= state.gc_data[3].len() { return None; }
+    if index >= state.gc_data[3].len() {
+        return None;
+    }
 
     let sample_size = state.gc_data[3][index].add_helper;
     let mms = state.gc_data[3][index].mms;
-    if mms == 0 { return None; }
+    if mms == 0 {
+        return None;
+    }
 
     let total_size = 10 + sample_size * count + 1; // header + data + ')'
-    if pos + total_size > data.len() { return None; }
-    if data[pos + total_size - 1] != b')' { return None; }
+    if pos + total_size > data.len() {
+        return None;
+    }
+    if data[pos + total_size - 1] != b')' {
+        return None;
+    }
 
     let acc = &mut state.gc_data[3][index];
 
@@ -841,24 +903,34 @@ fn try_parse_m_message(data: &[u8], pos: usize, state: &mut ParserState) -> Opti
 
 /// Try to parse a c (expansion channel) message.
 fn try_parse_c_message(data: &[u8], pos: usize, state: &mut ParserState) -> Option<usize> {
-    if pos + 12 > data.len() { return None; }
+    if pos + 12 > data.len() {
+        return None;
+    }
 
     // c message header: (c + unk1(1) + channel_field(2) + unk3(1) + unk4(1) + timecode(4)
     let channel_field = u16::from_le_bytes([data[pos + 3], data[pos + 4]]);
-    let timecode = i32::from_le_bytes([data[pos + 7], data[pos + 8], data[pos + 9], data[pos + 10]]);
+    let timecode =
+        i32::from_le_bytes([data[pos + 7], data[pos + 8], data[pos + 9], data[pos + 10]]);
     let index = (channel_field >> 3) as usize;
 
-    if index >= state.gc_data[2].len() { return None; }
+    if index >= state.gc_data[2].len() {
+        return None;
+    }
 
     let total_size = state.gc_data[2][index].add_helper;
-    if pos + total_size > data.len() { return None; }
-    if data[pos + total_size - 1] != b')' { return None; }
+    if pos + total_size > data.len() {
+        return None;
+    }
+    if data[pos + total_size - 1] != b')' {
+        return None;
+    }
 
     let acc = &mut state.gc_data[2][index];
     if timecode > acc.last_timecode {
         acc.last_timecode = timecode;
         // For c messages, we store timecode(4) + data (skip the c-specific header)
-        acc.data.extend_from_slice(&data[pos + 7..pos + total_size - 1]);
+        acc.data
+            .extend_from_slice(&data[pos + 7..pos + total_size - 1]);
     }
 
     Some(total_size)
@@ -900,7 +972,9 @@ fn decode_all_channels(
                 if g_idx < gc_data[0].len() && !gc_data[0][g_idx].data.is_empty() {
                     let acc = &gc_data[0][g_idx];
                     let stride = acc.add_helper - 3; // subtract opcode overhead
-                    if stride == 0 { continue; }
+                    if stride == 0 {
+                        continue;
+                    }
                     let n_rows = acc.data.len() / stride;
                     let grp_offset = ch_info.group_offset.unwrap_or(6);
                     // grp_offset is relative to the stored data (after stripping `(G` opcode):
@@ -909,15 +983,20 @@ fn decode_all_channels(
                     let data_offset_in_stored = grp_offset;
 
                     let mut timecodes = Vec::with_capacity(n_rows);
-                    let mut values = ChannelValues::new(decoder_type, ch_info.chs.units(), is_manual, n_rows);
+                    let mut values =
+                        ChannelValues::new(decoder_type, ch_info.chs.units(), is_manual, n_rows);
 
                     for row in 0..n_rows {
                         let row_start = row * stride;
                         // Timecode at start of each row
-                        if row_start + 4 > acc.data.len() { break; }
+                        if row_start + 4 > acc.data.len() {
+                            break;
+                        }
                         let tc = i32::from_le_bytes([
-                            acc.data[row_start], acc.data[row_start + 1],
-                            acc.data[row_start + 2], acc.data[row_start + 3],
+                            acc.data[row_start],
+                            acc.data[row_start + 1],
+                            acc.data[row_start + 2],
+                            acc.data[row_start + 3],
                         ]);
                         timecodes.push(tc as i64 - time_offset);
 
@@ -952,31 +1031,39 @@ fn decode_all_channels(
             let ch_usize = ch_idx as usize;
 
             // Check S messages
-            let (view_offset, stride_offset, cat_idx) = if ch_usize < gc_data[1].len() && !gc_data[1][ch_usize].data.is_empty() {
-                // S messages: stored = tc(4) + idx(2) + data(N), sample starts at offset 6
-                (6, 3, 1)
-            } else if ch_usize < gc_data[2].len() && !gc_data[2][ch_usize].data.is_empty() {
-                // c messages: stored = tc(4) + data(N), sample starts at offset 4
-                (4, 8, 2)
-            } else {
-                (0, 0, 255) // sentinel
-            };
+            let (view_offset, stride_offset, cat_idx) =
+                if ch_usize < gc_data[1].len() && !gc_data[1][ch_usize].data.is_empty() {
+                    // S messages: stored = tc(4) + idx(2) + data(N), sample starts at offset 6
+                    (6, 3, 1)
+                } else if ch_usize < gc_data[2].len() && !gc_data[2][ch_usize].data.is_empty() {
+                    // c messages: stored = tc(4) + data(N), sample starts at offset 4
+                    (4, 8, 2)
+                } else {
+                    (0, 0, 255) // sentinel
+                };
 
             if cat_idx < 4 {
                 let acc = &gc_data[cat_idx][ch_usize];
                 let stride = acc.add_helper - stride_offset;
-                if stride == 0 { continue; }
+                if stride == 0 {
+                    continue;
+                }
                 let n_rows = acc.data.len() / stride;
 
                 let mut timecodes = Vec::with_capacity(n_rows);
-                let mut values = ChannelValues::new(decoder_type, ch_info.chs.units(), is_manual, n_rows);
+                let mut values =
+                    ChannelValues::new(decoder_type, ch_info.chs.units(), is_manual, n_rows);
 
                 for row in 0..n_rows {
                     let row_start = row * stride;
-                    if row_start + 4 > acc.data.len() { break; }
+                    if row_start + 4 > acc.data.len() {
+                        break;
+                    }
                     let tc = i32::from_le_bytes([
-                        acc.data[row_start], acc.data[row_start + 1],
-                        acc.data[row_start + 2], acc.data[row_start + 3],
+                        acc.data[row_start],
+                        acc.data[row_start + 1],
+                        acc.data[row_start + 2],
+                        acc.data[row_start + 3],
                     ]);
                     timecodes.push(tc as i64 - time_offset);
 
@@ -1009,7 +1096,8 @@ fn decode_all_channels(
                     let n_rows = acc.timecodes.len();
 
                     let mut timecodes = Vec::with_capacity(n_rows);
-                    let mut values = ChannelValues::new(decoder_type, ch_info.chs.units(), is_manual, n_rows);
+                    let mut values =
+                        ChannelValues::new(decoder_type, ch_info.chs.units(), is_manual, n_rows);
 
                     for (i, &tc) in acc.timecodes.iter().enumerate() {
                         timecodes.push(tc as i64 - time_offset);
@@ -1045,9 +1133,12 @@ fn decode_all_channels(
 
 /// Process LAP messages with segment filtering, dedup, gap-fill, 0-based normalization.
 /// Matches aim_xrk.pyx:_get_laps (LAP message branch).
-fn process_laps(header_messages: &HashMap<u32, Vec<HeaderMessage>>, time_offset: i64) -> Vec<LapInfo> {
-    use std::io::Cursor;
+fn process_laps(
+    header_messages: &HashMap<u32, Vec<HeaderMessage>>,
+    time_offset: i64,
+) -> Vec<LapInfo> {
     use binrw::BinRead;
+    use std::io::Cursor;
 
     let mut lap_nums: Vec<i32> = Vec::new();
     let mut start_times: Vec<i64> = Vec::new();
@@ -1055,8 +1146,12 @@ fn process_laps(header_messages: &HashMap<u32, Vec<HeaderMessage>>, time_offset:
 
     if let Some(lap_msgs) = header_messages.get(&tokens::lap()) {
         for m in lap_msgs {
-            if m.payload.len() < 20 { continue; }
-            let Ok(lap) = LapPayload::read(&mut Cursor::new(&m.payload)) else { continue };
+            if m.payload.len() < 20 {
+                continue;
+            }
+            let Ok(lap) = LapPayload::read(&mut Cursor::new(&m.payload)) else {
+                continue;
+            };
 
             let end_time = lap.end_time as i64 - time_offset;
             let duration = lap.duration as i64;
@@ -1096,12 +1191,16 @@ fn process_laps(header_messages: &HashMap<u32, Vec<HeaderMessage>>, time_offset:
         }
     }
 
-    lap_nums.iter().enumerate().map(|(i, &n)| LapInfo {
-        segment: 0,
-        lap_num: n as u16,
-        duration: (end_times[i] - start_times[i]) as u32,
-        end_time: end_times[i] as u32,
-    }).collect()
+    lap_nums
+        .iter()
+        .enumerate()
+        .map(|(i, &n)| LapInfo {
+            segment: 0,
+            lap_num: n as u16,
+            duration: (end_times[i] - start_times[i]) as u32,
+            end_time: end_times[i] as u32,
+        })
+        .collect()
 }
 
 /// Processed lap info ready for Arrow conversion.
@@ -1115,8 +1214,8 @@ pub struct ProcessedLap {
 
 /// Get processed laps from ParseResult (with proper start/end times).
 pub fn get_processed_laps(result: &ParseResult) -> Vec<ProcessedLap> {
-    use std::io::Cursor;
     use binrw::BinRead;
+    use std::io::Cursor;
 
     let mut lap_nums: Vec<i32> = Vec::new();
     let mut start_times: Vec<i64> = Vec::new();
@@ -1124,14 +1223,20 @@ pub fn get_processed_laps(result: &ParseResult) -> Vec<ProcessedLap> {
 
     if let Some(lap_msgs) = result.header_messages.get(&tokens::lap()) {
         for m in lap_msgs {
-            if m.payload.len() < 20 { continue; }
-            let Ok(lap) = LapPayload::read(&mut Cursor::new(&m.payload)) else { continue };
+            if m.payload.len() < 20 {
+                continue;
+            }
+            let Ok(lap) = LapPayload::read(&mut Cursor::new(&m.payload)) else {
+                continue;
+            };
 
             let end_time = lap.end_time as i64 - result.time_offset;
             let duration = lap.duration as i64;
             let lap_num = lap.lap_num as i32;
 
-            if lap.segment != 0 { continue; }
+            if lap.segment != 0 {
+                continue;
+            }
 
             if lap_nums.is_empty() {
                 // accept
@@ -1159,9 +1264,13 @@ pub fn get_processed_laps(result: &ParseResult) -> Vec<ProcessedLap> {
         }
     }
 
-    lap_nums.iter().enumerate().map(|(i, &n)| ProcessedLap {
-        num: n,
-        start_time: start_times[i],
-        end_time: end_times[i],
-    }).collect()
+    lap_nums
+        .iter()
+        .enumerate()
+        .map(|(i, &n)| ProcessedLap {
+            num: n,
+            start_time: start_times[i],
+            end_time: end_times[i],
+        })
+        .collect()
 }

--- a/rust/src/payloads/chs.rs
+++ b/rust/src/payloads/chs.rs
@@ -11,39 +11,39 @@ use crate::tables;
 #[derive(Debug, Clone, BinRead)]
 #[br(little)]
 pub struct ChsPayload {
-    pub index: u16,            // [0:2]
-    pub _pad_2_4: [u8; 2],    // [2:4]
-    pub hardware_id: u16,      // [4:6]
-    pub source_channel_id: u16, // [6:8]
-    pub hardware_ref: u32,     // [8:12]
-    pub unit_type_byte: u8,    // [12]
+    pub index: u16,               // [0:2]
+    pub _pad_2_4: [u8; 2],        // [2:4]
+    pub hardware_id: u16,         // [4:6]
+    pub source_channel_id: u16,   // [6:8]
+    pub hardware_ref: u32,        // [8:12]
+    pub unit_type_byte: u8,       // [12]
     pub maybe_display_format: u8, // [13]
-    pub maybe_config_flags: u16, // [14:16]
-    pub source_type: u8,       // [16]
-    pub _pad_17_20: [u8; 3],   // [17:20]
-    pub decoder_type: u8,      // [20]
-    pub _pad_21_24: [u8; 3],   // [21:24]
-    pub short_name_raw: [u8; 8], // [24:32]
-    pub long_name_raw: [u8; 24], // [32:56]
-    pub _pad_56_64: [u8; 8],   // [56:64]
-    pub sample_period_us: u32, // [64:68]
-    pub data_offset: u16,      // [68:70]
-    pub _pad_70_72: [u8; 2],   // [70:72]
-    pub data_size: u8,         // [72]
-    pub _pad_73_76: [u8; 3],   // [73:76]
-    pub device_tag_raw: [u8; 4], // [76:80]
-    pub device_node_id: u8,    // [80]
-    pub maybe_device_flags: u8, // [81]
-    pub _pad_82_84: [u8; 2],   // [82:84]
-    pub maybe_output_type: u8, // [84]
-    pub _pad_85_88: [u8; 3],   // [85:88]
-    pub display_index: u32,    // [88:92]
-    pub maybe_output_size: u8, // [92]
-    pub _pad_93_96: [u8; 3],   // [93:96]
-    pub cal_value_1: f32,      // [96:100]
-    pub cal_value_2: f32,      // [100:104]
-    pub display_range_min: f32, // [104:108]
-    pub display_range_max: f32, // [108:112]
+    pub maybe_config_flags: u16,  // [14:16]
+    pub source_type: u8,          // [16]
+    pub _pad_17_20: [u8; 3],      // [17:20]
+    pub decoder_type: u8,         // [20]
+    pub _pad_21_24: [u8; 3],      // [21:24]
+    pub short_name_raw: [u8; 8],  // [24:32]
+    pub long_name_raw: [u8; 24],  // [32:56]
+    pub _pad_56_64: [u8; 8],      // [56:64]
+    pub sample_period_us: u32,    // [64:68]
+    pub data_offset: u16,         // [68:70]
+    pub _pad_70_72: [u8; 2],      // [70:72]
+    pub data_size: u8,            // [72]
+    pub _pad_73_76: [u8; 3],      // [73:76]
+    pub device_tag_raw: [u8; 4],  // [76:80]
+    pub device_node_id: u8,       // [80]
+    pub maybe_device_flags: u8,   // [81]
+    pub _pad_82_84: [u8; 2],      // [82:84]
+    pub maybe_output_type: u8,    // [84]
+    pub _pad_85_88: [u8; 3],      // [85:88]
+    pub display_index: u32,       // [88:92]
+    pub maybe_output_size: u8,    // [92]
+    pub _pad_93_96: [u8; 3],      // [93:96]
+    pub cal_value_1: f32,         // [96:100]
+    pub cal_value_2: f32,         // [100:104]
+    pub display_range_min: f32,   // [104:108]
+    pub display_range_max: f32,   // [108:112]
 }
 
 impl ChsPayload {
@@ -77,7 +77,10 @@ impl ChsPayload {
     /// Get the device tag as string.
     pub fn device_tag(&self) -> String {
         if self.device_tag_raw.iter().any(|&b| b != 0) {
-            let end = self.device_tag_raw.iter().position(|&b| b == 0)
+            let end = self
+                .device_tag_raw
+                .iter()
+                .position(|&b| b == 0)
                 .unwrap_or(self.device_tag_raw.len());
             String::from_utf8_lossy(&self.device_tag_raw[..end]).into_owned()
         } else {

--- a/rust/src/payloads/gps.rs
+++ b/rust/src/payloads/gps.rs
@@ -8,22 +8,22 @@ use binrw::BinRead;
 #[derive(Debug, Clone, BinRead)]
 #[br(little)]
 pub struct GpsPayload {
-    pub timecode: i32,    // [0:4]   AIM logger time [ms]
-    pub itow: u32,        // [4:8]   GPS time of week [ms]
-    pub ftow: i32,        // [8:12]  Fractional TOW [ns]
-    pub week: u16,        // [12:14] GPS week number
-    pub gps_fix: u8,      // [14]    Fix type (0=none, 2=2D, 3=3D)
-    pub flags: u8,        // [15]    Validity bitmask
-    pub ecef_x: i32,      // [16:20] ECEF X position [cm]
-    pub ecef_y: i32,      // [20:24] ECEF Y position [cm]
-    pub ecef_z: i32,      // [24:28] ECEF Z position [cm]
-    pub p_acc: u32,       // [28:32] Position accuracy [cm]
-    pub ecef_vx: i32,     // [32:36] ECEF X velocity [cm/s]
-    pub ecef_vy: i32,     // [36:40] ECEF Y velocity [cm/s]
-    pub ecef_vz: i32,     // [40:44] ECEF Z velocity [cm/s]
-    pub s_acc: u32,       // [44:48] Speed accuracy [cm/s]
-    pub pdop: u16,        // [48:50] Position DOP [*0.01]
-    pub reserved1: u8,    // [50]    u-blox reserved
-    pub num_sv: u8,       // [51]    Number of satellites used
-    pub reserved2: u32,   // [52:56] u-blox reserved
+    pub timecode: i32,  // [0:4]   AIM logger time [ms]
+    pub itow: u32,      // [4:8]   GPS time of week [ms]
+    pub ftow: i32,      // [8:12]  Fractional TOW [ns]
+    pub week: u16,      // [12:14] GPS week number
+    pub gps_fix: u8,    // [14]    Fix type (0=none, 2=2D, 3=3D)
+    pub flags: u8,      // [15]    Validity bitmask
+    pub ecef_x: i32,    // [16:20] ECEF X position [cm]
+    pub ecef_y: i32,    // [20:24] ECEF Y position [cm]
+    pub ecef_z: i32,    // [24:28] ECEF Z position [cm]
+    pub p_acc: u32,     // [28:32] Position accuracy [cm]
+    pub ecef_vx: i32,   // [32:36] ECEF X velocity [cm/s]
+    pub ecef_vy: i32,   // [36:40] ECEF Y velocity [cm/s]
+    pub ecef_vz: i32,   // [40:44] ECEF Z velocity [cm/s]
+    pub s_acc: u32,     // [44:48] Speed accuracy [cm/s]
+    pub pdop: u16,      // [48:50] Position DOP [*0.01]
+    pub reserved1: u8,  // [50]    u-blox reserved
+    pub num_sv: u8,     // [51]    Number of satellites used
+    pub reserved2: u32, // [52:56] u-blox reserved
 }

--- a/rust/src/payloads/idn.rs
+++ b/rust/src/payloads/idn.rs
@@ -15,6 +15,9 @@ impl IdnPayload {
     pub fn parse(data: &[u8]) -> Self {
         let model_id = u16::from_le_bytes([data[0], data[1]]);
         let logger_id = u32::from_le_bytes([data[6], data[7], data[8], data[9]]);
-        IdnPayload { model_id, logger_id }
+        IdnPayload {
+            model_id,
+            logger_id,
+        }
     }
 }

--- a/rust/src/payloads/lap.rs
+++ b/rust/src/payloads/lap.rs
@@ -8,10 +8,10 @@ use binrw::BinRead;
 #[derive(Debug, Clone, BinRead)]
 #[br(little)]
 pub struct LapPayload {
-    pub _pad: u8,         // [0]     padding
-    pub segment: u8,      // [1]     segment number
-    pub lap_num: u16,     // [2:4]   lap number
-    pub duration: u32,    // [4:8]   lap duration [ms]
+    pub _pad: u8,           // [0]     padding
+    pub segment: u8,        // [1]     segment number
+    pub lap_num: u16,       // [2:4]   lap number
+    pub duration: u32,      // [4:8]   lap duration [ms]
     pub _reserved: [u8; 8], // [8:16] reserved
-    pub end_time: u32,    // [16:20] lap end time [ms]
+    pub end_time: u32,      // [16:20] lap end time [ms]
 }

--- a/rust/src/payloads/odo.rs
+++ b/rust/src/payloads/odo.rs
@@ -10,8 +10,8 @@ use crate::messages::nullterm_string;
 #[derive(Debug, Clone)]
 pub struct OdoRecord {
     pub name: String,
-    pub time: u32,  // seconds
-    pub dist: u32,  // meters
+    pub time: u32, // seconds
+    pub dist: u32, // meters
 }
 
 /// ODO payload — collection of odometer records.
@@ -30,10 +30,16 @@ impl OdoPayload {
             // Skip Fuel records (matches Python behavior)
             if !name.starts_with("Fuel") {
                 let time = u32::from_le_bytes([
-                    data[offset + 16], data[offset + 17], data[offset + 18], data[offset + 19],
+                    data[offset + 16],
+                    data[offset + 17],
+                    data[offset + 18],
+                    data[offset + 19],
                 ]);
                 let dist = u32::from_le_bytes([
-                    data[offset + 20], data[offset + 21], data[offset + 22], data[offset + 23],
+                    data[offset + 20],
+                    data[offset + 21],
+                    data[offset + 22],
+                    data[offset + 23],
                 ]);
                 records.insert(name.clone(), OdoRecord { name, time, dist });
             }

--- a/rust/src/tables.rs
+++ b/rust/src/tables.rs
@@ -55,27 +55,111 @@ pub struct DecoderInfo {
 
 pub fn decoder_info(decoder_type: u8) -> Option<DecoderInfo> {
     match decoder_type {
-        0 => Some(DecoderInfo { format: 'i', interpolate: false, byte_size: 4 }),
-        1 => Some(DecoderInfo { format: 'H', interpolate: true, byte_size: 2 }),
-        3 => Some(DecoderInfo { format: 'i', interpolate: false, byte_size: 4 }),
-        4 => Some(DecoderInfo { format: 'h', interpolate: false, byte_size: 2 }),
-        6 => Some(DecoderInfo { format: 'f', interpolate: true, byte_size: 4 }),
-        8 => Some(DecoderInfo { format: 'i', interpolate: false, byte_size: 4 }),
-        11 => Some(DecoderInfo { format: 'h', interpolate: false, byte_size: 2 }),
-        12 => Some(DecoderInfo { format: 'i', interpolate: false, byte_size: 4 }),
-        13 => Some(DecoderInfo { format: 'B', interpolate: false, byte_size: 1 }),
-        15 => Some(DecoderInfo { format: 'H', interpolate: false, byte_size: 2 }),
-        20 => Some(DecoderInfo { format: 'H', interpolate: true, byte_size: 2 }),
-        22 => Some(DecoderInfo { format: 'i', interpolate: false, byte_size: 4 }),
-        24 => Some(DecoderInfo { format: 'i', interpolate: false, byte_size: 4 }),
-        26 => Some(DecoderInfo { format: 'i', interpolate: false, byte_size: 4 }),
-        27 => Some(DecoderInfo { format: 'i', interpolate: false, byte_size: 4 }),
-        31 => Some(DecoderInfo { format: 'i', interpolate: false, byte_size: 4 }),
-        32 => Some(DecoderInfo { format: 'i', interpolate: false, byte_size: 4 }),
-        33 => Some(DecoderInfo { format: 'i', interpolate: false, byte_size: 4 }),
-        37 => Some(DecoderInfo { format: 'i', interpolate: false, byte_size: 4 }),
-        38 => Some(DecoderInfo { format: 'i', interpolate: false, byte_size: 4 }),
-        39 => Some(DecoderInfo { format: 'i', interpolate: false, byte_size: 4 }),
+        0 => Some(DecoderInfo {
+            format: 'i',
+            interpolate: false,
+            byte_size: 4,
+        }),
+        1 => Some(DecoderInfo {
+            format: 'H',
+            interpolate: true,
+            byte_size: 2,
+        }),
+        3 => Some(DecoderInfo {
+            format: 'i',
+            interpolate: false,
+            byte_size: 4,
+        }),
+        4 => Some(DecoderInfo {
+            format: 'h',
+            interpolate: false,
+            byte_size: 2,
+        }),
+        6 => Some(DecoderInfo {
+            format: 'f',
+            interpolate: true,
+            byte_size: 4,
+        }),
+        8 => Some(DecoderInfo {
+            format: 'i',
+            interpolate: false,
+            byte_size: 4,
+        }),
+        11 => Some(DecoderInfo {
+            format: 'h',
+            interpolate: false,
+            byte_size: 2,
+        }),
+        12 => Some(DecoderInfo {
+            format: 'i',
+            interpolate: false,
+            byte_size: 4,
+        }),
+        13 => Some(DecoderInfo {
+            format: 'B',
+            interpolate: false,
+            byte_size: 1,
+        }),
+        15 => Some(DecoderInfo {
+            format: 'H',
+            interpolate: false,
+            byte_size: 2,
+        }),
+        20 => Some(DecoderInfo {
+            format: 'H',
+            interpolate: true,
+            byte_size: 2,
+        }),
+        22 => Some(DecoderInfo {
+            format: 'i',
+            interpolate: false,
+            byte_size: 4,
+        }),
+        24 => Some(DecoderInfo {
+            format: 'i',
+            interpolate: false,
+            byte_size: 4,
+        }),
+        26 => Some(DecoderInfo {
+            format: 'i',
+            interpolate: false,
+            byte_size: 4,
+        }),
+        27 => Some(DecoderInfo {
+            format: 'i',
+            interpolate: false,
+            byte_size: 4,
+        }),
+        31 => Some(DecoderInfo {
+            format: 'i',
+            interpolate: false,
+            byte_size: 4,
+        }),
+        32 => Some(DecoderInfo {
+            format: 'i',
+            interpolate: false,
+            byte_size: 4,
+        }),
+        33 => Some(DecoderInfo {
+            format: 'i',
+            interpolate: false,
+            byte_size: 4,
+        }),
+        37 => Some(DecoderInfo {
+            format: 'i',
+            interpolate: false,
+            byte_size: 4,
+        }),
+        38 => Some(DecoderInfo {
+            format: 'i',
+            interpolate: false,
+            byte_size: 4,
+        }),
+        39 => Some(DecoderInfo {
+            format: 'i',
+            interpolate: false,
+            byte_size: 4,
+        }),
         _ => None,
     }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #60
* __->__ #59

Add cargo fmt and cargo clippy to the justfile format/lint/check recipes.
Fix all clippy warnings and apply rustfmt across the Rust codebase.
Also make the benchmark recipe auto-rebuild the Rust extension.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>