### PR TITLE
fix: codebase cleanup — GPS immutability, Rust panics, dead code, assertions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ uv build             # Build wheel
 
 - `src/libxrk/aim_xrk.pyx` - Cython binary parser (default backend)
 - `src/libxrk/aim_xrk.pyi` - Type stubs for Cython module
-- `rust/` - Rust+PyO3 parser (~2x faster)
+- `crates/` - Rust+PyO3 parser (~2x faster)
 - `src/libxrk/_aim_xrk_rs.pyi` - Type stubs for Rust module
 - `src/libxrk/base.py` - LogFile dataclass, channel merging
 - `src/libxrk/gps.py` - GPS utilities, lap detection, timing fix
@@ -31,9 +31,9 @@ uv build             # Build wheel
 The library has two parser backends with identical APIs. Both are included in all published wheels.
 
 - **Cython** (default): `src/libxrk/aim_xrk.pyx` — mature, well-tested
-- **Rust**: `rust/` — ~2x faster, used automatically in Pyodide/WASM
+- **Rust**: `crates/` — ~2x faster, used automatically in Pyodide/WASM
 
-Set `LIBXRK_BACKEND=rust` to use the Rust parser. Falls back to Rust if Cython is unavailable.
+Set `LIBXRK_BACKEND=rust` to use the Rust parser. Default is Cython; no automatic fallback.
 
 ```bash
 just rust-build                        # Build Rust extension
@@ -93,7 +93,7 @@ After modifying `src/libxrk/aim_xrk.pyx`, you **must** run `uv sync --reinstall-
 
 ## Rust Rebuild
 
-After modifying Rust source in `rust/`, run `just rust-build` (release) or `just rust-build-debug` (faster compile). The Rust extension coexists with Cython — both can be installed simultaneously.
+After modifying Rust source in `crates/`, run `just rust-build` (release) or `just rust-build-debug` (faster compile). The Rust extension coexists with Cython — both can be installed simultaneously.
 
 ## Architecture Notes
 

--- a/crates/libxrk/src/gps/timing.rs
+++ b/crates/libxrk/src/gps/timing.rs
@@ -35,8 +35,9 @@ pub fn detect_gps_timing_offset_from_gnfi(
     }
 
     let tolerance: i64 = 5000;
-    let gps_end = *gps_timecodes.last().unwrap();
-    let gnfi_end = *gnfi_timecodes.last().unwrap();
+    // Safety: both slices have len >= 2 (checked above), so .last() is always Some.
+    let gps_end = *gps_timecodes.last().unwrap_or(&0);
+    let gnfi_end = *gnfi_timecodes.last().unwrap_or(&0);
     let offset = gps_end - gnfi_end;
 
     // Check if GPS extends ~65533ms beyond GNFI (the bug signature)
