### PR TITLE
feat: add strongly typed ChannelMetadata dataclass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ After modifying Rust source in `crates/`, run `just rust-build` (release) or `ju
 - Each channel is a PyArrow table with `timecodes` + value columns
 - Different channels have different sample rates
 - `get_channels_as_table()` merges via full outer join with interpolation/forward-fill
-- Channel metadata stored in PyArrow field.metadata (bytes keys: `b"units"`, `b"dec_pts"`, `b"interpolate"`, `b"function"`)
+- Channel metadata stored in PyArrow field.metadata; use `ChannelMetadata.from_field()` for typed access
 - GPS timing fix auto-corrects 65533ms gaps (AIM firmware bug)
 - All filtering/resampling methods return new `LogFile` instances (immutable pattern)
 - `resample_to_timecodes()` is the core resampling logic, other methods delegate to it

--- a/README.md
+++ b/README.md
@@ -110,6 +110,33 @@ df = (log
 
 All filtering and resampling methods return new `LogFile` instances (immutable pattern), enabling method chaining for complex analysis workflows.
 
+### Channel Metadata
+
+Each channel carries typed metadata accessible via `ChannelMetadata`:
+
+```python
+from libxrk import aim_xrk, ChannelMetadata
+
+log = aim_xrk('session.xrk')
+
+# Extract typed metadata from a channel
+meta = ChannelMetadata.from_channel_table(log.channels['Engine RPM'])
+print(meta.units)        # "rpm"
+print(meta.dec_pts)      # 0
+print(meta.interpolate)  # True
+print(meta.function)     # "Engine RPM"
+
+# Or from a PyArrow field directly
+field = log.channels['Engine RPM'].schema.field('Engine RPM')
+meta = ChannelMetadata.from_field(field)
+
+# Create metadata for custom channels
+meta = ChannelMetadata(units="m/s", dec_pts=1, interpolate=True)
+field = pa.field("speed", pa.float32(), metadata=meta.to_field_metadata())
+```
+
+Available fields: `units`, `dec_pts`, `interpolate`, `function`, `source_type`, `source_channel_id`, `device_tag`, `cal_value_1`, `cal_value_2`, `display_range_min`, `display_range_max`.
+
 ## Development
 
 ### Quick Check

--- a/crates/libxrk-python/Cargo.toml
+++ b/crates/libxrk-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libxrk-python"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 publish = false
 

--- a/crates/libxrk-python/src/lib.rs
+++ b/crates/libxrk-python/src/lib.rs
@@ -212,7 +212,7 @@ fn aim_xrk(py: Python<'_>, fname: Py<PyAny>, progress: Option<Py<PyAny>>) -> PyR
 
     // Build GPS Arrow tables after lap detection (consumes gps_result by value)
     if let Some(gps) = gps_result {
-        let gps_batches = libxrk::arrow::build_gps_channel_batches(gps)
+        let gps_batches = libxrk::arrow::build_gps_channel_batches(gps, arrow_bridge::format_float)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
         for (name, batch) in gps_batches {
             let py_batch = arrow_bridge::batch_to_pyarrow(py, batch)?;

--- a/crates/libxrk/src/arrow.rs
+++ b/crates/libxrk/src/arrow.rs
@@ -18,21 +18,21 @@ use crate::parser::{ChannelData, ChannelInfo, ChannelValues, ProcessedLap};
 /// Channel metadata keys used in Arrow field metadata.
 pub struct ChannelMetadata {
     pub units: String,
-    pub dec_pts: String,
-    pub interpolate: String,
+    pub dec_pts: u8,
+    pub interpolate: bool,
     pub function: String,
-    pub source_type: String,
-    pub source_channel_id: String,
+    pub source_type: u8,
+    pub source_channel_id: u16,
     pub device_tag: String,
-    pub cal_value_1: String,
-    pub cal_value_2: String,
-    pub display_range_min: String,
-    pub display_range_max: String,
+    pub cal_value_1: f32,
+    pub cal_value_2: f32,
+    pub display_range_min: f32,
+    pub display_range_max: f32,
 }
 
 impl ChannelMetadata {
-    /// Build metadata from a ChannelInfo, using a formatter for f32 values.
-    pub fn from_channel_info(ch_info: &ChannelInfo, format_f32: impl Fn(f32) -> String) -> Self {
+    /// Build metadata from a ChannelInfo.
+    pub fn from_channel_info(ch_info: &ChannelInfo) -> Self {
         let chs = &ch_info.chs;
         let units = if chs.data_size == 1 {
             "".to_string()
@@ -41,41 +41,44 @@ impl ChannelMetadata {
         };
         ChannelMetadata {
             units,
-            dec_pts: chs.dec_pts().to_string(),
-            interpolate: if chs.interpolate() { "True" } else { "False" }.to_string(),
+            dec_pts: chs.dec_pts(),
+            interpolate: chs.interpolate(),
             function: chs.function().to_string(),
-            source_type: chs.source_type.to_string(),
-            source_channel_id: chs.source_channel_id.to_string(),
+            source_type: chs.source_type,
+            source_channel_id: chs.source_channel_id,
             device_tag: chs.device_tag(),
-            cal_value_1: format_f32(chs.cal_value_1),
-            cal_value_2: format_f32(chs.cal_value_2),
-            display_range_min: format_f32(chs.display_range_min),
-            display_range_max: format_f32(chs.display_range_max),
+            cal_value_1: chs.cal_value_1,
+            cal_value_2: chs.cal_value_2,
+            display_range_min: chs.display_range_min,
+            display_range_max: chs.display_range_max,
         }
     }
 
     /// Convert to a HashMap suitable for Arrow field metadata.
-    pub fn to_hashmap(&self) -> HashMap<String, String> {
+    pub fn to_hashmap(&self, format_f32: impl Fn(f32) -> String) -> HashMap<String, String> {
         let mut m = HashMap::new();
         m.insert("units".to_string(), self.units.clone());
-        m.insert("dec_pts".to_string(), self.dec_pts.clone());
-        m.insert("interpolate".to_string(), self.interpolate.clone());
+        m.insert("dec_pts".to_string(), self.dec_pts.to_string());
+        m.insert(
+            "interpolate".to_string(),
+            if self.interpolate { "True" } else { "False" }.to_string(),
+        );
         m.insert("function".to_string(), self.function.clone());
-        m.insert("source_type".to_string(), self.source_type.clone());
+        m.insert("source_type".to_string(), self.source_type.to_string());
         m.insert(
             "source_channel_id".to_string(),
-            self.source_channel_id.clone(),
+            self.source_channel_id.to_string(),
         );
         m.insert("device_tag".to_string(), self.device_tag.clone());
-        m.insert("cal_value_1".to_string(), self.cal_value_1.clone());
-        m.insert("cal_value_2".to_string(), self.cal_value_2.clone());
+        m.insert("cal_value_1".to_string(), format_f32(self.cal_value_1));
+        m.insert("cal_value_2".to_string(), format_f32(self.cal_value_2));
         m.insert(
             "display_range_min".to_string(),
-            self.display_range_min.clone(),
+            format_f32(self.display_range_min),
         );
         m.insert(
             "display_range_max".to_string(),
-            self.display_range_max.clone(),
+            format_f32(self.display_range_max),
         );
         m
     }
@@ -84,16 +87,16 @@ impl ChannelMetadata {
     pub fn for_gps_channel(def: &GpsChannelDef) -> Self {
         ChannelMetadata {
             units: def.units.to_string(),
-            dec_pts: def.dec_pts.to_string(),
-            interpolate: if def.interpolate { "True" } else { "False" }.to_string(),
+            dec_pts: def.dec_pts as u8,
+            interpolate: def.interpolate,
             function: "".to_string(),
-            source_type: "0".to_string(),
-            source_channel_id: "0".to_string(),
+            source_type: 0,
+            source_channel_id: 0,
             device_tag: "".to_string(),
-            cal_value_1: "0.0".to_string(),
-            cal_value_2: "1.0".to_string(),
-            display_range_min: "0.0".to_string(),
-            display_range_max: "0.0".to_string(),
+            cal_value_1: 0.0,
+            cal_value_2: 1.0,
+            display_range_min: 0.0,
+            display_range_max: 0.0,
         }
     }
 }
@@ -140,7 +143,7 @@ pub fn build_all_channel_batches(
     for (ch_idx, ch_data) in channel_data.into_iter() {
         if let Some(ch_info) = channels.get(&ch_idx) {
             let name = ch_info.chs.long_name();
-            let metadata = ChannelMetadata::from_channel_info(ch_info, &format_f32).to_hashmap();
+            let metadata = ChannelMetadata::from_channel_info(ch_info).to_hashmap(&format_f32);
             let batch = build_channel_batch(&name, ch_data, metadata)?;
             batches.push((name, batch));
         }
@@ -180,8 +183,9 @@ fn build_gps_channel_batch(
     timecodes: Vec<i64>,
     values_f64: Option<Vec<f64>>,
     values_f32: Option<Vec<f32>>,
+    format_f32: &impl Fn(f32) -> String,
 ) -> arrow::error::Result<RecordBatch> {
-    let metadata = ChannelMetadata::for_gps_channel(def).to_hashmap();
+    let metadata = ChannelMetadata::for_gps_channel(def).to_hashmap(format_f32);
     let tc_array = Int64Array::from(timecodes);
 
     if def.is_f64 {
@@ -206,6 +210,7 @@ fn build_gps_channel_batch(
 /// Returns a Vec of (channel_name, RecordBatch) pairs.
 pub fn build_gps_channel_batches(
     gps: GpsDecodeResult,
+    format_f32: impl Fn(f32) -> String,
 ) -> arrow::error::Result<Vec<(String, RecordBatch)>> {
     let mut batches = Vec::with_capacity(12);
 
@@ -242,10 +247,10 @@ pub fn build_gps_channel_batches(
         let tc = timecodes.clone();
         let batch = if def.is_f64 {
             let vals = f64_channels.next().unwrap();
-            build_gps_channel_batch(def.name, def, tc, Some(vals), None)?
+            build_gps_channel_batch(def.name, def, tc, Some(vals), None, &format_f32)?
         } else {
             let vals = f32_channels.next().unwrap();
-            build_gps_channel_batch(def.name, def, tc, None, Some(vals))?
+            build_gps_channel_batch(def.name, def, tc, None, Some(vals), &format_f32)?
         };
         batches.push((def.name.to_string(), batch));
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libxrk"
-version = "0.10.1"
+version = "0.11.0"
 description = "Library for reading AIM XRK files from AIM automotive data loggers"
 authors = [
     {name = "Christopher Dewan",email = "chris.dewan@m3rlin.net"}

--- a/src/libxrk/CLAUDE.md
+++ b/src/libxrk/CLAUDE.md
@@ -64,15 +64,49 @@ Channels have different sample rates. Use `get_channels_as_table()` to merge.
 
 ## Channel Metadata
 
+Use the `ChannelMetadata` dataclass for typed access to channel metadata:
+
 ```python
-field = log.channels['Engine RPM'].schema.field('Engine RPM')
-units = field.metadata.get(b'units', b'').decode()  # e.g., "rpm"
-function = field.metadata.get(b'function', b'').decode()  # e.g., "Engine RPM"
+from libxrk import ChannelMetadata
+
+meta = ChannelMetadata.from_channel_table(log.channels['Engine RPM'])
+meta.units        # "rpm"
+meta.dec_pts      # 0
+meta.interpolate  # True
+meta.function     # "Engine RPM"
 ```
 
-Keys: `b"units"`, `b"dec_pts"`, `b"interpolate"`, `b"function"`, `b"source_type"`, `b"source_channel_id"`, `b"device_tag"`, `b"cal_value_1"`, `b"cal_value_2"`, `b"display_range_min"`, `b"display_range_max"`
+Or extract from a PyArrow field directly:
 
-The `b"function"` key contains the RS3 channel function classification (e.g., "Temperature", "Engine RPM", "Lateral Acceleration"). This is a best-effort lookup derived from `(maybe_display_format, unit_type_byte, config_flags)` in the CHS binary. Empty string for GPS-derived channels and unrecognized combinations.
+```python
+field = log.channels['Engine RPM'].schema.field('Engine RPM')
+meta = ChannelMetadata.from_field(field)
+```
+
+To create metadata for new channels:
+
+```python
+meta = ChannelMetadata(units="m/s", dec_pts=1, interpolate=True)
+field = pa.field("speed", pa.float32(), metadata=meta.to_field_metadata())
+```
+
+### ChannelMetadata Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `units` | str | `""` | Unit string (e.g., "rpm", "m/s") |
+| `dec_pts` | int | `0` | Display decimal places |
+| `interpolate` | bool | `False` | Linear interpolation when resampling |
+| `function` | str | `""` | RS3 function classification |
+| `source_type` | int | `0` | Source type (1=internal, 5=GPS, 9=CAN) |
+| `source_channel_id` | int | `0` | Channel ID within device |
+| `device_tag` | str | `""` | Device identifier (e.g., "@AIM") |
+| `cal_value_1` | float | `0.0` | Calibration offset |
+| `cal_value_2` | float | `1.0` | Calibration scale |
+| `display_range_min` | float | `0.0` | Min display range |
+| `display_range_max` | float | `0.0` | Max display range |
+
+The `function` field contains the RS3 channel function classification (e.g., "Temperature", "Engine RPM", "Lateral Acceleration"). This is a best-effort lookup derived from `(maybe_display_format, unit_type_byte, config_flags)` in the CHS binary. Empty string for GPS-derived channels and unrecognized combinations.
 
 ## LogFile Methods
 

--- a/src/libxrk/__init__.py
+++ b/src/libxrk/__init__.py
@@ -30,12 +30,13 @@ if _backend == "rust":
 else:
     from .aim_xrk import aim_xrk, aim_track_dbg
 
-from .base import LogFile
+from .base import ChannelMetadata, LogFile
 from .gps import GPS_CHANNEL_NAMES
 
 __all__ = [
     "aim_xrk",
     "aim_track_dbg",
+    "ChannelMetadata",
     "LogFile",
     "GPS_CHANNEL_NAMES",
 ]

--- a/src/libxrk/aim_xrk.pyx
+++ b/src/libxrk/aim_xrk.pyx
@@ -1220,19 +1220,20 @@ def _get_laps(lat_ch, lon_ch, msg_by_type, time_offset, last_time):
 def _channel_to_table(ch):
     """Convert a Channel object to a PyArrow table with metadata."""
     # Create metadata dict for the channel data field (without name, as it's the column name)
-    metadata = {
-        b'units': (ch.units if ch.size != 1 else '').encode('utf-8'),
-        b'dec_pts': str(ch.dec_pts).encode('utf-8'),
-        b'interpolate': str(ch.interpolate).encode('utf-8'),
-        b'function': ch.function.encode('utf-8'),
-        b'source_type': str(ch.source_type).encode('utf-8'),
-        b'source_channel_id': str(ch.source_channel_id).encode('utf-8'),
-        b'device_tag': ch.device_tag.encode('utf-8'),
-        b'cal_value_1': str(ch.cal_value_1).encode('utf-8'),
-        b'cal_value_2': str(ch.cal_value_2).encode('utf-8'),
-        b'display_range_min': str(ch.display_range_min).encode('utf-8'),
-        b'display_range_max': str(ch.display_range_max).encode('utf-8'),
-    }
+    meta = base.ChannelMetadata(
+        units=ch.units if ch.size != 1 else '',
+        dec_pts=ch.dec_pts,
+        interpolate=ch.interpolate,
+        function=ch.function,
+        source_type=ch.source_type,
+        source_channel_id=ch.source_channel_id,
+        device_tag=ch.device_tag,
+        cal_value_1=ch.cal_value_1,
+        cal_value_2=ch.cal_value_2,
+        display_range_min=ch.display_range_min,
+        display_range_max=ch.display_range_max,
+    )
+    metadata = meta.to_field_metadata()
     
     # Determine the appropriate type for values based on the data
     if isinstance(ch.sampledata, memoryview):

--- a/src/libxrk/base.py
+++ b/src/libxrk/base.py
@@ -15,6 +15,114 @@ import numpy as np
 assert sys.byteorder == "little"
 
 
+@dataclass(frozen=True)
+class ChannelMetadata:
+    """Typed metadata for a telemetry channel.
+
+    Provides typed access to channel metadata stored in PyArrow field metadata.
+    Use ``from_field()`` or ``from_channel_table()`` to extract metadata, and
+    ``to_field_metadata()`` to serialize back to PyArrow format.
+
+    Attributes:
+        units: Unit string (e.g., "rpm", "m/s"). Empty for single-byte channels.
+        dec_pts: Display decimal places.
+        interpolate: Whether to use linear interpolation when resampling.
+        function: RS3 function classification (e.g., "Engine RPM").
+        source_type: Source type (1=internal, 5=GPS, 9=CAN).
+        source_channel_id: Channel ID within the device.
+        device_tag: Device identifier (e.g., "@AIM").
+        cal_value_1: Calibration offset.
+        cal_value_2: Calibration scale.
+        display_range_min: Minimum display range.
+        display_range_max: Maximum display range.
+
+    Example:
+        >>> field = log.channels['Engine RPM'].schema.field('Engine RPM')
+        >>> meta = ChannelMetadata.from_field(field)
+        >>> meta.units
+        'rpm'
+        >>> meta.interpolate
+        True
+    """
+
+    units: str = ""
+    dec_pts: int = 0
+    interpolate: bool = False
+    function: str = ""
+    source_type: int = 0
+    source_channel_id: int = 0
+    device_tag: str = ""
+    cal_value_1: float = 0.0
+    cal_value_2: float = 1.0
+    display_range_min: float = 0.0
+    display_range_max: float = 0.0
+
+    @classmethod
+    def from_field(cls, field: pa.Field) -> "ChannelMetadata":
+        """Extract typed metadata from a PyArrow field.
+
+        Args:
+            field: A PyArrow field with metadata dict.
+
+        Returns:
+            ChannelMetadata with decoded and typed values.
+        """
+        m = field.metadata or {}
+        return cls(
+            units=m.get(b"units", b"").decode(),
+            dec_pts=int(m.get(b"dec_pts", b"0").decode() or "0"),
+            interpolate=m.get(b"interpolate", b"").decode() == "True",
+            function=m.get(b"function", b"").decode(),
+            source_type=int(m.get(b"source_type", b"0").decode() or "0"),
+            source_channel_id=int(m.get(b"source_channel_id", b"0").decode() or "0"),
+            device_tag=m.get(b"device_tag", b"").decode(),
+            cal_value_1=float(m.get(b"cal_value_1", b"0.0").decode() or "0.0"),
+            cal_value_2=float(m.get(b"cal_value_2", b"1.0").decode() or "1.0"),
+            display_range_min=float(m.get(b"display_range_min", b"0.0").decode() or "0.0"),
+            display_range_max=float(m.get(b"display_range_max", b"0.0").decode() or "0.0"),
+        )
+
+    @classmethod
+    def from_channel_table(cls, table: pa.Table) -> "ChannelMetadata":
+        """Extract typed metadata from a channel table.
+
+        Channel tables have exactly two columns: ``timecodes`` and the value
+        column.  This method finds the non-timecodes field and reads its
+        metadata.
+
+        Args:
+            table: A PyArrow table with ``timecodes`` + one value column.
+
+        Returns:
+            ChannelMetadata with decoded and typed values.
+        """
+        for i in range(table.schema.__len__()):
+            field = table.schema.field(i)
+            if field.name != "timecodes":
+                return cls.from_field(field)
+        return cls()
+
+    def to_field_metadata(self) -> dict[bytes, bytes]:
+        """Pack into PyArrow field metadata format.
+
+        Returns:
+            Dict with bytes keys and bytes values suitable for ``pa.Field.with_metadata()``.
+        """
+        return {
+            b"units": self.units.encode(),
+            b"dec_pts": str(self.dec_pts).encode(),
+            b"interpolate": str(self.interpolate).encode(),
+            b"function": self.function.encode(),
+            b"source_type": str(self.source_type).encode(),
+            b"source_channel_id": str(self.source_channel_id).encode(),
+            b"device_tag": self.device_tag.encode(),
+            b"cal_value_1": str(self.cal_value_1).encode(),
+            b"cal_value_2": str(self.cal_value_2).encode(),
+            b"display_range_min": str(self.display_range_min).encode(),
+            b"display_range_max": str(self.display_range_max).encode(),
+        }
+
+
 @dataclass(eq=False)
 class LogFile:
     """
@@ -72,11 +180,9 @@ class LogFile:
         channel_names = sorted(resampled.channels.keys())
 
         # Collect metadata for restoration
-        channel_metadata = {}
+        channel_metadata: dict[str, ChannelMetadata] = {}
         for name in channel_names:
-            field = resampled.channels[name].schema.field(name)
-            if field.metadata:
-                channel_metadata[name] = field.metadata
+            channel_metadata[name] = ChannelMetadata.from_channel_table(resampled.channels[name])
 
         # Build the result table
         columns_dict = {"timecodes": union_timecodes}
@@ -86,15 +192,16 @@ class LogFile:
         result = pa.table(columns_dict)
 
         # Restore schema with metadata
-        if channel_metadata:
-            new_fields = []
-            for field in result.schema:
-                if field.name in channel_metadata:
-                    new_fields.append(field.with_metadata(channel_metadata[field.name]))
-                else:
-                    new_fields.append(field)
-            new_schema = pa.schema(new_fields)
-            result = result.cast(new_schema)
+        new_fields = []
+        for field in result.schema:
+            if field.name in channel_metadata:
+                new_fields.append(
+                    field.with_metadata(channel_metadata[field.name].to_field_metadata())
+                )
+            else:
+                new_fields.append(field)
+        new_schema = pa.schema(new_fields)
+        result = result.cast(new_schema)
 
         return result
 
@@ -244,14 +351,11 @@ class LogFile:
 
         for name, channel_table in source.channels.items():
             field = channel_table.schema.field(name)
+            meta = ChannelMetadata.from_field(field)
             channel_timecodes = channel_table.column("timecodes").to_numpy()
             channel_values = channel_table.column(name).to_numpy(zero_copy_only=False)
 
-            # Check if we should interpolate
-            should_interpolate = False
-            if field.metadata:
-                interpolate_value = field.metadata.get(b"interpolate", b"").decode("utf-8")
-                should_interpolate = interpolate_value == "True"
+            should_interpolate = meta.interpolate
 
             if should_interpolate:
                 # Linear interpolation using numpy
@@ -294,10 +398,10 @@ class LogFile:
             )
 
             # Restore metadata
-            if field.metadata:
-                new_field = new_table.schema.field(name).with_metadata(field.metadata)
-                new_schema = pa.schema([new_table.schema.field("timecodes"), new_field])
-                new_table = new_table.cast(new_schema)
+            metadata = meta.to_field_metadata()
+            new_field = new_table.schema.field(name).with_metadata(metadata)
+            new_schema = pa.schema([new_table.schema.field("timecodes"), new_field])
+            new_table = new_table.cast(new_schema)
 
             new_channels[name] = new_table
 

--- a/src/libxrk/gps.py
+++ b/src/libxrk/gps.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pyarrow as pa
 
+from .base import ChannelMetadata
+
 if TYPE_CHECKING:
     from .base import LogFile
 
@@ -452,7 +454,7 @@ def fix_gps_timing_gaps(
         table = new_channels[name]
         value_column = table.column(name)
         field = table.schema.field(name)
-        metadata = field.metadata
+        meta = ChannelMetadata.from_field(field)
 
         new_table = pa.table(
             {
@@ -461,10 +463,10 @@ def fix_gps_timing_gaps(
             }
         )
 
-        if metadata:
-            new_field = new_table.schema.field(name).with_metadata(metadata)
-            new_schema = pa.schema([new_table.schema.field("timecodes"), new_field])
-            new_table = new_table.cast(new_schema)
+        metadata = meta.to_field_metadata()
+        new_field = new_table.schema.field(name).with_metadata(metadata)
+        new_schema = pa.schema([new_table.schema.field("timecodes"), new_field])
+        new_table = new_table.cast(new_schema)
 
         new_channels[name] = new_table
 

--- a/tests/test_86_xrk.py
+++ b/tests/test_86_xrk.py
@@ -9,7 +9,7 @@ import pyarrow as pa
 from parameterized import parameterized
 
 from libxrk import aim_xrk
-from libxrk.base import LogFile
+from libxrk.base import ChannelMetadata, LogFile
 
 
 # Path to test data
@@ -711,22 +711,17 @@ class Test86XRK(unittest.TestCase):
 
         for channel_name, expected_units, expected_dec_pts, expected_interpolate in test_cases:
             self.assertIn(channel_name, log.channels, f"Channel '{channel_name}' not found")
-            channel_table = log.channels[channel_name]
-            schema = channel_table.schema
-            data_field = schema.field(channel_name)
-            metadata = data_field.metadata or {}
+            meta = ChannelMetadata.from_channel_table(log.channels[channel_name])
 
-            units = metadata.get(b"units", b"").decode("utf-8")
-            dec_pts = metadata.get(b"dec_pts", b"").decode("utf-8")
-            interpolate = metadata.get(b"interpolate", b"").decode("utf-8")
-
-            self.assertEqual(units, expected_units, f"Channel '{channel_name}' units mismatch")
+            self.assertEqual(meta.units, expected_units, f"Channel '{channel_name}' units mismatch")
             self.assertEqual(
-                dec_pts, expected_dec_pts, f"Channel '{channel_name}' dec_pts mismatch"
+                meta.dec_pts,
+                int(expected_dec_pts),
+                f"Channel '{channel_name}' dec_pts mismatch",
             )
             self.assertEqual(
-                interpolate,
-                expected_interpolate,
+                meta.interpolate,
+                expected_interpolate == "True",
                 f"Channel '{channel_name}' interpolate mismatch",
             )
 
@@ -782,14 +777,11 @@ class Test86XRK(unittest.TestCase):
 
         for channel_name, expected_function in test_cases:
             self.assertIn(channel_name, log.channels, f"Channel '{channel_name}' not found")
-            channel_table = log.channels[channel_name]
-            data_field = channel_table.schema.field(channel_name)
-            metadata = data_field.metadata or {}
-            function = metadata.get(b"function", b"").decode("utf-8")
+            meta = ChannelMetadata.from_channel_table(log.channels[channel_name])
             self.assertEqual(
-                function,
+                meta.function,
                 expected_function,
-                f"Channel '{channel_name}' function: got {function!r}, expected {expected_function!r}",
+                f"Channel '{channel_name}' function: got {meta.function!r}, expected {expected_function!r}",
             )
 
 
@@ -901,15 +893,20 @@ class Test86CrossBackend(unittest.TestCase):
     def test_channel_metadata_match(self) -> None:
         """Channel metadata (units, dec_pts, interpolate, function) should match between backends."""
         for name in self.rust_log.channels:
-            rust_meta = self.rust_log.channels[name].schema.field(name).metadata or {}
-            cython_meta = self.cython_log.channels[name].schema.field(name).metadata or {}
-            for key in (b"units", b"dec_pts", b"interpolate", b"function"):
-                self.assertEqual(
-                    rust_meta.get(key),
-                    cython_meta.get(key),
-                    f"Channel {name!r} metadata {key!r}: "
-                    f"rust={rust_meta.get(key)!r} != cython={cython_meta.get(key)!r}",
-                )
+            rust_meta = ChannelMetadata.from_channel_table(self.rust_log.channels[name])
+            cython_meta = ChannelMetadata.from_channel_table(self.cython_log.channels[name])
+            self.assertEqual(rust_meta.units, cython_meta.units, f"Channel {name!r} units mismatch")
+            self.assertEqual(
+                rust_meta.dec_pts, cython_meta.dec_pts, f"Channel {name!r} dec_pts mismatch"
+            )
+            self.assertEqual(
+                rust_meta.interpolate,
+                cython_meta.interpolate,
+                f"Channel {name!r} interpolate mismatch",
+            )
+            self.assertEqual(
+                rust_meta.function, cython_meta.function, f"Channel {name!r} function mismatch"
+            )
 
     def test_expansion_device_metadata_match(self) -> None:
         """Expansion device metadata should match between backends."""

--- a/tests/test_aim_official_xrk.py
+++ b/tests/test_aim_official_xrk.py
@@ -14,7 +14,7 @@ from typing import ClassVar
 import numpy as np
 
 from libxrk import aim_xrk
-from libxrk.base import LogFile
+from libxrk.base import ChannelMetadata, LogFile
 
 
 # Path to test data
@@ -213,15 +213,17 @@ class TestAIMOfficialCrossBackend(unittest.TestCase):
     def test_channel_metadata_match(self) -> None:
         """Channel metadata (units, dec_pts, interpolate) should match between backends."""
         for name in self.rust_log.channels:
-            rust_meta = self.rust_log.channels[name].schema.field(name).metadata or {}
-            cython_meta = self.cython_log.channels[name].schema.field(name).metadata or {}
-            for key in (b"units", b"dec_pts", b"interpolate"):
-                self.assertEqual(
-                    rust_meta.get(key),
-                    cython_meta.get(key),
-                    f"Channel {name!r} metadata {key!r}: "
-                    f"rust={rust_meta.get(key)!r} != cython={cython_meta.get(key)!r}",
-                )
+            rust_meta = ChannelMetadata.from_channel_table(self.rust_log.channels[name])
+            cython_meta = ChannelMetadata.from_channel_table(self.cython_log.channels[name])
+            self.assertEqual(rust_meta.units, cython_meta.units, f"Channel {name!r} units mismatch")
+            self.assertEqual(
+                rust_meta.dec_pts, cython_meta.dec_pts, f"Channel {name!r} dec_pts mismatch"
+            )
+            self.assertEqual(
+                rust_meta.interpolate,
+                cython_meta.interpolate,
+                f"Channel {name!r} interpolate mismatch",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_channel_metadata.py
+++ b/tests/test_channel_metadata.py
@@ -1,0 +1,264 @@
+"""Unit tests for ChannelMetadata dataclass."""
+
+import unittest
+
+import pyarrow as pa
+
+from libxrk.base import ChannelMetadata, LogFile
+
+
+class TestChannelMetadataRoundtrip(unittest.TestCase):
+    """Tests for ChannelMetadata serialization roundtrips."""
+
+    def test_roundtrip_all_fields(self):
+        """Construct → to_field_metadata() → attach to field → from_field() → equal."""
+        original = ChannelMetadata(
+            units="rpm",
+            dec_pts=2,
+            interpolate=True,
+            function="Engine RPM",
+            source_type=1,
+            source_channel_id=42,
+            device_tag="@AIM",
+            cal_value_1=0.5,
+            cal_value_2=2.0,
+            display_range_min=-100.0,
+            display_range_max=10000.0,
+        )
+
+        field = pa.field("test", pa.float32(), metadata=original.to_field_metadata())
+        restored = ChannelMetadata.from_field(field)
+
+        self.assertEqual(restored, original)
+
+    def test_defaults_roundtrip(self):
+        """Default ChannelMetadata should roundtrip correctly."""
+        original = ChannelMetadata()
+
+        field = pa.field("test", pa.float32(), metadata=original.to_field_metadata())
+        restored = ChannelMetadata.from_field(field)
+
+        self.assertEqual(restored, original)
+
+    def test_interpolate_true_roundtrip(self):
+        """interpolate=True should serialize as 'True' and roundtrip."""
+        meta = ChannelMetadata(interpolate=True)
+        raw = meta.to_field_metadata()
+        self.assertEqual(raw[b"interpolate"], b"True")
+
+        field = pa.field("test", pa.float32(), metadata=raw)
+        restored = ChannelMetadata.from_field(field)
+        self.assertTrue(restored.interpolate)
+
+    def test_interpolate_false_roundtrip(self):
+        """interpolate=False should serialize as 'False' and roundtrip."""
+        meta = ChannelMetadata(interpolate=False)
+        raw = meta.to_field_metadata()
+        self.assertEqual(raw[b"interpolate"], b"False")
+
+        field = pa.field("test", pa.float32(), metadata=raw)
+        restored = ChannelMetadata.from_field(field)
+        self.assertFalse(restored.interpolate)
+
+
+class TestChannelMetadataFromField(unittest.TestCase):
+    """Tests for ChannelMetadata.from_field() and from_channel_table()."""
+
+    def test_from_field_missing_metadata(self):
+        """from_field with no metadata should return defaults."""
+        field = pa.field("test", pa.float32())
+        meta = ChannelMetadata.from_field(field)
+
+        self.assertEqual(meta, ChannelMetadata())
+
+    def test_from_field_partial_metadata(self):
+        """from_field with only some keys should fill defaults for the rest."""
+        field = pa.field("test", pa.float32(), metadata={b"units": b"rpm", b"dec_pts": b"3"})
+        meta = ChannelMetadata.from_field(field)
+
+        self.assertEqual(meta.units, "rpm")
+        self.assertEqual(meta.dec_pts, 3)
+        self.assertFalse(meta.interpolate)
+        self.assertEqual(meta.function, "")
+        self.assertEqual(meta.cal_value_2, 1.0)
+
+    def test_from_field_empty_string_values(self):
+        """from_field should handle empty string values for numeric fields."""
+        field = pa.field(
+            "test",
+            pa.float32(),
+            metadata={b"dec_pts": b"", b"source_type": b"", b"cal_value_1": b""},
+        )
+        meta = ChannelMetadata.from_field(field)
+
+        self.assertEqual(meta.dec_pts, 0)
+        self.assertEqual(meta.source_type, 0)
+        self.assertEqual(meta.cal_value_1, 0.0)
+
+    def test_from_channel_table(self):
+        """ChannelMetadata.from_channel_table extracts metadata from a table."""
+        meta = ChannelMetadata(units="m/s", dec_pts=1, interpolate=True)
+        table = pa.table(
+            {
+                "timecodes": pa.array([0, 100], type=pa.int64()),
+                "speed": pa.array([1.0, 2.0], type=pa.float32()),
+            }
+        )
+        field = table.schema.field("speed").with_metadata(meta.to_field_metadata())
+        table = table.cast(pa.schema([table.schema.field("timecodes"), field]))
+
+        restored = ChannelMetadata.from_channel_table(table)
+
+        self.assertEqual(restored.units, "m/s")
+        self.assertEqual(restored.dec_pts, 1)
+        self.assertTrue(restored.interpolate)
+
+
+class TestChannelMetadataToFieldMetadata(unittest.TestCase):
+    """Tests for ChannelMetadata.to_field_metadata() serialization."""
+
+    def test_all_keys_present(self):
+        """to_field_metadata should include all 11 metadata keys."""
+        meta = ChannelMetadata()
+        raw = meta.to_field_metadata()
+
+        expected_keys = {
+            b"units",
+            b"dec_pts",
+            b"interpolate",
+            b"function",
+            b"source_type",
+            b"source_channel_id",
+            b"device_tag",
+            b"cal_value_1",
+            b"cal_value_2",
+            b"display_range_min",
+            b"display_range_max",
+        }
+        self.assertEqual(set(raw.keys()), expected_keys)
+
+    def test_all_values_are_bytes(self):
+        """to_field_metadata should produce all bytes keys and values."""
+        meta = ChannelMetadata(
+            units="rpm", dec_pts=2, interpolate=True, source_type=5, cal_value_1=1.5
+        )
+        raw = meta.to_field_metadata()
+
+        for key, value in raw.items():
+            self.assertIsInstance(key, bytes, f"Key {key!r} is not bytes")
+            self.assertIsInstance(value, bytes, f"Value for {key!r} is not bytes")
+
+
+class TestChannelMetadataProperties(unittest.TestCase):
+    """Tests for ChannelMetadata dataclass properties."""
+
+    def test_frozen(self):
+        """ChannelMetadata should be immutable."""
+        meta = ChannelMetadata(units="rpm")
+        with self.assertRaises(AttributeError):
+            meta.units = "m/s"  # type: ignore[misc]
+
+    def test_equality(self):
+        """Two ChannelMetadata with same fields should be equal."""
+        a = ChannelMetadata(units="rpm", dec_pts=2, interpolate=True)
+        b = ChannelMetadata(units="rpm", dec_pts=2, interpolate=True)
+        self.assertEqual(a, b)
+
+    def test_inequality(self):
+        """Two ChannelMetadata with different fields should not be equal."""
+        a = ChannelMetadata(units="rpm")
+        b = ChannelMetadata(units="m/s")
+        self.assertNotEqual(a, b)
+
+    def test_default_values(self):
+        """Default ChannelMetadata should have expected defaults."""
+        meta = ChannelMetadata()
+        self.assertEqual(meta.units, "")
+        self.assertEqual(meta.dec_pts, 0)
+        self.assertFalse(meta.interpolate)
+        self.assertEqual(meta.function, "")
+        self.assertEqual(meta.source_type, 0)
+        self.assertEqual(meta.source_channel_id, 0)
+        self.assertEqual(meta.device_tag, "")
+        self.assertEqual(meta.cal_value_1, 0.0)
+        self.assertEqual(meta.cal_value_2, 1.0)
+        self.assertEqual(meta.display_range_min, 0.0)
+        self.assertEqual(meta.display_range_max, 0.0)
+
+
+class TestChannelMetadataPreservation(unittest.TestCase):
+    """Tests that ChannelMetadata survives LogFile operations."""
+
+    def _make_channel(self, name: str, meta: ChannelMetadata) -> pa.Table:
+        table = pa.table(
+            {
+                "timecodes": pa.array([0, 100, 200], type=pa.int64()),
+                name: pa.array([1.0, 2.0, 3.0], type=pa.float32()),
+            }
+        )
+        field = table.schema.field(name).with_metadata(meta.to_field_metadata())
+        return table.cast(pa.schema([table.schema.field("timecodes"), field]))
+
+    def _make_log(self, channels: dict[str, pa.Table]) -> LogFile:
+        return LogFile(
+            channels=channels,
+            laps=pa.table(
+                {
+                    "num": pa.array([0], type=pa.int32()),
+                    "start_time": pa.array([0], type=pa.int64()),
+                    "end_time": pa.array([300], type=pa.int64()),
+                }
+            ),
+            metadata={},
+            file_name="test.xrk",
+        )
+
+    def test_preserved_through_select_channels(self):
+        """Metadata should survive select_channels."""
+        meta = ChannelMetadata(units="rpm", dec_pts=2, interpolate=True, function="Engine RPM")
+        log = self._make_log({"RPM": self._make_channel("RPM", meta)})
+
+        result = log.select_channels(["RPM"])
+        restored = ChannelMetadata.from_channel_table(result.channels["RPM"])
+        self.assertEqual(restored, meta)
+
+    def test_preserved_through_filter_by_time_range(self):
+        """Metadata should survive filter_by_time_range."""
+        meta = ChannelMetadata(units="m/s", dec_pts=1, interpolate=True)
+        log = self._make_log({"Speed": self._make_channel("Speed", meta)})
+
+        result = log.filter_by_time_range(0, 150)
+        restored = ChannelMetadata.from_channel_table(result.channels["Speed"])
+        self.assertEqual(restored, meta)
+
+    def test_preserved_through_filter_by_lap(self):
+        """Metadata should survive filter_by_lap."""
+        meta = ChannelMetadata(units="deg", dec_pts=1, interpolate=True, device_tag="@AIM")
+        log = self._make_log({"Steering": self._make_channel("Steering", meta)})
+
+        result = log.filter_by_lap(0)
+        restored = ChannelMetadata.from_channel_table(result.channels["Steering"])
+        self.assertEqual(restored, meta)
+
+    def test_preserved_through_resample_to_timecodes(self):
+        """Metadata should survive resample_to_timecodes."""
+        meta = ChannelMetadata(units="rpm", dec_pts=0, interpolate=True, source_type=9)
+        log = self._make_log({"RPM": self._make_channel("RPM", meta)})
+
+        target = pa.array([0, 50, 100, 150, 200], type=pa.int64())
+        result = log.resample_to_timecodes(target)
+        restored = ChannelMetadata.from_channel_table(result.channels["RPM"])
+        self.assertEqual(restored, meta)
+
+    def test_preserved_through_get_channels_as_table(self):
+        """Metadata should survive get_channels_as_table merge."""
+        meta = ChannelMetadata(units="bar", dec_pts=2, interpolate=True)
+        log = self._make_log({"BRK": self._make_channel("BRK", meta)})
+
+        result = log.get_channels_as_table()
+        restored = ChannelMetadata.from_field(result.schema.field("BRK"))
+        self.assertEqual(restored, meta)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_get_channels_as_table.py
+++ b/tests/test_get_channels_as_table.py
@@ -2,7 +2,7 @@
 
 import unittest
 import pyarrow as pa
-from libxrk.base import LogFile
+from libxrk.base import ChannelMetadata, LogFile
 
 
 class TestChannelMerge(unittest.TestCase):
@@ -291,18 +291,16 @@ class TestChannelMerge(unittest.TestCase):
 
     def test_column_metadata_preserved(self):
         """Test that column metadata is preserved in the merged table."""
-        # Create channels with metadata
+        # Create channels with metadata using ChannelMetadata
+        meta_a = ChannelMetadata(units="m/s", dec_pts=2, interpolate=True)
         channel_a = pa.table(
             {
                 "timecodes": pa.array([0, 100], type=pa.int64()),
                 "ChannelA": pa.array([1.0, 2.0], type=pa.float32()),
             }
         )
-        # Add metadata to ChannelA
         channel_a_field = channel_a.schema.field("ChannelA")
-        channel_a_field_with_meta = channel_a_field.with_metadata(
-            {b"units": b"m/s", b"dec_pts": b"2", b"interpolate": b"linear"}
-        )
+        channel_a_field_with_meta = channel_a_field.with_metadata(meta_a.to_field_metadata())
         new_schema_a = pa.schema(
             [
                 channel_a.schema.field("timecodes"),
@@ -311,17 +309,15 @@ class TestChannelMerge(unittest.TestCase):
         )
         channel_a = channel_a.cast(new_schema_a)
 
+        meta_b = ChannelMetadata(units="rpm", dec_pts=0, interpolate=False)
         channel_b = pa.table(
             {
                 "timecodes": pa.array([50, 150], type=pa.int64()),
                 "ChannelB": pa.array([10.0, 20.0], type=pa.float32()),
             }
         )
-        # Add different metadata to ChannelB
         channel_b_field = channel_b.schema.field("ChannelB")
-        channel_b_field_with_meta = channel_b_field.with_metadata(
-            {b"units": b"rpm", b"dec_pts": b"0", b"interpolate": b"step"}
-        )
+        channel_b_field_with_meta = channel_b_field.with_metadata(meta_b.to_field_metadata())
         new_schema_b = pa.schema(
             [
                 channel_b.schema.field("timecodes"),
@@ -339,22 +335,16 @@ class TestChannelMerge(unittest.TestCase):
 
         result = log.get_channels_as_table()
 
-        # Check that metadata is preserved for ChannelA
-        schema = result.schema
-        channel_a_field = schema.field("ChannelA")
-        channel_a_metadata = channel_a_field.metadata or {}
+        # Check that metadata is preserved using ChannelMetadata
+        result_meta_a = ChannelMetadata.from_field(result.schema.field("ChannelA"))
+        self.assertEqual(result_meta_a.units, "m/s")
+        self.assertEqual(result_meta_a.dec_pts, 2)
+        self.assertTrue(result_meta_a.interpolate)
 
-        self.assertEqual(channel_a_metadata.get(b"units"), b"m/s")
-        self.assertEqual(channel_a_metadata.get(b"dec_pts"), b"2")
-        self.assertEqual(channel_a_metadata.get(b"interpolate"), b"linear")
-
-        # Check that metadata is preserved for ChannelB
-        channel_b_field = schema.field("ChannelB")
-        channel_b_metadata = channel_b_field.metadata or {}
-
-        self.assertEqual(channel_b_metadata.get(b"units"), b"rpm")
-        self.assertEqual(channel_b_metadata.get(b"dec_pts"), b"0")
-        self.assertEqual(channel_b_metadata.get(b"interpolate"), b"step")
+        result_meta_b = ChannelMetadata.from_field(result.schema.field("ChannelB"))
+        self.assertEqual(result_meta_b.units, "rpm")
+        self.assertEqual(result_meta_b.dec_pts, 0)
+        self.assertFalse(result_meta_b.interpolate)
 
     def test_forward_fill_without_interpolate_metadata(self):
         """Test that channels without interpolate metadata use forward fill."""
@@ -407,7 +397,9 @@ class TestChannelMerge(unittest.TestCase):
         )
         # Add interpolate=True metadata
         channel_a_field = channel_a.schema.field("ChannelA")
-        channel_a_field_with_meta = channel_a_field.with_metadata({b"interpolate": b"True"})
+        channel_a_field_with_meta = channel_a_field.with_metadata(
+            ChannelMetadata(interpolate=True).to_field_metadata()
+        )
         new_schema_a = pa.schema([channel_a.schema.field("timecodes"), channel_a_field_with_meta])
         channel_a = channel_a.cast(new_schema_a)
 
@@ -419,7 +411,9 @@ class TestChannelMerge(unittest.TestCase):
         )
         # Add interpolate=True metadata
         channel_b_field = channel_b.schema.field("ChannelB")
-        channel_b_field_with_meta = channel_b_field.with_metadata({b"interpolate": b"True"})
+        channel_b_field_with_meta = channel_b_field.with_metadata(
+            ChannelMetadata(interpolate=True).to_field_metadata()
+        )
         new_schema_b = pa.schema([channel_b.schema.field("timecodes"), channel_b_field_with_meta])
         channel_b = channel_b.cast(new_schema_b)
 
@@ -469,7 +463,9 @@ class TestChannelMerge(unittest.TestCase):
             }
         )
         channel_a_field = channel_a.schema.field("ChannelA")
-        channel_a_field_with_meta = channel_a_field.with_metadata({b"interpolate": b"True"})
+        channel_a_field_with_meta = channel_a_field.with_metadata(
+            ChannelMetadata(interpolate=True).to_field_metadata()
+        )
         new_schema_a = pa.schema([channel_a.schema.field("timecodes"), channel_a_field_with_meta])
         channel_a = channel_a.cast(new_schema_a)
 
@@ -481,7 +477,9 @@ class TestChannelMerge(unittest.TestCase):
             }
         )
         channel_b_field = channel_b.schema.field("ChannelB")
-        channel_b_field_with_meta = channel_b_field.with_metadata({b"interpolate": b"False"})
+        channel_b_field_with_meta = channel_b_field.with_metadata(
+            ChannelMetadata(interpolate=False).to_field_metadata()
+        )
         new_schema_b = pa.schema([channel_b.schema.field("timecodes"), channel_b_field_with_meta])
         channel_b = channel_b.cast(new_schema_b)
 
@@ -519,7 +517,7 @@ class TestInterpolationTypePromotion(unittest.TestCase):
             }
         )
         field = channel.schema.field("Sensor")
-        field_with_meta = field.with_metadata({b"interpolate": b"True"})
+        field_with_meta = field.with_metadata(ChannelMetadata(interpolate=True).to_field_metadata())
         schema = pa.schema([channel.schema.field("timecodes"), field_with_meta])
         channel = channel.cast(schema)
 
@@ -554,7 +552,9 @@ class TestInterpolationTypePromotion(unittest.TestCase):
             }
         )
         field = channel.schema.field("Counter")
-        field_with_meta = field.with_metadata({b"interpolate": b"False"})
+        field_with_meta = field.with_metadata(
+            ChannelMetadata(interpolate=False).to_field_metadata()
+        )
         schema = pa.schema([channel.schema.field("timecodes"), field_with_meta])
         channel = channel.cast(schema)
 
@@ -583,7 +583,7 @@ class TestInterpolationTypePromotion(unittest.TestCase):
             }
         )
         field = channel.schema.field("Speed")
-        field_with_meta = field.with_metadata({b"interpolate": b"True"})
+        field_with_meta = field.with_metadata(ChannelMetadata(interpolate=True).to_field_metadata())
         schema = pa.schema([channel.schema.field("timecodes"), field_with_meta])
         channel = channel.cast(schema)
 

--- a/tests/test_gps_timing.py
+++ b/tests/test_gps_timing.py
@@ -6,7 +6,7 @@ from typing import ClassVar, Dict, Optional
 import numpy as np
 import pyarrow as pa
 
-from libxrk import GPS_CHANNEL_NAMES, LogFile, aim_xrk
+from libxrk import GPS_CHANNEL_NAMES, ChannelMetadata, LogFile, aim_xrk
 from libxrk.gps import fix_gps_timing_gaps
 
 
@@ -48,55 +48,27 @@ def create_mock_log_with_gps_gap(
 
     channels = {}
 
-    # Create GPS Speed channel with metadata
-    channels["GPS Speed"] = pa.table(
-        {"timecodes": pa.array(timecodes, type=pa.int64()), "GPS Speed": pa.array(gps_speed)}
-    )
-    speed_field = (
-        channels["GPS Speed"]
-        .schema.field("GPS Speed")
-        .with_metadata({b"units": b"m/s", b"dec_pts": b"2", b"interpolate": b"True"})
-    )
-    channels["GPS Speed"] = channels["GPS Speed"].cast(
-        pa.schema([channels["GPS Speed"].schema.field("timecodes"), speed_field])
-    )
+    # GPS channel metadata definitions
+    gps_meta = {
+        "GPS Speed": ChannelMetadata(units="m/s", dec_pts=2, interpolate=True),
+        "GPS Latitude": ChannelMetadata(units="deg", dec_pts=6, interpolate=True),
+        "GPS Longitude": ChannelMetadata(units="deg", dec_pts=6, interpolate=True),
+        "GPS Altitude": ChannelMetadata(units="m", dec_pts=1, interpolate=True),
+    }
+    gps_values = {
+        "GPS Speed": gps_speed,
+        "GPS Latitude": gps_lat,
+        "GPS Longitude": gps_lon,
+        "GPS Altitude": gps_alt,
+    }
 
-    # Create other GPS channels
-    channels["GPS Latitude"] = pa.table(
-        {"timecodes": pa.array(timecodes, type=pa.int64()), "GPS Latitude": pa.array(gps_lat)}
-    )
-    lat_field = (
-        channels["GPS Latitude"]
-        .schema.field("GPS Latitude")
-        .with_metadata({b"units": b"deg", b"dec_pts": b"6", b"interpolate": b"True"})
-    )
-    channels["GPS Latitude"] = channels["GPS Latitude"].cast(
-        pa.schema([channels["GPS Latitude"].schema.field("timecodes"), lat_field])
-    )
-
-    channels["GPS Longitude"] = pa.table(
-        {"timecodes": pa.array(timecodes, type=pa.int64()), "GPS Longitude": pa.array(gps_lon)}
-    )
-    lon_field = (
-        channels["GPS Longitude"]
-        .schema.field("GPS Longitude")
-        .with_metadata({b"units": b"deg", b"dec_pts": b"6", b"interpolate": b"True"})
-    )
-    channels["GPS Longitude"] = channels["GPS Longitude"].cast(
-        pa.schema([channels["GPS Longitude"].schema.field("timecodes"), lon_field])
-    )
-
-    channels["GPS Altitude"] = pa.table(
-        {"timecodes": pa.array(timecodes, type=pa.int64()), "GPS Altitude": pa.array(gps_alt)}
-    )
-    alt_field = (
-        channels["GPS Altitude"]
-        .schema.field("GPS Altitude")
-        .with_metadata({b"units": b"m", b"dec_pts": b"1", b"interpolate": b"True"})
-    )
-    channels["GPS Altitude"] = channels["GPS Altitude"].cast(
-        pa.schema([channels["GPS Altitude"].schema.field("timecodes"), alt_field])
-    )
+    # Create GPS channels with metadata
+    for name, values in gps_values.items():
+        table = pa.table(
+            {"timecodes": pa.array(timecodes, type=pa.int64()), name: pa.array(values)}
+        )
+        field = table.schema.field(name).with_metadata(gps_meta[name].to_field_metadata())
+        channels[name] = table.cast(pa.schema([table.schema.field("timecodes"), field]))
 
     # Add a non-GPS channel with normal timing
     non_gps_timecodes = np.arange(0, n_samples * 20, 20, dtype=np.int64)  # 50Hz
@@ -169,10 +141,9 @@ class TestGpsTimingGapFix(unittest.TestCase):
         log = fix_gps_timing_gaps(log)
 
         # Check metadata is preserved
-        speed_field = log.channels["GPS Speed"].schema.field("GPS Speed")
-        self.assertIsNotNone(speed_field.metadata)
-        self.assertEqual(speed_field.metadata.get(b"units"), b"m/s")
-        self.assertEqual(speed_field.metadata.get(b"dec_pts"), b"2")
+        meta = ChannelMetadata.from_channel_table(log.channels["GPS Speed"])
+        self.assertEqual(meta.units, "m/s")
+        self.assertEqual(meta.dec_pts, 2)
 
     def test_preserves_channel_values(self):
         """Test that channel values (not timecodes) are unchanged."""
@@ -437,9 +408,10 @@ class TestGpsTimingGapFixIntegration(unittest.TestCase):
         """Verify channel metadata is preserved after fix."""
         for name in GPS_CHANNEL_NAMES:
             if name in self.log_xrk.channels:
+                meta = ChannelMetadata.from_channel_table(self.log_xrk.channels[name])
+                # GPS channels should have units set (except satellite/fix channels)
                 field = self.log_xrk.channels[name].schema.field(name)
                 self.assertIsNotNone(field.metadata, f"Metadata missing for {name}")
-                self.assertIn(b"units", field.metadata, f"units missing for {name}")
 
     def test_laps_present_and_reasonable(self):
         """Verify laps are present and most have reasonable timing."""

--- a/tests/test_logfile_methods.py
+++ b/tests/test_logfile_methods.py
@@ -2,7 +2,7 @@
 
 import unittest
 import pyarrow as pa
-from libxrk.base import LogFile
+from libxrk.base import ChannelMetadata, LogFile
 
 
 def create_channel_with_metadata(
@@ -21,19 +21,16 @@ def create_channel_with_metadata(
         }
     )
 
-    metadata = {}
-    if units:
-        metadata[b"units"] = units.encode()
-    if dec_pts:
-        metadata[b"dec_pts"] = dec_pts.encode()
-    if interpolate:
-        metadata[b"interpolate"] = interpolate.encode()
-
-    if metadata:
-        field = table.schema.field(name)
-        new_field = field.with_metadata(metadata)
-        new_schema = pa.schema([table.schema.field("timecodes"), new_field])
-        table = table.cast(new_schema)
+    meta = ChannelMetadata(
+        units=units,
+        dec_pts=int(dec_pts) if dec_pts else 0,
+        interpolate=interpolate == "True",
+    )
+    metadata = meta.to_field_metadata()
+    field = table.schema.field(name)
+    new_field = field.with_metadata(metadata)
+    new_schema = pa.schema([table.schema.field("timecodes"), new_field])
+    table = table.cast(new_schema)
 
     return table
 
@@ -103,10 +100,10 @@ class TestSelectChannels(unittest.TestCase):
 
         result = log.select_channels(["ChannelA"])
 
-        field = result.channels["ChannelA"].schema.field("ChannelA")
-        self.assertEqual(field.metadata.get(b"units"), b"m/s")
-        self.assertEqual(field.metadata.get(b"dec_pts"), b"2")
-        self.assertEqual(field.metadata.get(b"interpolate"), b"True")
+        meta = ChannelMetadata.from_channel_table(result.channels["ChannelA"])
+        self.assertEqual(meta.units, "m/s")
+        self.assertEqual(meta.dec_pts, 2)
+        self.assertTrue(meta.interpolate)
 
 
 class TestFilterByTimeRange(unittest.TestCase):
@@ -152,9 +149,9 @@ class TestFilterByTimeRange(unittest.TestCase):
 
         result = log.filter_by_time_range(0, 150)
 
-        field = result.channels["ChannelA"].schema.field("ChannelA")
-        self.assertEqual(field.metadata.get(b"units"), b"rpm")
-        self.assertEqual(field.metadata.get(b"interpolate"), b"True")
+        meta = ChannelMetadata.from_channel_table(result.channels["ChannelA"])
+        self.assertEqual(meta.units, "rpm")
+        self.assertTrue(meta.interpolate)
 
     def test_filter_by_time_range_empty_result(self):
         """Test filtering that results in empty channels."""
@@ -317,10 +314,10 @@ class TestResampleToTimecodes(unittest.TestCase):
         target = pa.array([0, 50, 100], type=pa.int64())
         result = log.resample_to_timecodes(target)
 
-        field = result.channels["ChannelA"].schema.field("ChannelA")
-        self.assertEqual(field.metadata.get(b"units"), b"m/s")
-        self.assertEqual(field.metadata.get(b"dec_pts"), b"2")
-        self.assertEqual(field.metadata.get(b"interpolate"), b"True")
+        meta = ChannelMetadata.from_channel_table(result.channels["ChannelA"])
+        self.assertEqual(meta.units, "m/s")
+        self.assertEqual(meta.dec_pts, 2)
+        self.assertTrue(meta.interpolate)
 
     def test_resample_to_timecodes_with_channel_names(self):
         """Test resampling specific channels only."""
@@ -426,9 +423,9 @@ class TestGetChannelsAsTableRefactored(unittest.TestCase):
 
         result = log.get_channels_as_table()
 
-        field = result.schema.field("ChannelA")
-        self.assertEqual(field.metadata.get(b"units"), b"m/s")
-        self.assertEqual(field.metadata.get(b"interpolate"), b"True")
+        meta = ChannelMetadata.from_field(result.schema.field("ChannelA"))
+        self.assertEqual(meta.units, "m/s")
+        self.assertTrue(meta.interpolate)
 
     def test_get_channels_as_table_empty(self):
         """Test that empty channels returns empty table."""

--- a/tests/test_sfj_xrk.py
+++ b/tests/test_sfj_xrk.py
@@ -9,7 +9,7 @@ import pyarrow as pa
 from parameterized import parameterized
 
 from libxrk import aim_xrk
-from libxrk.base import LogFile
+from libxrk.base import ChannelMetadata, LogFile
 
 
 # Path to test data
@@ -355,22 +355,17 @@ class TestSFJXRK(unittest.TestCase):
 
         for channel_name, expected_units, expected_dec_pts, expected_interpolate in test_cases:
             self.assertIn(channel_name, log.channels, f"Channel '{channel_name}' not found")
-            channel_table = log.channels[channel_name]
-            schema = channel_table.schema
-            data_field = schema.field(channel_name)
-            metadata = data_field.metadata or {}
+            meta = ChannelMetadata.from_channel_table(log.channels[channel_name])
 
-            units = metadata.get(b"units", b"").decode("utf-8")
-            dec_pts = metadata.get(b"dec_pts", b"").decode("utf-8")
-            interpolate = metadata.get(b"interpolate", b"").decode("utf-8")
-
-            self.assertEqual(units, expected_units, f"Channel '{channel_name}' units mismatch")
+            self.assertEqual(meta.units, expected_units, f"Channel '{channel_name}' units mismatch")
             self.assertEqual(
-                dec_pts, expected_dec_pts, f"Channel '{channel_name}' dec_pts mismatch"
+                meta.dec_pts,
+                int(expected_dec_pts),
+                f"Channel '{channel_name}' dec_pts mismatch",
             )
             self.assertEqual(
-                interpolate,
-                expected_interpolate,
+                meta.interpolate,
+                expected_interpolate == "True",
                 f"Channel '{channel_name}' interpolate mismatch",
             )
 
@@ -543,15 +538,23 @@ class TestSFJCrossBackend(unittest.TestCase):
     def test_channel_metadata_match(self) -> None:
         """Channel metadata (units, dec_pts, interpolate) should match between backends."""
         for name in self.rust_log.channels:
-            rust_meta = self.rust_log.channels[name].schema.field(name).metadata or {}
-            cython_meta = self.cython_log.channels[name].schema.field(name).metadata or {}
-            for key in (b"units", b"dec_pts", b"interpolate"):
-                self.assertEqual(
-                    rust_meta.get(key),
-                    cython_meta.get(key),
-                    f"Channel {name!r} metadata {key!r}: "
-                    f"rust={rust_meta.get(key)!r} != cython={cython_meta.get(key)!r}",
-                )
+            rust_meta = ChannelMetadata.from_channel_table(self.rust_log.channels[name])
+            cython_meta = ChannelMetadata.from_channel_table(self.cython_log.channels[name])
+            self.assertEqual(
+                rust_meta.units,
+                cython_meta.units,
+                f"Channel {name!r} units mismatch",
+            )
+            self.assertEqual(
+                rust_meta.dec_pts,
+                cython_meta.dec_pts,
+                f"Channel {name!r} dec_pts mismatch",
+            )
+            self.assertEqual(
+                rust_meta.interpolate,
+                cython_meta.interpolate,
+                f"Channel {name!r} interpolate mismatch",
+            )
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -460,7 +460,7 @@ wheels = [
 
 [[package]]
 name = "libxrk"
-version = "0.10.1"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "cython" },


### PR DESCRIPTION

Replace raw dict[bytes, bytes] metadata access with a frozen ChannelMetadata
dataclass providing typed fields (str, int, bool, float) and from_field /
from_channel_table / to_field_metadata helpers for PyArrow interop.

Refactor all internal metadata handling in base.py, gps.py, and aim_xrk.pyx
to use ChannelMetadata. Type the Rust ChannelMetadata struct fields (dec_pts:
u8, interpolate: bool, source_type: u8, source_channel_id: u16, f32 floats)
with string serialization deferred to to_hashmap(). Export ChannelMetadata
from libxrk.__init__.

Closes #41