@@ -139,22 +140,24 @@ pub fn detect_gap_corrections(
 
     // Method 3: Indirect detection - GPS extends ~65533ms beyond other channels
     if let Some(max_non_gps_end) = non_gps_max_end_time {
-        let gps_end = *gps_timecodes.last().unwrap();
+        // Safety: gps_timecodes.len() >= 2 checked at function entry
+        let gps_end = *gps_timecodes.last().unwrap_or(&0);
         let end_offset = gps_end - max_non_gps_end;
 
         if (OVERFLOW_GAP_MIN..=OVERFLOW_GAP_MAX).contains(&end_offset) {
-            // Find the largest gap
-            let largest_gap_idx = gap_indices
+            // Find the largest gap — gap_indices is non-empty (checked at line 109),
+            // but guard against panics on malformed data regardless.
+            if let Some(largest_gap_idx) = gap_indices
                 .iter()
                 .copied()
                 .max_by_key(|&i| gps_timecodes[i + 1] - gps_timecodes[i])
-                .unwrap();
-
-            let gap_time = gps_timecodes[largest_gap_idx];
-            corrections.push(GapCorrection {
-                gap_time,
-                correction: OVERFLOW_BUG_MS,
-            });
+            {
+                let gap_time = gps_timecodes[largest_gap_idx];
+                corrections.push(GapCorrection {
+                    gap_time,
+                    correction: OVERFLOW_BUG_MS,
+                });
+            }
         }
     }
 

--- a/crates/libxrk/src/messages.rs
+++ b/crates/libxrk/src/messages.rs
@@ -113,7 +113,9 @@ impl HeaderMessage {
         let payload = &d[payload_start..payload_end];
 
         // Checksum: sum of payload bytes truncated to u16 (wrapping is intentional)
-        let checksum: u16 = payload.iter().fold(0u16, |acc, &b| acc.wrapping_add(b as u16));
+        let checksum: u16 = payload
+            .iter()
+            .fold(0u16, |acc, &b| acc.wrapping_add(b as u16));
 
         // Footer
         let ftr = &d[payload_end..];

--- a/crates/libxrk/src/parser.rs
+++ b/crates/libxrk/src/parser.rs
@@ -416,7 +416,7 @@ impl ParserState {
         for acc in &self.gc_data[3] {
             if !acc.timecodes.is_empty() {
                 tc_min_candidates.push(acc.timecodes[0] as i64);
-                tc_max_candidates.push(*acc.timecodes.last().unwrap() as i64);
+                tc_max_candidates.push(*acc.timecodes.last().unwrap_or(&0) as i64);
             }
         }
 
@@ -1131,12 +1131,23 @@ fn decode_all_channels(
     result
 }
 
-/// Process LAP messages with segment filtering, dedup, gap-fill, 0-based normalization.
+/// Raw parsed lap data: parallel vectors of (lap_num, start_time, end_time).
+/// Lap nums are normalized to 0-based indexing.
+struct RawLapData {
+    lap_nums: Vec<i32>,
+    start_times: Vec<i64>,
+    end_times: Vec<i64>,
+}
+
+/// Parse LAP messages with segment filtering, dedup, gap-fill, 0-based normalization.
+///
+/// This is the shared core logic used by both `process_laps` (internal `LapInfo`)
+/// and `get_processed_laps` (public `ProcessedLap`).
 /// Matches aim_xrk.pyx:_get_laps (LAP message branch).
-fn process_laps(
+fn parse_lap_messages(
     header_messages: &HashMap<u32, Vec<HeaderMessage>>,
     time_offset: i64,
-) -> Vec<LapInfo> {
+) -> RawLapData {
     use binrw::BinRead;
     use std::io::Cursor;
 
@@ -1162,20 +1173,23 @@ fn process_laps(
                 continue;
             }
 
-            if lap_nums.is_empty() {
-                // First lap — accept
-            } else if *lap_nums.last().unwrap() == lap_num {
-                // Duplicate — skip
-                continue;
-            } else if *lap_nums.last().unwrap() + 1 == lap_num {
-                // Sequential — accept
-            } else if *lap_nums.last().unwrap() + 2 == lap_num {
-                // Gap of 1 — emit inferred lap
-                lap_nums.push(lap_num - 1);
-                start_times.push(*end_times.last().unwrap());
-                end_times.push(end_time - duration);
+            // Compare with the last lap number we've seen.
+            // Using .last() which returns Option — no unwrap needed.
+            if let Some(&last_num) = lap_nums.last() {
+                if last_num == lap_num {
+                    // Duplicate — skip
+                    continue;
+                } else if last_num + 2 == lap_num {
+                    // Gap of 1 — emit inferred lap
+                    let inferred_start = end_times.last().copied().unwrap_or(0);
+                    lap_nums.push(lap_num - 1);
+                    start_times.push(inferred_start);
+                    end_times.push(end_time - duration);
+                }
+                // last_num + 1 == lap_num: sequential — accept (fall through)
+                // else: unexpected gap, skip silently (Cython asserts but we don't)
             }
-            // else: unexpected gap, skip silently (Cython asserts but we don't)
+            // else: first lap — accept (fall through)
 
             lap_nums.push(lap_num);
             start_times.push(end_time - duration);
@@ -1184,21 +1198,35 @@ fn process_laps(
     }
 
     // Normalize to 0-based indexing
-    if !lap_nums.is_empty() {
-        let min_lap = *lap_nums.iter().min().unwrap();
+    if let Some(&min_lap) = lap_nums.iter().min() {
         for n in &mut lap_nums {
             *n -= min_lap;
         }
     }
 
-    lap_nums
+    RawLapData {
+        lap_nums,
+        start_times,
+        end_times,
+    }
+}
+
+/// Process LAP messages with segment filtering, dedup, gap-fill, 0-based normalization.
+/// Returns internal `LapInfo` structs stored in `ParseResult`.
+fn process_laps(
+    header_messages: &HashMap<u32, Vec<HeaderMessage>>,
+    time_offset: i64,
+) -> Vec<LapInfo> {
+    let raw = parse_lap_messages(header_messages, time_offset);
+
+    raw.lap_nums
         .iter()
         .enumerate()
         .map(|(i, &n)| LapInfo {
             segment: 0,
             lap_num: n as u16,
-            duration: (end_times[i] - start_times[i]) as u32,
-            end_time: end_times[i] as u32,
+            duration: (raw.end_times[i] - raw.start_times[i]) as u32,
+            end_time: raw.end_times[i] as u32,
         })
         .collect()
 }
@@ -1214,63 +1242,15 @@ pub struct ProcessedLap {
 
 /// Get processed laps from ParseResult (with proper start/end times).
 pub fn get_processed_laps(result: &ParseResult) -> Vec<ProcessedLap> {
-    use binrw::BinRead;
-    use std::io::Cursor;
+    let raw = parse_lap_messages(&result.header_messages, result.time_offset);
 
-    let mut lap_nums: Vec<i32> = Vec::new();
-    let mut start_times: Vec<i64> = Vec::new();
-    let mut end_times: Vec<i64> = Vec::new();
-
-    if let Some(lap_msgs) = result.header_messages.get(&tokens::lap()) {
-        for m in lap_msgs {
-            if m.payload.len() < 20 {
-                continue;
-            }
-            let Ok(lap) = LapPayload::read(&mut Cursor::new(&m.payload)) else {
-                continue;
-            };
-
-            let end_time = lap.end_time as i64 - result.time_offset;
-            let duration = lap.duration as i64;
-            let lap_num = lap.lap_num as i32;
-
-            if lap.segment != 0 {
-                continue;
-            }
-
-            if lap_nums.is_empty() {
-                // accept
-            } else if *lap_nums.last().unwrap() == lap_num {
-                continue;
-            } else if *lap_nums.last().unwrap() + 1 == lap_num {
-                // accept
-            } else if *lap_nums.last().unwrap() + 2 == lap_num {
-                lap_nums.push(lap_num - 1);
-                start_times.push(*end_times.last().unwrap());
-                end_times.push(end_time - duration);
-            }
-
-            lap_nums.push(lap_num);
-            start_times.push(end_time - duration);
-            end_times.push(end_time);
-        }
-    }
-
-    // Normalize to 0-based
-    if !lap_nums.is_empty() {
-        let min_lap = *lap_nums.iter().min().unwrap();
-        for n in &mut lap_nums {
-            *n -= min_lap;
-        }
-    }
-
-    lap_nums
+    raw.lap_nums
         .iter()
         .enumerate()
         .map(|(i, &n)| ProcessedLap {
             num: n,
-            start_time: start_times[i],
-            end_time: end_times[i],
+            start_time: raw.start_times[i],
+            end_time: raw.end_times[i],
         })
         .collect()
 }

--- a/src/libxrk/aim_xrk.pyx
+++ b/src/libxrk/aim_xrk.pyx
@@ -9,7 +9,6 @@ import math
 import mmap
 import numpy as np
 import os
-from pprint import pprint # pylint: disable=unused-import
 import struct
 import sys
 import time
@@ -407,10 +406,14 @@ def _decode_sequence(s, progress=None):
                                            &sv[pos])
                     pos += 1
                 elif typ == ord_op_c:
-                    assert msg.c.unk1 == 0, '%x' % msg.c.unk1
-                    assert (msg.c.channel & 7) == 4, '%x' % (msg.c.channel & 7)
-                    assert msg.c.unk3 == 0x84, '%x' % msg.c.unk3
-                    assert msg.c.unk4 == 6, '%x' % msg.c.unk4
+                    if msg.c.unk1 != 0:
+                        raise ValueError('Unexpected c.unk1: %x' % msg.c.unk1)
+                    if (msg.c.channel & 7) != 4:
+                        raise ValueError('Unexpected c.channel low bits: %x' % (msg.c.channel & 7))
+                    if msg.c.unk3 != 0x84:
+                        raise ValueError('Unexpected c.unk3: %x' % msg.c.unk3)
+                    if msg.c.unk4 != 6:
+                        raise ValueError('Unexpected c.unk4: %x' % msg.c.unk4)
                     data_cat = &gc_data[2]
                     data_p = &dereference(data_cat)[msg.c.channel >> 3]
                     if data_p >= &dereference(data_cat.end()):
@@ -435,11 +438,13 @@ def _decode_sequence(s, progress=None):
                     if hlen >= len_s:
                         raise IndexError
                     ver = msg.h.ver
-                    assert msg.h.cl == ord_gt, "%s at %x" % (chr(msg.h.cl), pos+11)
+                    if msg.h.cl != ord_gt:
+                        raise ValueError("Expected '>' at %x, got %s" % (pos+11, chr(msg.h.cl)))
                     pos += 12
 
                     # get some "free" range checking here before we go walking data[]
-                    assert sv[pos+hlen] == ord_lt, "%s at %x" % (s[pos+hlen], pos+hlen)
+                    if sv[pos+hlen] != ord_lt:
+                        raise ValueError("Expected '<' at %x, got %s" % (pos+hlen, s[pos+hlen]))
 
                     bytesum: cython.ushort = accumulate[byte_ptr, cython.int](
                         &sv[pos], &sv[pos+hlen], 0)
@@ -447,9 +452,12 @@ def _decode_sequence(s, progress=None):
 
                     msgf = <hmsg_ftr *>&sv[pos]
 
-                    assert msgf.tok == tok, "%x vs %x at %x" % (msgf.tok, tok, pos+1)
-                    assert msgf.bytesum == bytesum, '%x vs %x at %x' % (msgf.bytesum, bytesum, pos+5)
-                    assert msgf.cl == ord_gt, "%s at %x" % (chr(msgf.cl), pos+7)
+                    if msgf.tok != tok:
+                        raise ValueError("Token mismatch: %x vs %x at %x" % (msgf.tok, tok, pos+1))
+                    if msgf.bytesum != bytesum:
+                        raise ValueError('Checksum mismatch: %x vs %x at %x' % (msgf.bytesum, bytesum, pos+5))
+                    if msgf.cl != ord_gt:
+                        raise ValueError("Expected '>' at %x, got %s" % (pos+7, chr(msgf.cl)))
                     pos += 8
 
                     if (tok >> 24) == 32:
@@ -485,8 +493,10 @@ def _decode_sequence(s, progress=None):
                                     gc_data[3][m.content.index].Mms = struct.unpack_from(
                                         '<I', m.content.unknown, 64)[0] // 1000
                                 else:
-                                    assert channels[m.content.index].short_name == m.content.short_name, "%s vs %s" % (channels[m.content.index].short_name, m.content.short_name)
-                                    assert channels[m.content.index].long_name == m.content.long_name
+                                    if channels[m.content.index].short_name != m.content.short_name:
+                                        raise ValueError("Channel short_name mismatch: %s vs %s" % (channels[m.content.index].short_name, m.content.short_name))
+                                    if channels[m.content.index].long_name != m.content.long_name:
+                                        raise ValueError("Channel long_name mismatch: %s vs %s" % (channels[m.content.index].long_name, m.content.long_name))
                             for m in data.get(_tokdec('GRP'), []):
                                 groups += [None] * (m.content.index - len(groups) + 1)
                                 groups[m.content.index] = m.content
@@ -504,7 +514,8 @@ def _decode_sequence(s, progress=None):
                                     channels[ch].size for ch in m.content.channels)
                         elif tok == _tokdec('GRP'):
                             data = memoryview(data).cast('H')
-                            assert data[1] == len(data[2:])
+                            if data[1] != len(data[2:]):
+                                raise ValueError("GRP channel count mismatch: %d vs %d" % (data[1], len(data[2:])))
                             data = Group(index = data[0], channels = data[2:])
                         elif tok == _tokdec('CDE'):
                             data = ['%02x' % x for x in data]
@@ -713,7 +724,7 @@ def _decode_sequence(s, progress=None):
                         except KeyError:
                             messages[tok] = [Message(tok, ver, data)]
                 else:
-                    assert False, "%02x%02x at %x" % (s[pos], s[pos+1], pos)
+                    raise ValueError("Unknown byte sequence %02x%02x at %x" % (s[pos], s[pos+1], pos))
         except Exception as _err: # pylint: disable=broad-exception-caught
             if oldpos != badpos + badbytes and badbytes:
                 if show_bad:
@@ -736,7 +747,8 @@ def _decode_sequence(s, progress=None):
                   ', '.join('%02x' % c for c in s[badpos:badpos + badbytes])
                   )
         badbytes = 0
-    assert pos == len(s)
+    if pos != len(s):
+        raise ValueError("Parser did not consume entire input: pos=%d, len=%d" % (pos, len(s)))
     # Compute time_offset and last_time from raw gc_data buffers and GPS data.
     # Channel timecodes are not yet populated (process_channel runs later), so we
     # scan the accumulated raw data vectors directly.
@@ -806,7 +818,8 @@ def _decode_sequence(s, progress=None):
                 stride_offset = 8
                 data_p = &gc_data[2][c.index]
             if data_p.data.size():
-                assert len(c.timecodes) == 0, "Can't have both S/c and M records for channel %s (index=%d, %d vs %d)" % (c.long_name, c.index, len(c.timecodes), data_p.data.size())
+                if len(c.timecodes) != 0:
+                    raise ValueError("Can't have both S/c and M records for channel %s (index=%d, %d vs %d)" % (c.long_name, c.index, len(c.timecodes), data_p.data.size()))
 
                 # TREAD LIGHTLY - raw pointers here
                 view = np.asarray(<cython.uchar[:data_p.data.size()]> &data_p.data[0])
@@ -1012,7 +1025,8 @@ def _decode_gps(gpsmsg, time_offset):
     """
     if not gpsmsg: return []
     alldata = memoryview(gpsmsg)
-    assert len(alldata) % 56 == 0
+    if len(alldata) % 56 != 0:
+        raise ValueError("GPS data length %d is not a multiple of 56" % len(alldata))
     timecodes = np.asarray(alldata[0:].cast('i')[::56//4])
     # certain old MXP firmware (and maybe others) would periodically
     # butcher the upper 16-bits of the timecode field.  If necessary,
@@ -1163,7 +1177,7 @@ def _get_laps(lat_ch, lon_ch, msg_by_type, time_offset, last_time):
                 start_times.append(end_times[-1])
                 end_times.append(end_time - duration)
             else:
-                assert False, 'Lap gap from %d to %d' % (lap_nums[-1], lap)
+                raise ValueError('Lap gap from %d to %d' % (lap_nums[-1], lap))
             lap_nums.append(lap)
             start_times.append(end_time - duration)
             end_times.append(end_time)
@@ -1348,8 +1362,8 @@ def aim_xrk(fname, progress=None):
     # Pass GNFI timecodes for more robust detection (if available)
     # Only correct lap boundaries when laps came from GPS-based detection
     # (not from LAP messages, which use the internal clock unaffected by the bug)
-    fix_gps_timing_gaps(log, gnfi_timecodes=data.gnfi_timecodes,
-                        correct_laps=not data.has_lap_messages)
+    log = fix_gps_timing_gaps(log, gnfi_timecodes=data.gnfi_timecodes,
+                              correct_laps=not data.has_lap_messages)
 
     return log
 

--- a/src/libxrk/gps.py
+++ b/src/libxrk/gps.py
@@ -25,25 +25,6 @@ GPS_CHANNEL_NAMES = (
     "GPS_Yaw_Rate",
 )
 
-# None of the algorithms are slow
-# fastest: Fukushima 2006, but worse accuracy
-# most accurate: Vermeille, also very compact code
-# runner up: Osen
-
-
-# Also considered:
-
-# https://ea4eoz.blogspot.com/2015/11/simple-wgs-84-ecef-conversion-functions.html
-# slower algorithm, not great accuracy
-
-# http://wiki.gis.com/wiki/index.php/Geodetic_system
-# poor height accuracy
-
-# Olson, D. K., Converting Earth-Centered, Earth-Fixed Coordinates to
-# Geodetic Coordinates, IEEE Transactions on Aerospace and Electronic
-# Systems, 32 (1996) 473-476.
-# difficult to vectorize (poor for numpy/python)
-
 GPS = namedtuple("GPS", ["lat", "long", "alt"])
 
 
@@ -87,141 +68,6 @@ def lla2ecef(lat, lon, alt):
     z = ((1 - e_sq) * N + alt) * slat
 
     return x, y, z
-
-
-# Karl Osen. Accurate Conversion of Earth-Fixed Earth-Centered Coordinates to Geodetic Coordinates.
-# [Research Report] Norwegian University of Science and Technology. 2017. ￿hal-01704943v2
-# https://hal.science/hal-01704943v2/document
-# pretty accurate, reasonably fast
-def ecef2lla_osen(x, y, z):
-    invaa = +2.45817225764733181057e-0014  # 1/(a^2)
-    l = +3.34718999507065852867e-0003  # (e^2)/2
-    p1mee = +9.93305620009858682943e-0001  # 1-(e^2)
-    p1meedaa = +2.44171631847341700642e-0014  # (1-(e^2))/(a^2)
-    ll4 = +4.48147234524044602618e-0005  # 4*(l^2) = e^4
-    ll = +1.12036808631011150655e-0005  # l^2 = (e^4)/4
-    invcbrt2 = +7.93700525984099737380e-0001  # 1/(2^(1/3))
-    inv3 = +3.33333333333333333333e-0001  # 1/3
-    inv6 = +1.66666666666666666667e-0001  # 1/6
-
-    w = x * x + y * y
-    m = w * invaa
-    w = np.sqrt(w)
-    n = z * z * p1meedaa
-    mpn = m + n
-    p = inv6 * (mpn - ll4)
-    P = p * p
-    G = m * n * ll
-    H = 2 * P * p + G
-    p = None
-    # if H < Hmin: return -1
-    C = np.cbrt(H + G + 2 * np.sqrt(H * G)) * invcbrt2
-    G = None
-    H = None
-    i = -ll - 0.5 * mpn
-    beta = inv3 * i - C - P / C
-    C = None
-    P = None
-    k = ll * (ll - mpn)
-    mpn = None
-    # Compute t
-    t = np.sqrt(np.sqrt(beta * beta - k) - 0.5 * (beta + i)) + np.sqrt(np.abs(0.5 * (beta - i))) * (
-        2 * (m < n) - 1
-    )
-    beta = None
-    # Use Newton-Raphson's method to compute t correction
-    g = 2 * l * (m - n)
-    m = None
-    n = None
-    tt = t * t
-    dt = -(tt * (tt + (i + i)) + g * t + k) / (4 * t * (tt + i) + g)
-    g = None
-    i = None
-    tt = None
-    # compute latitude (range -PI/2..PI/2)
-    u = t + dt + l
-    v = t + dt - l
-    dt = None
-    zu = z * u
-    wv = w * v
-    # compute altitude
-    invuv = 1 / (u * v)
-    return GPS(
-        np.arctan2(zu, wv) * (180 / np.pi),
-        np.arctan2(y, x) * (180 / np.pi),
-        np.sqrt(np.square(w - wv * invuv) + np.square(z - zu * p1mee * invuv)) * (1 - 2 * (u < 1)),
-    )
-
-
-# https://www.researchgate.net/publication/227215135_Transformation_from_Cartesian_to_Geodetic_Coordinates_Accelerated_by_Halley's_Method/link/0912f50af90e6de252000000/download
-# "Fukushima 2006"
-# fastest, reasonably accurate but not best
-def ecef2lla_fukushima2006(x, y, z):
-    a = 6378137.0
-    finv = 298.257222101
-    f = 1.0 / finv
-    e2 = (2 - f) * f
-    ec2 = 1 - e2
-    ec = np.sqrt(ec2)
-    # b = a * ec
-    c = a * e2
-    # PIH = 2 * np.arctan(1.)
-
-    lamb = np.arctan2(y, x)
-    s0 = np.abs(z)
-    p2 = x * x + y * y
-    p = np.sqrt(p2)
-    zc = ec * s0
-    c0 = ec * p
-    c02 = c0 * c0
-    s02 = s0 * s0
-    a02 = c02 + s02
-    a0 = np.sqrt(a02)
-    # a03 = a02 * a0
-    a03 = a02
-    a03 *= a0
-    a02 = None
-    # s1 = zc * a03 + c * (s02 * s0)
-    s02 *= s0
-    s02 *= c
-    s1 = s02
-    s1 += zc * a03
-    s02 = None
-    # c1 = p * a03 - c * (c02 * c0)
-    c02 *= c0
-    c02 *= c
-    c1 = p * a03 - c02
-    c02 = None
-    cs0c0 = c * c0 * s0
-    # b0 = 1.5 * cs0c0 * ((p*s0 - zc*c0) * a0 - cs0c0)
-    zc *= c0
-    b0 = cs0c0
-    b0 *= 1.5 * ((p * s0 - zc) * a0 - cs0c0)
-    a0 = None
-    zc = None
-    cs0c0 = None
-    s1 = s1 * a03 - b0 * s0
-    # cc = ec * (c1 * a03 - b0 * c0)
-    c1 *= a03
-    b0 *= c0
-    c1 -= b0
-    cc = c1
-    cc *= ec
-    c1 = None
-    a03 = None
-    c0 = None
-    b0 = None
-    phi = np.arctan2(s1, cc)
-    s12 = s1 * s1
-    cc2 = cc * cc
-    h = (p * cc + s0 * s1 - a * np.sqrt(ec2 * s12 + cc2)) / np.sqrt(s12 + cc2)
-    s1 = None
-    cc = None
-    s12 = None
-    cc2 = None
-    phi = np.copysign(phi, z)
-
-    return GPS(phi * (180 / np.pi), lamb * (180 / np.pi), h)
 
 
 # Computing geodetic coordinates from geocentric coordinates
@@ -402,51 +248,6 @@ def ecef_velocity_to_enu(dX, dY, dZ, lat_rad, lon_rad):
     return V_east, V_north
 
 
-if __name__ == "__main__":
-
-    def perf_test():
-        import time
-
-        samples = 10000000
-        lat = -90.0 + 180.0 * np.random.rand(samples, 1)
-        long = -180.0 + 360.0 * np.random.rand(samples, 1)
-        alt = -11e3 + (20e3) * np.random.rand(
-            samples, 1
-        )  # From approximately the bottom of the Mariana trench, to the top of the Everest
-
-        print("generating x,y,z")
-        x, y, z = lla2ecef(lat, long, alt)
-        algos = [
-            ("osen", ecef2lla_osen),
-            ("fukushima2006", ecef2lla_fukushima2006),
-            ("vermeille2003", ecef2lla_vermeille2003),
-        ]
-        stats: dict[str, list[float]] = {name: [] for name, algo in algos}
-        for _ in range(5):
-            for name, algo in algos:
-                start = time.time()
-                ilat, ilong, ialt = algo(x, y, z)
-                duration = time.time() - start
-                stats[name].append(duration)
-                print("algorithm %s took %.3f" % (name, duration))
-                print(
-                    "  avg",
-                    np.sqrt(np.sum((ilat - lat) ** 2)) / len(ilat),
-                    np.sqrt(np.sum((ilong - long) ** 2)) / len(ilong),
-                    np.sqrt(np.sum((ialt - alt) ** 2)) / len(ialt),
-                )
-                print(
-                    "  max",
-                    np.max(np.abs(ilat - lat)),
-                    np.max(np.abs(ilong - long)),
-                    np.max(np.abs(ialt - alt)),
-                )
-        for name, stat in stats.items():
-            print(name, ", ".join(["%.3f" % s for s in stat]))
-
-    perf_test()
-
-
 def detect_gps_timing_offset_from_gnfi(
     gps_timecodes: np.ndarray,
     gnfi_timecodes: np.ndarray,
@@ -531,8 +332,7 @@ def fix_gps_timing_gaps(
     3. Indirect detection: GPS ends ~65533ms after other channels, indicating
        the bug occurred during a GPS signal loss (hidden within a smaller gap)
 
-    The fix is applied in-place to the LogFile's channels dict and optionally
-    the laps table.
+    Returns a new LogFile with corrected timecodes (the original is not modified).
 
     Parameters
     ----------
@@ -553,7 +353,7 @@ def fix_gps_timing_gaps(
     Returns
     -------
     LogFile
-        The same LogFile object with corrected GPS timecodes (and optionally
+        A new LogFile with corrected GPS timecodes (and optionally
         lap boundaries).
     """
     # The firmware bug causes a gap of approximately 65533ms (0xFFED).
@@ -643,12 +443,13 @@ def fix_gps_timing_gaps(
 
     gps_time_fixed = gps_time_fixed.astype(np.int64)
 
-    # Update all GPS channels with corrected timecodes
+    # Build new channels dict with corrected GPS timecodes
+    new_channels = dict(log.channels)
     for name in GPS_CHANNEL_NAMES:
-        if name not in log.channels:
+        if name not in new_channels:
             continue
 
-        table = log.channels[name]
+        table = new_channels[name]
         value_column = table.column(name)
         field = table.schema.field(name)
         metadata = field.metadata
@@ -665,10 +466,11 @@ def fix_gps_timing_gaps(
             new_schema = pa.schema([new_table.schema.field("timecodes"), new_field])
             new_table = new_table.cast(new_schema)
 
-        log.channels[name] = new_table
+        new_channels[name] = new_table
 
     # Fix lap boundaries (start_time, end_time) only when laps came from
     # GPS-based detection (not LAP messages, which use the internal clock)
+    new_laps = log.laps
     if correct_laps and log.laps is not None and len(log.laps) > 0:
         start_times = log.laps.column("start_time").to_numpy().astype(np.float64)
         end_times = log.laps.column("end_time").to_numpy().astype(np.float64)
@@ -686,6 +488,13 @@ def fix_gps_timing_gaps(
             else:
                 new_laps_data[col_name] = log.laps.column(col_name)
 
-        log.laps = pa.table(new_laps_data)
+        new_laps = pa.table(new_laps_data)
 
-    return log
+    from .base import LogFile
+
+    return LogFile(
+        channels=new_channels,
+        laps=new_laps,
+        metadata=log.metadata,
+        file_name=log.file_name,
+    )

--- a/tests/test_gps_timing.py
+++ b/tests/test_gps_timing.py
@@ -139,7 +139,7 @@ class TestGpsTimingGapFix(unittest.TestCase):
         self.assertTrue(np.any(dt_before > 400), "Test setup: gap should exist before fix")
 
         # Apply the fix
-        fix_gps_timing_gaps(log)
+        log = fix_gps_timing_gaps(log)
 
         # Verify the gap is fixed
         gps_time_after = log.channels["GPS Speed"].column("timecodes").to_numpy()
@@ -151,7 +151,7 @@ class TestGpsTimingGapFix(unittest.TestCase):
     def test_fixes_all_gps_channels(self):
         """Test that all GPS channels are corrected together."""
         log = create_mock_log_with_gps_gap()
-        fix_gps_timing_gaps(log)
+        log = fix_gps_timing_gaps(log)
 
         # All GPS channels should have the same corrected timecodes
         reference_time = log.channels["GPS Speed"].column("timecodes").to_numpy()
@@ -166,7 +166,7 @@ class TestGpsTimingGapFix(unittest.TestCase):
     def test_preserves_channel_metadata(self):
         """Test that channel metadata is preserved after fix."""
         log = create_mock_log_with_gps_gap()
-        fix_gps_timing_gaps(log)
+        log = fix_gps_timing_gaps(log)
 
         # Check metadata is preserved
         speed_field = log.channels["GPS Speed"].schema.field("GPS Speed")
@@ -181,7 +181,7 @@ class TestGpsTimingGapFix(unittest.TestCase):
         # Store original values
         original_speed = log.channels["GPS Speed"].column("GPS Speed").to_numpy().copy()
 
-        fix_gps_timing_gaps(log)
+        log = fix_gps_timing_gaps(log)
 
         # Values should be unchanged
         fixed_speed = log.channels["GPS Speed"].column("GPS Speed").to_numpy()
@@ -194,7 +194,7 @@ class TestGpsTimingGapFix(unittest.TestCase):
         # Store original BRK timecodes
         original_brk_time = log.channels["BRK"].column("timecodes").to_numpy().copy()
 
-        fix_gps_timing_gaps(log)
+        log = fix_gps_timing_gaps(log)
 
         # BRK timecodes should be unchanged
         fixed_brk_time = log.channels["BRK"].column("timecodes").to_numpy()
@@ -207,7 +207,7 @@ class TestGpsTimingGapFix(unittest.TestCase):
         # Get original lap 3 start (which is after the gap at ~70000ms)
         original_lap3_start = log.laps.column("start_time").to_numpy()[2]
 
-        fix_gps_timing_gaps(log)
+        log = fix_gps_timing_gaps(log)
 
         # Lap 3 start should be shifted back by the gap correction
         fixed_lap3_start = log.laps.column("start_time").to_numpy()[2]
@@ -245,7 +245,7 @@ class TestGpsTimingGapFix(unittest.TestCase):
 
         original_time = log.channels["GPS Speed"].column("timecodes").to_numpy().copy()
 
-        fix_gps_timing_gaps(log)
+        log = fix_gps_timing_gaps(log)
 
         fixed_time = log.channels["GPS Speed"].column("timecodes").to_numpy()
         np.testing.assert_array_equal(original_time, fixed_time)
@@ -300,7 +300,7 @@ class TestGpsTimingGapFix(unittest.TestCase):
 
         log = LogFile(channels=channels, laps=laps, metadata={}, file_name="test.xrk")
 
-        fix_gps_timing_gaps(log)
+        log = fix_gps_timing_gaps(log)
 
         # Verify both gaps are fixed
         fixed_time = log.channels["GPS Speed"].column("timecodes").to_numpy()
@@ -325,11 +325,11 @@ class TestGpsTimingGapFix(unittest.TestCase):
         result = fix_gps_timing_gaps(log)
         self.assertIs(result, log)
 
-    def test_returns_same_log_object(self):
-        """Test that the function returns the same LogFile object (in-place modification)."""
+    def test_returns_new_log_object(self):
+        """Test that the function returns a new LogFile (immutable pattern)."""
         log = create_mock_log_with_gps_gap()
         result = fix_gps_timing_gaps(log)
-        self.assertIs(result, log)
+        self.assertIsNot(result, log)
 
 
 class TestGpsTimingGapFixIntegration(unittest.TestCase):
@@ -545,7 +545,7 @@ class TestGnfiBasedDetection(unittest.TestCase):
         self.assertTrue(np.any(dt_before > 400), "Test setup: gap should exist before fix")
 
         # Apply the fix WITHOUT GNFI (should fall back to heuristics)
-        fix_gps_timing_gaps(log, gnfi_timecodes=None)
+        log = fix_gps_timing_gaps(log, gnfi_timecodes=None)
 
         # Verify the gap is fixed
         gps_time_after = log.channels["GPS Speed"].column("timecodes").to_numpy()
@@ -579,7 +579,7 @@ class TestGnfiBasedDetection(unittest.TestCase):
         log = LogFile(channels=channels, laps=None, metadata={}, file_name="test.xrk")
 
         # Apply fix with GNFI
-        fix_gps_timing_gaps(log, gnfi_timecodes=gnfi_timecodes)
+        log = fix_gps_timing_gaps(log, gnfi_timecodes=gnfi_timecodes)
 
         # Verify the gap is fixed
         gps_time_fixed = log.channels["GPS Speed"].column("timecodes").to_numpy()


### PR DESCRIPTION
## Summary

Codebase cleanup driven by a multi-expert review and prioritization debate. Focuses on the highest-impact issues: a mutation trap in the GPS timing fix, Rust panics on malformed data, and accumulated dead code.

- **Fix GPS timing immutability violation**: `fix_gps_timing_gaps()` was mutating `LogFile` in-place while every other method returns new instances — a trap for any contributor who follows the established pattern. Now returns a new `LogFile` like everything else.
- **Fix Rust `unwrap()` panics**: 15+ `unwrap()` calls in parser.rs and gps/timing.rs replaced with proper error handling. Via PyO3, a Rust panic kills the entire Python process with an opaque `PanicException`.
- **Deduplicate Rust lap processing**: `get_laps()` and `get_processed_laps()` shared ~80 lines of nearly identical lap-parsing logic. Extracted shared `parse_lap_messages()` function.
- **Delete dead code from gps.py**: Removed ~170 lines of unused ECEF-to-LLA algorithms that were benchmarked, a winner chosen, and losers left behind.
- **Replace `assert` with `ValueError` in Cython parser**: 14 assertions used for data validation → proper exceptions that work under `python -O`.
- **Fix CLAUDE.md docs**: Corrected backend fallback claim and `rust/` → `crates/` references.

## Test plan

- [x] All 219 tests pass on Cython backend (`just test`)
- [x] All 219 tests pass on Rust backend (`LIBXRK_BACKEND=rust just test`)
- [x] GPS timing tests pass (`uv run pytest tests/test_gps_timing.py -v`) — 38/38
- [x] Black formatting clean
- [x] mypy clean
- [x] cargo clippy clean (no warnings)
- [x] Cross-backend parity verified (GPS timecodes, values, laps all match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)