### PR TITLE
feat: match Cython parser strictness + add 126 Rust unit tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,12 @@ uv build             # Build wheel
 The library has two parser backends with identical APIs. Both are included in all published wheels.
 
 - **Cython** (default): `src/libxrk/aim_xrk.pyx` — mature, well-tested
-- **Rust**: `crates/` — ~2x faster, used automatically in Pyodide/WASM
+- **Rust**: `crates/` — ~2x faster
 
-Set `LIBXRK_BACKEND=rust` to use the Rust parser. Default is Cython; no automatic fallback.
+Both backends are always included in all build types (CPython wheels, Pyodide/WASM wheels, sdist).
+A failure to build either backend fails the whole build. There is no automatic fallback.
+
+Set `LIBXRK_BACKEND=rust` to use the Rust parser. Default is Cython on all platforms, including Pyodide.
 
 ```bash
 just rust-build                        # Build Rust extension
@@ -93,7 +96,7 @@ After modifying `src/libxrk/aim_xrk.pyx`, you **must** run `uv sync --reinstall-
 
 ## Rust Rebuild
 
-After modifying Rust source in `crates/`, run `just rust-build` (release) or `just rust-build-debug` (faster compile). The Rust extension coexists with Cython — both can be installed simultaneously.
+After modifying Rust source in `crates/`, run `just rust-build` (release) or `just rust-build-debug` (faster compile). Both backends are always installed together — a failure to build either fails the whole build.
 
 ## Architecture Notes
 

--- a/crates/libxrk-python/src/lib.rs
+++ b/crates/libxrk-python/src/lib.rs
@@ -79,7 +79,8 @@ fn aim_xrk(py: Python<'_>, fname: Py<PyAny>, progress: Option<Py<PyAny>>) -> PyR
         closure
     });
 
-    let mut result = libxrk::parser::parse_xrk(&data, progress_cb.as_ref().map(|cb| cb.as_ref()));
+    let mut result = libxrk::parser::parse_xrk(&data, progress_cb.as_ref().map(|cb| cb.as_ref()))
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
 
     // Compute non-GPS max end time before moving channel_data out
     let non_gps_max_end_time: Option<i64> = result
@@ -111,7 +112,8 @@ fn aim_xrk(py: Python<'_>, fname: Py<PyAny>, progress: Option<Py<PyAny>>) -> PyR
     }
 
     // Decode GPS channels
-    let mut gps_result = libxrk::gps::decode_gps(&result.gps_data, result.time_offset);
+    let mut gps_result = libxrk::gps::decode_gps(&result.gps_data, result.time_offset)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
 
     // Apply GPS timing fix
     if let Some(ref mut gps) = gps_result {
@@ -167,7 +169,8 @@ fn aim_xrk(py: Python<'_>, fname: Py<PyAny>, progress: Option<Py<PyAny>>) -> PyR
     };
 
     // Build laps
-    let mut processed_laps = libxrk::parser::get_processed_laps(&result);
+    let mut processed_laps = libxrk::parser::get_processed_laps(&result)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
 
     // Validate LAP-message-based laps
     if processed_laps
@@ -241,7 +244,8 @@ fn aim_track_dbg(py: Python<'_>, fname: Py<PyAny>) -> PyResult<Py<PyAny>> {
     let raw_data = read_source_bytes(py, fname_bound)?;
     let data = libxrk::decompress_if_zlib(&raw_data);
 
-    let result = libxrk::parser::parse_xrk(&data, None);
+    let result = libxrk::parser::parse_xrk(&data, None)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
 
     let dict = PyDict::new(py);
     for (&tok, msgs) in &result.header_messages {

--- a/crates/libxrk/src/bin/bench_parse.rs
+++ b/crates/libxrk/src/bin/bench_parse.rs
@@ -52,7 +52,7 @@ fn main() {
 
     // Warmup
     for _ in 0..2 {
-        let result = parser::parse_xrk(&data, None);
+        let result = parser::parse_xrk(&data, None).expect("parse failed");
         let _ = gps::decode_gps(&result.gps_data, result.time_offset);
         std::hint::black_box(&result);
     }
@@ -60,7 +60,7 @@ fn main() {
     let mut times = Vec::with_capacity(iterations);
     for _ in 0..iterations {
         let t0 = Instant::now();
-        let result = parser::parse_xrk(&data, None);
+        let result = parser::parse_xrk(&data, None).expect("parse failed");
         let _ = gps::decode_gps(&result.gps_data, result.time_offset);
         std::hint::black_box(&result);
         times.push(t0.elapsed().as_secs_f64() * 1000.0);

--- a/crates/libxrk/src/decoders.rs
+++ b/crates/libxrk/src/decoders.rs
@@ -197,9 +197,189 @@ mod tests {
     }
 
     #[test]
+    fn test_half_to_f32_nan() {
+        // 0x7C01 = NaN (mantissa != 0 with max exponent)
+        assert!(half_to_f32(0x7C01).is_nan());
+    }
+
+    #[test]
+    fn test_half_to_f32_negative_zero() {
+        // 0x8000 = -0.0
+        let v = half_to_f32(0x8000);
+        assert_eq!(v, 0.0);
+        assert!(v.is_sign_negative());
+    }
+
+    #[test]
+    fn test_half_to_f32_subnormal() {
+        // Smallest subnormal: 0x0001
+        let v = half_to_f32(0x0001);
+        assert!(v > 0.0);
+        assert!(v < 1e-6);
+    }
+
+    #[test]
     fn test_gear_lookup() {
         assert_eq!(gear_lookup(0x4E), 0); // 'N'
         assert_eq!(gear_lookup(0x31), 1); // '1'
         assert_eq!(gear_lookup(0x36), 6); // '6'
+    }
+
+    #[test]
+    fn test_gear_lookup_all_gears() {
+        assert_eq!(gear_lookup(0x32), 2);
+        assert_eq!(gear_lookup(0x33), 3);
+        assert_eq!(gear_lookup(0x34), 4);
+        assert_eq!(gear_lookup(0x35), 5);
+    }
+
+    #[test]
+    fn test_gear_lookup_passthrough() {
+        // Unknown values pass through unchanged
+        assert_eq!(gear_lookup(0xFF), 0xFF);
+        assert_eq!(gear_lookup(0x00), 0x00);
+    }
+
+    #[test]
+    fn test_decode_sample_int32() {
+        let data = 42i32.to_le_bytes();
+        match decode_sample(0, &data).unwrap() {
+            SampleValue::Int32(v) => assert_eq!(v, 42),
+            _ => panic!("expected Int32"),
+        }
+    }
+
+    #[test]
+    fn test_decode_sample_uint16() {
+        let data = 1234u16.to_le_bytes();
+        match decode_sample(1, &data).unwrap() {
+            SampleValue::UInt16(v) => assert_eq!(v, 1234),
+            _ => panic!("expected UInt16"),
+        }
+    }
+
+    #[test]
+    fn test_decode_sample_int16() {
+        let data = (-500i16).to_le_bytes();
+        match decode_sample(4, &data).unwrap() {
+            SampleValue::Int16(v) => assert_eq!(v, -500),
+            _ => panic!("expected Int16"),
+        }
+    }
+
+    #[test]
+    fn test_decode_sample_float32() {
+        let data = 1.5f32.to_le_bytes();
+        match decode_sample(6, &data).unwrap() {
+            SampleValue::Float32(v) => assert!((v - 1.5).abs() < 0.01),
+            _ => panic!("expected Float32"),
+        }
+    }
+
+    #[test]
+    fn test_decode_sample_uint8() {
+        match decode_sample(13, &[255]).unwrap() {
+            SampleValue::UInt8(v) => assert_eq!(v, 255),
+            _ => panic!("expected UInt8"),
+        }
+    }
+
+    #[test]
+    fn test_decode_sample_gear_lookup() {
+        let data = 0x4Eu16.to_le_bytes(); // 'N'
+        match decode_sample(15, &data).unwrap() {
+            SampleValue::UInt16(v) => assert_eq!(v, 0), // Neutral
+            _ => panic!("expected UInt16"),
+        }
+    }
+
+    #[test]
+    fn test_decode_sample_float16() {
+        let data = 0x3C00u16.to_le_bytes(); // 1.0 in half precision
+        match decode_sample(20, &data).unwrap() {
+            SampleValue::Float32(v) => assert!((v - 1.0).abs() < 1e-6),
+            _ => panic!("expected Float32"),
+        }
+    }
+
+    #[test]
+    fn test_decode_sample_unknown_type() {
+        assert!(decode_sample(255, &[0, 0, 0, 0]).is_none());
+    }
+
+    #[test]
+    fn test_decode_sample_too_short() {
+        assert!(decode_sample(0, &[1, 2]).is_none()); // needs 4 bytes
+        assert!(decode_sample(1, &[1]).is_none()); // needs 2 bytes
+        assert!(decode_sample(13, &[]).is_none()); // needs 1 byte
+    }
+
+    #[test]
+    fn test_decode_manual_gear() {
+        // Test gear 3: bit 16-18 = 3, bit 19 = 0
+        let val: u64 = 3 << 16;
+        let data = val.to_le_bytes();
+        match decode_manual_gear(&data).unwrap() {
+            SampleValue::UInt32(v) => assert_eq!(v, 3),
+            _ => panic!("expected UInt32"),
+        }
+    }
+
+    #[test]
+    fn test_decode_manual_gear_neutral() {
+        // Neutral: bit 19 = 1
+        let val: u64 = 1 << 19;
+        let data = val.to_le_bytes();
+        match decode_manual_gear(&data).unwrap() {
+            SampleValue::UInt32(v) => assert_eq!(v, 0),
+            _ => panic!("expected UInt32"),
+        }
+    }
+
+    #[test]
+    fn test_decode_manual_gear_too_short() {
+        assert!(decode_manual_gear(&[0; 7]).is_none());
+    }
+
+    #[test]
+    fn test_is_manual_decoder() {
+        assert!(is_manual_decoder("Calculated_Gear"));
+        assert!(is_manual_decoder("PreCalcGear"));
+        assert!(!is_manual_decoder("Engine RPM"));
+        assert!(!is_manual_decoder(""));
+    }
+
+    #[test]
+    fn test_sample_byte_size() {
+        assert_eq!(sample_byte_size(0), Some(4)); // i32
+        assert_eq!(sample_byte_size(1), Some(2)); // u16
+        assert_eq!(sample_byte_size(6), Some(4)); // f32
+        assert_eq!(sample_byte_size(13), Some(1)); // u8
+        assert_eq!(sample_byte_size(255), None); // unknown
+    }
+
+    #[test]
+    fn test_sample_value_as_f64() {
+        assert_eq!(SampleValue::Int32(42).as_f64(), 42.0);
+        assert_eq!(SampleValue::UInt16(100).as_f64(), 100.0);
+        assert_eq!(SampleValue::Float32(1.5).as_f64() as f32, 1.5);
+        assert_eq!(SampleValue::Float64(2.5).as_f64(), 2.5);
+    }
+
+    #[test]
+    fn test_sample_value_as_f32() {
+        assert_eq!(SampleValue::Int32(42).as_f32(), 42.0);
+        assert_eq!(SampleValue::Float32(1.5).as_f32(), 1.5);
+    }
+
+    #[test]
+    fn test_all_int32_decoder_types() {
+        let data = 99i32.to_le_bytes();
+        for dt in [0, 3, 8, 12, 22, 24, 26, 27, 31, 32, 33, 37, 38, 39] {
+            match decode_sample(dt, &data) {
+                Some(SampleValue::Int32(v)) => assert_eq!(v, 99, "decoder_type={}", dt),
+                other => panic!("decoder_type={}: expected Int32, got {:?}", dt, other),
+            }
+        }
     }
 }

--- a/crates/libxrk/src/error.rs
+++ b/crates/libxrk/src/error.rs
@@ -51,3 +51,42 @@ impl From<arrow::error::ArrowError> for Error {
         Error::Arrow(e)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display_invalid_data() {
+        let e = Error::InvalidData("bad stuff".into());
+        assert_eq!(e.to_string(), "invalid data: bad stuff");
+    }
+
+    #[test]
+    fn test_display_decompression() {
+        let e = Error::Decompression("corrupt".into());
+        assert_eq!(e.to_string(), "decompression error: corrupt");
+    }
+
+    #[test]
+    fn test_display_io() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "gone");
+        let e = Error::from(io_err);
+        assert!(e.to_string().starts_with("I/O error:"));
+    }
+
+    #[test]
+    fn test_source_io() {
+        use std::error::Error as StdError;
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "gone");
+        let e = Error::from(io_err);
+        assert!(e.source().is_some());
+    }
+
+    #[test]
+    fn test_source_invalid_data() {
+        use std::error::Error as StdError;
+        let e = Error::InvalidData("test".into());
+        assert!(e.source().is_none());
+    }
+}

--- a/crates/libxrk/src/gps/processing.rs
+++ b/crates/libxrk/src/gps/processing.rs
@@ -8,6 +8,7 @@ use std::f64::consts::PI;
 use crate::gps::utils as gps_utils;
 
 /// Result of GPS decoding: 12 GPS channels with shared timecodes.
+#[derive(Debug)]
 pub struct GpsDecodeResult {
     pub timecodes: Vec<i64>,
     // Float64 channels (position/speed)
@@ -128,12 +129,18 @@ pub const GPS_CHANNEL_DEFS: &[GpsChannelDef] = &[
 /// Each GPS message is 56 bytes:
 ///   - Bytes 0-3: AIM logger timecode (int32)
 ///   - Bytes 4-55: u-blox NAV-SOL payload (52 bytes)
-pub fn decode_gps(gps_data: &[u8], time_offset: i64) -> Option<GpsDecodeResult> {
+pub fn decode_gps(
+    gps_data: &[u8],
+    time_offset: i64,
+) -> Result<Option<GpsDecodeResult>, crate::Error> {
     if gps_data.is_empty() {
-        return None;
+        return Ok(None);
     }
     if !gps_data.len().is_multiple_of(56) {
-        return None;
+        return Err(crate::Error::InvalidData(format!(
+            "GPS data length {} is not a multiple of 56",
+            gps_data.len()
+        )));
     }
 
     let n = gps_data.len() / 56;
@@ -310,7 +317,7 @@ pub fn decode_gps(gps_data: &[u8], time_offset: i64) -> Option<GpsDecodeResult> 
     let position_accuracy: Vec<f32> = posacc_cm.iter().map(|&v| v as f32 / 100.0).collect();
     let velocity_accuracy: Vec<f32> = velacc_cms.iter().map(|&v| v as f32 / 100.0).collect();
 
-    Some(GpsDecodeResult {
+    Ok(Some(GpsDecodeResult {
         timecodes,
         speed,
         latitude,
@@ -324,7 +331,7 @@ pub fn decode_gps(gps_data: &[u8], time_offset: i64) -> Option<GpsDecodeResult> 
         inline_acc,
         lateral_acc,
         yaw_rate,
-    })
+    }))
 }
 
 /// Fix timecodes for old MXP firmware that butchers the upper 16 bits.
@@ -393,5 +400,131 @@ impl GpsDecodeResult {
                 [x, y, z]
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Create a minimal 56-byte GPS NAV-SOL record with the given timecode.
+    fn make_gps_record(timecode: i32) -> Vec<u8> {
+        let mut record = vec![0u8; 56];
+        record[0..4].copy_from_slice(&timecode.to_le_bytes());
+        record[14] = 3; // GPS fix type (3D)
+        let ecef_x: i32 = 637_813_700; // ~6378137m in cm
+        record[16..20].copy_from_slice(&ecef_x.to_le_bytes());
+        record[20..24].copy_from_slice(&0i32.to_le_bytes());
+        record[24..28].copy_from_slice(&0i32.to_le_bytes());
+        record[28..32].copy_from_slice(&100u32.to_le_bytes()); // pos acc 1m
+        record[44..48].copy_from_slice(&50u32.to_le_bytes()); // vel acc 0.5 m/s
+        record[48..50].copy_from_slice(&150u16.to_le_bytes()); // pDOP 1.50
+        record[51] = 12; // 12 satellites
+        record
+    }
+
+    #[test]
+    fn test_decode_gps_empty_returns_none() {
+        let result = decode_gps(&[], 0).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_decode_gps_invalid_length_returns_error() {
+        let data = vec![0u8; 57];
+        let result = decode_gps(&data, 0);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("not a multiple of 56"),
+            "error was: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_decode_gps_invalid_length_55() {
+        let data = vec![0u8; 55];
+        assert!(decode_gps(&data, 0).is_err());
+    }
+
+    #[test]
+    fn test_decode_gps_single_record() {
+        let record = make_gps_record(1000);
+        let result = decode_gps(&record, 0).unwrap().unwrap();
+        assert_eq!(result.timecodes.len(), 1);
+        assert_eq!(result.timecodes[0], 1000);
+        assert_eq!(result.speed.len(), 1);
+        assert_eq!(result.latitude.len(), 1);
+        assert_eq!(result.longitude.len(), 1);
+        assert_eq!(result.altitude.len(), 1);
+        assert_eq!(result.satellites.len(), 1);
+        assert_eq!(result.fix.len(), 1);
+        assert_eq!(result.pdop.len(), 1);
+        assert_eq!(result.position_accuracy.len(), 1);
+        assert_eq!(result.velocity_accuracy.len(), 1);
+        assert_eq!(result.inline_acc.len(), 1);
+        assert_eq!(result.lateral_acc.len(), 1);
+        assert_eq!(result.yaw_rate.len(), 1);
+    }
+
+    #[test]
+    fn test_decode_gps_single_record_values() {
+        let record = make_gps_record(5000);
+        let result = decode_gps(&record, 1000).unwrap().unwrap();
+        assert_eq!(result.timecodes[0], 4000);
+        assert!(result.speed[0].abs() < 0.01);
+        assert_eq!(result.satellites[0], 12.0);
+        assert_eq!(result.fix[0], 3.0);
+        assert!((result.pdop[0] - 1.50).abs() < 0.01);
+        assert!((result.position_accuracy[0] - 1.0).abs() < 0.01);
+        assert!((result.velocity_accuracy[0] - 0.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_decode_gps_two_records() {
+        let mut data = make_gps_record(1000);
+        data.extend_from_slice(&make_gps_record(2000));
+        let result = decode_gps(&data, 0).unwrap().unwrap();
+        assert_eq!(result.timecodes.len(), 2);
+        assert_eq!(result.timecodes[0], 1000);
+        assert_eq!(result.timecodes[1], 2000);
+    }
+
+    #[test]
+    fn test_decode_gps_time_offset_applied() {
+        let data = make_gps_record(5000);
+        let result = decode_gps(&data, 3000).unwrap().unwrap();
+        assert_eq!(result.timecodes[0], 2000);
+    }
+
+    #[test]
+    fn test_fix_timecodes_monotonic() {
+        let mut tcs = vec![100, 200, 300, 400];
+        fix_timecodes(&mut tcs);
+        assert_eq!(tcs, vec![100, 200, 300, 400]);
+    }
+
+    #[test]
+    fn test_fix_timecodes_backward_corrected() {
+        let mut tcs = vec![100, 200, 50, 150];
+        fix_timecodes(&mut tcs);
+        for w in tcs.windows(2) {
+            assert!(w[1] >= w[0], "timecodes not monotonic after fix: {:?}", tcs);
+        }
+    }
+
+    #[test]
+    fn test_fix_timecodes_single() {
+        let mut tcs = vec![100];
+        fix_timecodes(&mut tcs);
+        assert_eq!(tcs, vec![100]);
+    }
+
+    #[test]
+    fn test_fix_timecodes_empty() {
+        let mut tcs: Vec<i32> = vec![];
+        fix_timecodes(&mut tcs);
+        assert!(tcs.is_empty());
     }
 }

--- a/crates/libxrk/src/lib.rs
+++ b/crates/libxrk/src/lib.rs
@@ -91,7 +91,7 @@ pub fn read_xrk_with_progress(
     let data = decompress_if_zlib(data);
 
     // Parse with the Rust streaming parser
-    let mut result = parser::parse_xrk(&data, progress);
+    let mut result = parser::parse_xrk(&data, progress)?;
 
     // Compute non-GPS max end time before moving channel_data out
     let non_gps_max_end_time: Option<i64> = result
@@ -135,7 +135,7 @@ pub fn read_xrk_with_progress(
         .collect();
 
     // Decode GPS channels
-    let mut gps_result = gps::decode_gps(&result.gps_data, result.time_offset);
+    let mut gps_result = gps::decode_gps(&result.gps_data, result.time_offset)?;
 
     // Apply GPS timing fix
     if let Some(ref mut gps) = gps_result {
@@ -173,7 +173,7 @@ pub fn read_xrk_with_progress(
     let metadata = metadata::extract_metadata(&result);
 
     // Build laps — GPS timing fix was applied above
-    let mut processed_laps = parser::get_processed_laps(&result);
+    let mut processed_laps = parser::get_processed_laps(&result)?;
 
     // Validate LAP-message-based laps
     if processed_laps
@@ -259,5 +259,52 @@ pub fn decompress_if_zlib(data: &[u8]) -> Vec<u8> {
         }
     } else {
         data.to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decompress_if_zlib_passthrough_non_zlib() {
+        let data = b"hello world";
+        let result = decompress_if_zlib(data);
+        assert_eq!(result, data);
+    }
+
+    #[test]
+    fn test_decompress_if_zlib_empty() {
+        let result = decompress_if_zlib(&[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_decompress_if_zlib_single_byte() {
+        let result = decompress_if_zlib(&[0x78]);
+        assert_eq!(result, vec![0x78]);
+    }
+
+    #[test]
+    fn test_decompress_if_zlib_valid_zlib() {
+        use std::io::Write;
+        // Compress some data with zlib
+        let original = b"test data for compression";
+        let mut encoder =
+            flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(original).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        let result = decompress_if_zlib(&compressed);
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn test_decompress_if_zlib_fake_header() {
+        // Starts with zlib magic but isn't valid zlib — should return original data
+        let data = [0x78, 0x9C, 0xFF, 0xFF, 0xFF, 0xFF];
+        let result = decompress_if_zlib(&data);
+        // Returns original since decompression fails and partial is empty
+        assert_eq!(result, data);
     }
 }

--- a/crates/libxrk/src/messages.rs
+++ b/crates/libxrk/src/messages.rs
@@ -465,4 +465,159 @@ mod tests {
         assert_eq!(nullterm_string(b"noterm"), "noterm");
         assert_eq!(nullterm_string(b"\0"), "");
     }
+
+    /// Build a valid header message frame for testing.
+    fn make_test_frame(token_str: &str, version: u8, payload: &[u8]) -> Vec<u8> {
+        let wire_token = tokdec(token_str);
+        let wire_token = if token_str.len() == 3 {
+            wire_token | (0x20 << 24)
+        } else {
+            wire_token
+        };
+        let payload_len = payload.len() as i32;
+        let checksum: u16 = payload
+            .iter()
+            .fold(0u16, |acc, &b| acc.wrapping_add(b as u16));
+
+        let mut frame = Vec::new();
+        frame.push(0x3C);
+        frame.push(0x68);
+        frame.extend_from_slice(&wire_token.to_le_bytes());
+        frame.extend_from_slice(&payload_len.to_le_bytes());
+        frame.push(version);
+        frame.push(0x3E);
+        frame.extend_from_slice(payload);
+        frame.push(0x3C);
+        frame.extend_from_slice(&wire_token.to_le_bytes());
+        frame.extend_from_slice(&checksum.to_le_bytes());
+        frame.push(0x3E);
+        frame
+    }
+
+    #[test]
+    fn test_header_message_parse_valid() {
+        let payload = b"test payload";
+        let frame = make_test_frame("TST", 1, payload);
+        let (msg, consumed) = HeaderMessage::parse(&frame, 0).unwrap();
+        assert_eq!(msg.version, 1);
+        assert_eq!(msg.payload, payload);
+        assert_eq!(consumed, frame.len());
+    }
+
+    #[test]
+    fn test_header_message_parse_empty_payload() {
+        let frame = make_test_frame("TST", 0, b"");
+        let (msg, consumed) = HeaderMessage::parse(&frame, 0).unwrap();
+        assert!(msg.payload.is_empty());
+        assert_eq!(consumed, frame.len());
+    }
+
+    #[test]
+    fn test_header_message_parse_too_short() {
+        let frame = vec![0x3C, 0x68, 0, 0, 0]; // only 5 bytes
+        assert!(matches!(
+            HeaderMessage::parse(&frame, 0),
+            Err(HeaderError::TooShort)
+        ));
+    }
+
+    #[test]
+    fn test_header_message_parse_bad_opcode() {
+        let mut frame = make_test_frame("TST", 0, b"x");
+        frame[0] = 0xFF; // corrupt opcode
+        assert!(matches!(
+            HeaderMessage::parse(&frame, 0),
+            Err(HeaderError::BadOpcode)
+        ));
+    }
+
+    #[test]
+    fn test_header_message_parse_bad_checksum() {
+        let mut frame = make_test_frame("TST", 0, b"test");
+        // Corrupt the checksum (2nd-to-last and 3rd-to-last bytes before final >)
+        let cksum_pos = frame.len() - 3;
+        frame[cksum_pos] ^= 0xFF;
+        assert!(matches!(
+            HeaderMessage::parse(&frame, 0),
+            Err(HeaderError::ChecksumMismatch)
+        ));
+    }
+
+    #[test]
+    fn test_header_message_parse_with_offset() {
+        let padding = vec![0u8; 10]; // some padding before the frame
+        let payload = b"data";
+        let frame = make_test_frame("TST", 0, payload);
+        let mut data = padding;
+        data.extend_from_slice(&frame);
+        let (msg, consumed) = HeaderMessage::parse(&data, 10).unwrap();
+        assert_eq!(msg.payload, payload);
+        assert_eq!(consumed, frame.len());
+    }
+
+    #[test]
+    fn test_header_message_token_stripped() {
+        let frame = make_test_frame("GPS", 0, b"x");
+        let (msg, _) = HeaderMessage::parse(&frame, 0).unwrap();
+        // 3-char token "GPS" should have padding stripped
+        assert_eq!(msg.token, tokdec("GPS"));
+    }
+
+    #[test]
+    fn test_header_message_4char_token() {
+        let frame = make_test_frame("GNFI", 0, b"x");
+        let (msg, _) = HeaderMessage::parse(&frame, 0).unwrap();
+        assert_eq!(msg.token, tokdec("GNFI"));
+    }
+
+    #[test]
+    fn test_dispatch_payload_string_msg() {
+        let msg = HeaderMessage {
+            token: tokens::rcr(),
+            version: 0,
+            payload: b"Driver Name\0".to_vec(),
+        };
+        match dispatch_payload(&msg) {
+            Payload::StringMsg(s) => assert_eq!(s, "Driver Name"),
+            _ => panic!("expected StringMsg"),
+        }
+    }
+
+    #[test]
+    fn test_dispatch_payload_racm_mode() {
+        let msg = HeaderMessage {
+            token: tokens::racm(),
+            version: 0,
+            payload: b"speed\0".to_vec(),
+        };
+        match dispatch_payload(&msg) {
+            Payload::Racm(payloads::racm::RacmPayload::Mode(s)) => assert_eq!(s, "speed"),
+            _ => panic!("expected Racm Mode"),
+        }
+    }
+
+    #[test]
+    fn test_dispatch_payload_unknown_token() {
+        let msg = HeaderMessage {
+            token: tokdec("XXXX"),
+            version: 0,
+            payload: vec![1, 2, 3],
+        };
+        match dispatch_payload(&msg) {
+            Payload::Unknown(data) => assert_eq!(data, vec![1, 2, 3]),
+            _ => panic!("expected Unknown"),
+        }
+    }
+
+    #[test]
+    fn test_token_constants() {
+        // Verify a few token constants round-trip
+        assert_eq!(tokenc(tokens::gps()), "GPS");
+        assert_eq!(tokenc(tokens::chs()), "CHS");
+        assert_eq!(tokenc(tokens::grp()), "GRP");
+        assert_eq!(tokenc(tokens::lap()), "LAP");
+        assert_eq!(tokenc(tokens::gnfi()), "GNFI");
+        assert_eq!(tokenc(tokens::cnf()), "CNF");
+        assert_eq!(tokenc(tokens::enf()), "ENF");
+    }
 }

--- a/crates/libxrk/src/parser.rs
+++ b/crates/libxrk/src/parser.rs
@@ -5,10 +5,12 @@
 
 use std::collections::HashMap;
 
+use crate::error::Error;
 use crate::messages::{self, tokens, HeaderMessage, Payload};
 use crate::payloads::chs::ChsPayload;
 use crate::payloads::grp::GrpPayload;
 use crate::payloads::lap::LapPayload;
+use crate::tables;
 
 /// Accumulator for a single channel or group's data messages.
 #[derive(Debug)]
@@ -188,7 +190,10 @@ pub struct LapInfo {
 /// Parse an XRK byte stream.
 ///
 /// This is the main entry point equivalent to `_decode_sequence()`.
-pub fn parse_xrk(data: &[u8], progress: Option<&dyn Fn(usize, usize)>) -> ParseResult {
+pub fn parse_xrk(
+    data: &[u8],
+    progress: Option<&dyn Fn(usize, usize)>,
+) -> Result<ParseResult, Error> {
     let mut state = ParserState::new();
 
     // Pre-scan: learn channel structure from headers and count data sizes.
@@ -197,7 +202,14 @@ pub fn parse_xrk(data: &[u8], progress: Option<&dyn Fn(usize, usize)>) -> ParseR
     let hints = prescan(data, &mut state);
     state.apply_prescan_hints(&hints);
 
-    scan_stream(data, &mut state, progress);
+    let final_pos = scan_stream(data, &mut state, progress);
+    if final_pos != data.len() {
+        return Err(Error::InvalidData(format!(
+            "Parser did not consume entire input: pos={}, len={}",
+            final_pos,
+            data.len()
+        )));
+    }
     state.finalize()
 }
 
@@ -306,6 +318,69 @@ impl ParserState {
     fn register_chs(&mut self, chs: &ChsPayload) {
         let idx = chs.index as usize;
 
+        // Check for duplicate CHS with different names (D)
+        if let Some(existing) = self.channels.get(&chs.index) {
+            if existing.chs.short_name() != chs.short_name()
+                || existing.chs.long_name() != chs.long_name()
+            {
+                eprintln!(
+                    "Channel name mismatch at index {}: '{}'/'{}' vs '{}'/'{}'. \
+                     Please report at https://github.com/m3rlin45/libxrk/issues",
+                    chs.index,
+                    existing.chs.short_name(),
+                    existing.chs.long_name(),
+                    chs.short_name(),
+                    chs.long_name()
+                );
+                // Skip registration (matches Cython error-recovery behavior)
+                return;
+            }
+        }
+
+        // Warn for unknown unit types (I)
+        if !tables::is_known_unit(chs.unit_type_byte) {
+            eprintln!(
+                "Unknown units[{}] for {}",
+                chs.unit_type_byte & 0x7F,
+                chs.long_name()
+            );
+        }
+
+        // Warn for non-zero CHS padding bytes (I)
+        let has_nonzero_pad = chs._pad_2_4.iter().any(|&b| b != 0)
+            || chs._pad_17_20.iter().any(|&b| b != 0)
+            || chs._pad_21_24.iter().any(|&b| b != 0)
+            || chs._pad_56_64.iter().any(|&b| b != 0)
+            || chs._pad_70_72.iter().any(|&b| b != 0)
+            || chs._pad_73_76.iter().any(|&b| b != 0)
+            || chs._pad_85_88.iter().any(|&b| b != 0)
+            || chs._pad_93_96.iter().any(|&b| b != 0);
+        if has_nonzero_pad {
+            let mut details = Vec::new();
+            for (base, pad) in [
+                (2usize, &chs._pad_2_4[..]),
+                (17, &chs._pad_17_20[..]),
+                (21, &chs._pad_21_24[..]),
+                (56, &chs._pad_56_64[..]),
+                (70, &chs._pad_70_72[..]),
+                (73, &chs._pad_73_76[..]),
+                (85, &chs._pad_85_88[..]),
+                (93, &chs._pad_93_96[..]),
+            ] {
+                for (i, &b) in pad.iter().enumerate() {
+                    if b != 0 {
+                        details.push(format!("[{}]=0x{:02x}", base + i, b));
+                    }
+                }
+            }
+            eprintln!(
+                "CHS padding non-zero for channel {}: {}. \
+                 Please report at https://github.com/m3rlin45/libxrk/issues with your XRK file.",
+                chs.long_name(),
+                details.join(", ")
+            );
+        }
+
         // Register in channel_sizes
         self.channel_sizes.insert(chs.index, chs.data_size);
 
@@ -364,7 +439,7 @@ impl ParserState {
             .insert(grp.index, GroupInfo { grp: grp.clone() });
     }
 
-    fn finalize(self) -> ParseResult {
+    fn finalize(self) -> Result<ParseResult, Error> {
         // Compute time_offset and last_time
         let mut tc_min_candidates: Vec<i64> = Vec::new();
         let mut tc_max_candidates: Vec<i64> = Vec::new();
@@ -444,12 +519,12 @@ impl ParserState {
 
         // Now decode channels
         let channel_data =
-            decode_all_channels(&self.gc_data, &self.channels, &self.groups, time_offset);
+            decode_all_channels(&self.gc_data, &self.channels, &self.groups, time_offset)?;
 
         // Extract and process lap info from LAP messages
         let laps = process_laps(&self.header_messages, time_offset);
 
-        ParseResult {
+        Ok(ParseResult {
             channels: self.channels,
             groups: self.groups,
             header_messages: self.header_messages,
@@ -460,7 +535,7 @@ impl ParserState {
             channel_data,
             laps,
             enf_sub_messages: self.enf_sub_messages,
-        }
+        })
     }
 }
 
@@ -538,17 +613,23 @@ fn prescan(data: &[u8], state: &mut ParserState) -> PrescanResult {
                 }
                 b'c' => {
                     if pos + 12 <= len {
+                        let unk1 = data[pos + 2];
                         let channel_field = u16::from_le_bytes([data[pos + 3], data[pos + 4]]);
-                        let index = (channel_field >> 3) as usize;
-                        if index < state.gc_data[2].len() {
-                            let total_size = state.gc_data[2][index].add_helper;
-                            if total_size > 8
-                                && pos + total_size <= len
-                                && data[pos + total_size - 1] == b')'
-                            {
-                                hints.add_data_bytes(2, index, total_size - 8);
-                                pos += total_size;
-                                continue;
+                        let unk3 = data[pos + 5];
+                        let unk4 = data[pos + 6];
+                        // Validate c-message fields (C)
+                        if unk1 == 0 && (channel_field & 7) == 4 && unk3 == 0x84 && unk4 == 6 {
+                            let index = (channel_field >> 3) as usize;
+                            if index < state.gc_data[2].len() {
+                                let total_size = state.gc_data[2][index].add_helper;
+                                if total_size > 8
+                                    && pos + total_size <= len
+                                    && data[pos + total_size - 1] == b')'
+                                {
+                                    hints.add_data_bytes(2, index, total_size - 8);
+                                    pos += total_size;
+                                    continue;
+                                }
                             }
                         }
                     }
@@ -606,15 +687,43 @@ fn prescan_header_message(msg: &HeaderMessage, state: &mut ParserState, hints: &
     }
 }
 
+/// Print accumulated bad bytes as a diagnostic warning.
+fn flush_bad_bytes(data: &[u8], bad_pos: usize, bad_count: usize) {
+    if bad_count > 0 {
+        let end = (bad_pos + bad_count).min(data.len());
+        let hex: Vec<String> = data[bad_pos..end]
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect();
+        eprintln!(
+            "Bad bytes({} at {:x}): {}",
+            bad_count,
+            bad_pos,
+            hex.join(", ")
+        );
+    }
+}
+
 /// Scan the byte stream and populate the parser state.
-fn scan_stream(data: &[u8], state: &mut ParserState, progress: Option<&dyn Fn(usize, usize)>) {
+/// Returns the final position after scanning.
+fn scan_stream(
+    data: &[u8],
+    state: &mut ParserState,
+    progress: Option<&dyn Fn(usize, usize)>,
+) -> usize {
     let len = data.len();
     let mut pos: usize = 0;
+    let mut bad_pos: usize = 0;
+    let mut bad_count: usize = 0;
     let progress_interval: usize = 8_000_000;
     let mut next_progress: usize = progress_interval;
 
     while pos < len {
         if pos + 3 > len {
+            if bad_count == 0 {
+                bad_pos = pos;
+            }
+            bad_count += 1;
             pos += 1;
             continue;
         }
@@ -628,6 +737,8 @@ fn scan_stream(data: &[u8], state: &mut ParserState, progress: Option<&dyn Fn(us
                 b'G' => {
                     // G message: group data
                     if let Some(consumed) = try_parse_g_message(data, pos, state) {
+                        flush_bad_bytes(data, bad_pos, bad_count);
+                        bad_count = 0;
                         pos += consumed;
                         continue;
                     }
@@ -635,6 +746,8 @@ fn scan_stream(data: &[u8], state: &mut ParserState, progress: Option<&dyn Fn(us
                 b'S' => {
                     // S message: single channel sample
                     if let Some(consumed) = try_parse_s_message(data, pos, state) {
+                        flush_bad_bytes(data, bad_pos, bad_count);
+                        bad_count = 0;
                         pos += consumed;
                         continue;
                     }
@@ -642,6 +755,8 @@ fn scan_stream(data: &[u8], state: &mut ParserState, progress: Option<&dyn Fn(us
                 b'M' => {
                     // M message: multi-sample burst
                     if let Some(consumed) = try_parse_m_message(data, pos, state) {
+                        flush_bad_bytes(data, bad_pos, bad_count);
+                        bad_count = 0;
                         pos += consumed;
                         continue;
                     }
@@ -649,6 +764,8 @@ fn scan_stream(data: &[u8], state: &mut ParserState, progress: Option<&dyn Fn(us
                 b'c' => {
                     // c message: expansion device channel
                     if let Some(consumed) = try_parse_c_message(data, pos, state) {
+                        flush_bad_bytes(data, bad_pos, bad_count);
+                        bad_count = 0;
                         pos += consumed;
                         continue;
                     }
@@ -665,15 +782,26 @@ fn scan_stream(data: &[u8], state: &mut ParserState, progress: Option<&dyn Fn(us
             }
 
             if let Ok((msg, consumed)) = HeaderMessage::parse(data, pos) {
+                flush_bad_bytes(data, bad_pos, bad_count);
+                bad_count = 0;
                 handle_header_message(&msg, state);
                 pos += consumed;
                 continue;
             }
         }
 
-        // No match — skip byte
+        // No match — bad byte
+        if bad_count == 0 {
+            bad_pos = pos;
+        }
+        bad_count += 1;
         pos += 1;
     }
+
+    // Flush any remaining bad bytes
+    flush_bad_bytes(data, bad_pos, bad_count);
+
+    pos
 }
 
 /// Handle a parsed header message: dispatch payload and update state.
@@ -864,6 +992,13 @@ fn try_parse_m_message(data: &[u8], pos: usize, state: &mut ParserState) -> Opti
     let sample_size = state.gc_data[3][index].add_helper;
     let mms = state.gc_data[3][index].mms;
     if mms == 0 {
+        // Warn about missing sample period (G) — matches Cython error-recovery behavior
+        let ch_name = state
+            .channels
+            .get(&(index as u16))
+            .map(|c| c.chs.long_name())
+            .unwrap_or_else(|| "unknown".to_string());
+        eprintln!("No ms understood for channel {}", ch_name);
         return None;
     }
 
@@ -908,7 +1043,14 @@ fn try_parse_c_message(data: &[u8], pos: usize, state: &mut ParserState) -> Opti
     }
 
     // c message header: (c + unk1(1) + channel_field(2) + unk3(1) + unk4(1) + timecode(4)
+    // Validate c-message fields (C)
+    let unk1 = data[pos + 2];
     let channel_field = u16::from_le_bytes([data[pos + 3], data[pos + 4]]);
+    let unk3 = data[pos + 5];
+    let unk4 = data[pos + 6];
+    if unk1 != 0 || (channel_field & 7) != 4 || unk3 != 0x84 || unk4 != 6 {
+        return None;
+    }
     let timecode =
         i32::from_le_bytes([data[pos + 7], data[pos + 8], data[pos + 9], data[pos + 10]]);
     let index = (channel_field >> 3) as usize;
@@ -942,7 +1084,7 @@ fn decode_all_channels(
     channels: &HashMap<u16, ChannelInfo>,
     groups: &HashMap<u16, GroupInfo>,
     time_offset: i64,
-) -> HashMap<u16, ChannelData> {
+) -> Result<HashMap<u16, ChannelData>, Error> {
     let mut result = HashMap::new();
 
     for (&ch_idx, ch_info) in channels {
@@ -1029,6 +1171,17 @@ fn decode_all_channels(
         } else {
             // Non-group channel: try S messages, then c messages, then M messages
             let ch_usize = ch_idx as usize;
+
+            // Check for S/c + M conflict (E)
+            let has_sc = (ch_usize < gc_data[1].len() && !gc_data[1][ch_usize].data.is_empty())
+                || (ch_usize < gc_data[2].len() && !gc_data[2][ch_usize].data.is_empty());
+            let has_m = ch_usize < gc_data[3].len() && !gc_data[3][ch_usize].timecodes.is_empty();
+            if has_sc && has_m {
+                return Err(Error::InvalidData(format!(
+                    "Can't have both S/c and M records for channel {} (index={})",
+                    ch_name, ch_usize
+                )));
+            }
 
             // Check S messages
             let (view_offset, stride_offset, cat_idx) =
@@ -1128,11 +1281,12 @@ fn decode_all_channels(
         }
     }
 
-    result
+    Ok(result)
 }
 
 /// Raw parsed lap data: parallel vectors of (lap_num, start_time, end_time).
 /// Lap nums are normalized to 0-based indexing.
+#[derive(Debug)]
 struct RawLapData {
     lap_nums: Vec<i32>,
     start_times: Vec<i64>,
@@ -1147,7 +1301,7 @@ struct RawLapData {
 fn parse_lap_messages(
     header_messages: &HashMap<u32, Vec<HeaderMessage>>,
     time_offset: i64,
-) -> RawLapData {
+) -> Result<RawLapData, Error> {
     use binrw::BinRead;
     use std::io::Cursor;
 
@@ -1185,9 +1339,14 @@ fn parse_lap_messages(
                     lap_nums.push(lap_num - 1);
                     start_times.push(inferred_start);
                     end_times.push(end_time - duration);
+                } else if last_num + 1 != lap_num {
+                    // Unexpected gap (> 1 or backwards) (B)
+                    return Err(Error::InvalidData(format!(
+                        "Lap gap from {} to {}",
+                        last_num, lap_num
+                    )));
                 }
                 // last_num + 1 == lap_num: sequential — accept (fall through)
-                // else: unexpected gap, skip silently (Cython asserts but we don't)
             }
             // else: first lap — accept (fall through)
 
@@ -1204,20 +1363,27 @@ fn parse_lap_messages(
         }
     }
 
-    RawLapData {
+    Ok(RawLapData {
         lap_nums,
         start_times,
         end_times,
-    }
+    })
 }
 
 /// Process LAP messages with segment filtering, dedup, gap-fill, 0-based normalization.
 /// Returns internal `LapInfo` structs stored in `ParseResult`.
+/// Errors from parse_lap_messages are logged and result in empty laps.
 fn process_laps(
     header_messages: &HashMap<u32, Vec<HeaderMessage>>,
     time_offset: i64,
 ) -> Vec<LapInfo> {
-    let raw = parse_lap_messages(header_messages, time_offset);
+    let raw = match parse_lap_messages(header_messages, time_offset) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Warning: lap parsing error: {}", e);
+            return Vec::new();
+        }
+    };
 
     raw.lap_nums
         .iter()
@@ -1241,10 +1407,11 @@ pub struct ProcessedLap {
 }
 
 /// Get processed laps from ParseResult (with proper start/end times).
-pub fn get_processed_laps(result: &ParseResult) -> Vec<ProcessedLap> {
-    let raw = parse_lap_messages(&result.header_messages, result.time_offset);
+pub fn get_processed_laps(result: &ParseResult) -> Result<Vec<ProcessedLap>, Error> {
+    let raw = parse_lap_messages(&result.header_messages, result.time_offset)?;
 
-    raw.lap_nums
+    Ok(raw
+        .lap_nums
         .iter()
         .enumerate()
         .map(|(i, &n)| ProcessedLap {
@@ -1252,5 +1419,722 @@ pub fn get_processed_laps(result: &ParseResult) -> Vec<ProcessedLap> {
             start_time: raw.start_times[i],
             end_time: raw.end_times[i],
         })
-        .collect()
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::messages::{tokdec, HeaderMessage};
+    use std::collections::HashMap;
+
+    // ── Header message frame builder ───────────────────────────────────
+
+    /// Build a valid header message frame with correct checksum and framing.
+    fn make_header_frame(token_str: &str, version: u8, payload: &[u8]) -> Vec<u8> {
+        let wire_token = tokdec(token_str);
+        // Pad 3-char tokens with space
+        let wire_token = if token_str.len() == 3 {
+            wire_token | (0x20 << 24)
+        } else {
+            wire_token
+        };
+        let payload_len = payload.len() as i32;
+        let checksum: u16 = payload
+            .iter()
+            .fold(0u16, |acc, &b| acc.wrapping_add(b as u16));
+
+        let mut frame = Vec::new();
+        frame.push(0x3C); // '<'
+        frame.push(0x68); // 'h'
+        frame.extend_from_slice(&wire_token.to_le_bytes());
+        frame.extend_from_slice(&payload_len.to_le_bytes());
+        frame.push(version);
+        frame.push(0x3E); // '>'
+        frame.extend_from_slice(payload);
+        frame.push(0x3C); // '<'
+        frame.extend_from_slice(&wire_token.to_le_bytes());
+        frame.extend_from_slice(&checksum.to_le_bytes());
+        frame.push(0x3E); // '>'
+        frame
+    }
+
+    // ── CHS payload builder ────────────────────────────────────────────
+
+    /// Build a 112-byte CHS payload with the given properties.
+    fn make_chs_bytes(
+        index: u16,
+        short_name: &str,
+        long_name: &str,
+        decoder_type: u8,
+        data_size: u8,
+        unit_type_byte: u8,
+        sample_period_us: u32,
+    ) -> Vec<u8> {
+        let mut data = vec![0u8; 112];
+        data[0..2].copy_from_slice(&index.to_le_bytes());
+        data[12] = unit_type_byte;
+        data[20] = decoder_type;
+        // short_name at [24:32]
+        for (i, b) in short_name.bytes().enumerate() {
+            if i < 8 {
+                data[24 + i] = b;
+            }
+        }
+        // long_name at [32:56]
+        for (i, b) in long_name.bytes().enumerate() {
+            if i < 24 {
+                data[32 + i] = b;
+            }
+        }
+        data[64..68].copy_from_slice(&sample_period_us.to_le_bytes());
+        data[72] = data_size;
+        data
+    }
+
+    // ── LAP payload builder ────────────────────────────────────────────
+
+    /// Build a 20-byte LAP payload.
+    fn make_lap_payload(segment: u8, lap_num: u16, duration: u32, end_time: u32) -> Vec<u8> {
+        let mut data = vec![0u8; 20];
+        data[1] = segment;
+        data[2..4].copy_from_slice(&lap_num.to_le_bytes());
+        data[4..8].copy_from_slice(&duration.to_le_bytes());
+        data[16..20].copy_from_slice(&end_time.to_le_bytes());
+        data
+    }
+
+    // ── S message builder ──────────────────────────────────────────────
+
+    /// Build an S data message: (S + timecode(4) + index(2) + data(N) + )
+    fn make_s_message(timecode: i32, index: u16, sample_data: &[u8]) -> Vec<u8> {
+        let mut msg = Vec::new();
+        msg.push(b'(');
+        msg.push(b'S');
+        msg.extend_from_slice(&timecode.to_le_bytes());
+        msg.extend_from_slice(&index.to_le_bytes());
+        msg.extend_from_slice(sample_data);
+        msg.push(b')');
+        msg
+    }
+
+    // ── M message builder ──────────────────────────────────────────────
+
+    /// Build an M data message: (M + timecode(4) + index(2) + count(2) + data(N*count) + )
+    fn make_m_message(timecode: i32, index: u16, count: u16, samples: &[u8]) -> Vec<u8> {
+        let mut msg = Vec::new();
+        msg.push(b'(');
+        msg.push(b'M');
+        msg.extend_from_slice(&timecode.to_le_bytes());
+        msg.extend_from_slice(&index.to_le_bytes());
+        msg.extend_from_slice(&count.to_le_bytes());
+        msg.extend_from_slice(samples);
+        msg.push(b')');
+        msg
+    }
+
+    // ── c message builder ──────────────────────────────────────────────
+
+    /// Build a c (expansion) message:
+    /// (c + unk1(1) + channel_field(2) + unk3(1) + unk4(1) + timecode(4) + data(N) + )
+    fn make_c_message(index: u16, timecode: i32, sample_data: &[u8]) -> Vec<u8> {
+        let channel_field = (index << 3) | 4; // lower 3 bits = 0b100
+        let mut msg = Vec::new();
+        msg.push(b'(');
+        msg.push(b'c');
+        msg.push(0); // unk1
+        msg.extend_from_slice(&channel_field.to_le_bytes());
+        msg.push(0x84); // unk3
+        msg.push(6); // unk4
+        msg.extend_from_slice(&timecode.to_le_bytes());
+        msg.extend_from_slice(sample_data);
+        msg.push(b')');
+        msg
+    }
+
+    /// Build a c message with custom field values for validation testing.
+    fn make_c_message_raw(
+        unk1: u8,
+        channel_field: u16,
+        unk3: u8,
+        unk4: u8,
+        timecode: i32,
+        sample_data: &[u8],
+    ) -> Vec<u8> {
+        let mut msg = Vec::new();
+        msg.push(b'(');
+        msg.push(b'c');
+        msg.push(unk1);
+        msg.extend_from_slice(&channel_field.to_le_bytes());
+        msg.push(unk3);
+        msg.push(unk4);
+        msg.extend_from_slice(&timecode.to_le_bytes());
+        msg.extend_from_slice(sample_data);
+        msg.push(b')');
+        msg
+    }
+
+    // ── GRP payload builder ────────────────────────────────────────────
+
+    fn make_grp_payload(index: u16, channel_indices: &[u16]) -> Vec<u8> {
+        let mut data = Vec::new();
+        data.extend_from_slice(&index.to_le_bytes());
+        data.extend_from_slice(&(channel_indices.len() as u16).to_le_bytes());
+        for &ch in channel_indices {
+            data.extend_from_slice(&ch.to_le_bytes());
+        }
+        data
+    }
+
+    // ── Build a complete XRK stream from components ────────────────────
+
+    /// Build a minimal XRK stream: CHS header(s) + data messages.
+    fn build_xrk_stream(headers: &[Vec<u8>], data_msgs: &[Vec<u8>]) -> Vec<u8> {
+        let mut stream = Vec::new();
+        for h in headers {
+            stream.extend_from_slice(h);
+        }
+        for d in data_msgs {
+            stream.extend_from_slice(d);
+        }
+        stream
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Tests
+    // ═══════════════════════════════════════════════════════════════════
+
+    // ── parse_xrk: basic tests ─────────────────────────────────────────
+
+    #[test]
+    fn test_parse_xrk_empty() {
+        let result = parse_xrk(&[], None);
+        assert!(result.is_ok());
+        let r = result.unwrap();
+        assert!(r.channels.is_empty());
+        assert!(r.channel_data.is_empty());
+    }
+
+    #[test]
+    fn test_parse_xrk_single_chs_no_data() {
+        let chs_bytes = make_chs_bytes(0, "RPM", "Engine RPM", 0, 4, 15, 0);
+        let frame = make_header_frame("CHS", 0, &chs_bytes);
+        let result = parse_xrk(&frame, None).unwrap();
+        assert_eq!(result.channels.len(), 1);
+        assert!(result.channels.contains_key(&0));
+        assert!(result.channel_data.is_empty());
+    }
+
+    #[test]
+    fn test_parse_xrk_s_message_produces_channel_data() {
+        // decoder_type=0 → i32, byte_size=4
+        let chs_bytes = make_chs_bytes(0, "RPM", "Engine RPM", 0, 4, 15, 0);
+        let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        let sample = 5000i32.to_le_bytes();
+        let s_msg = make_s_message(1000, 0, &sample);
+        let stream = build_xrk_stream(&[chs_frame], &[s_msg]);
+        let result = parse_xrk(&stream, None).unwrap();
+        assert!(result.channel_data.contains_key(&0));
+        let ch = &result.channel_data[&0];
+        assert_eq!(ch.timecodes.len(), 1);
+        match &ch.values {
+            ChannelValues::Int32(v) => {
+                assert_eq!(v.len(), 1);
+                assert_eq!(v[0], 5000);
+            }
+            other => panic!("expected Int32, got {:?}", std::mem::discriminant(other)),
+        }
+    }
+
+    #[test]
+    fn test_parse_xrk_multiple_s_messages() {
+        let chs_bytes = make_chs_bytes(0, "RPM", "Engine RPM", 0, 4, 15, 0);
+        let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        let s1 = make_s_message(1000, 0, &1000i32.to_le_bytes());
+        let s2 = make_s_message(2000, 0, &2000i32.to_le_bytes());
+        let s3 = make_s_message(3000, 0, &3000i32.to_le_bytes());
+        let stream = build_xrk_stream(&[chs_frame], &[s1, s2, s3]);
+        let result = parse_xrk(&stream, None).unwrap();
+        let ch = &result.channel_data[&0];
+        assert_eq!(ch.timecodes.len(), 3);
+        match &ch.values {
+            ChannelValues::Int32(v) => assert_eq!(v, &[1000, 2000, 3000]),
+            _ => panic!("expected Int32"),
+        }
+    }
+
+    #[test]
+    fn test_parse_xrk_s_message_timecode_dedup() {
+        // Two S messages with the same timecode: only the first should be accepted
+        let chs_bytes = make_chs_bytes(0, "RPM", "Engine RPM", 0, 4, 15, 0);
+        let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        let s1 = make_s_message(1000, 0, &100i32.to_le_bytes());
+        let s2 = make_s_message(1000, 0, &200i32.to_le_bytes()); // dupe timecode
+        let s3 = make_s_message(2000, 0, &300i32.to_le_bytes());
+        let stream = build_xrk_stream(&[chs_frame], &[s1, s2, s3]);
+        let result = parse_xrk(&stream, None).unwrap();
+        let ch = &result.channel_data[&0];
+        assert_eq!(ch.timecodes.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_xrk_m_message_produces_channel_data() {
+        // decoder_type=1 → u16, byte_size=2; mms from sample_period_us
+        let chs_bytes = make_chs_bytes(0, "TPS", "TPS", 1, 2, 1, 10_000);
+        let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        // 3 samples of u16, each 2 bytes
+        let mut samples = Vec::new();
+        samples.extend_from_slice(&100u16.to_le_bytes());
+        samples.extend_from_slice(&200u16.to_le_bytes());
+        samples.extend_from_slice(&300u16.to_le_bytes());
+        let m_msg = make_m_message(1000, 0, 3, &samples);
+        let stream = build_xrk_stream(&[chs_frame], &[m_msg]);
+        let result = parse_xrk(&stream, None).unwrap();
+        let ch = &result.channel_data[&0];
+        // 3 samples at mms=10: timecodes should be 1000, 1010, 1020 (relative)
+        assert_eq!(ch.timecodes.len(), 3);
+        match &ch.values {
+            ChannelValues::UInt16(v) => assert_eq!(v, &[100, 200, 300]),
+            _ => panic!("expected UInt16"),
+        }
+    }
+
+    #[test]
+    fn test_parse_xrk_c_message_produces_channel_data() {
+        let chs_bytes = make_chs_bytes(0, "EGT", "Exhaust Gas", 0, 4, 17, 0);
+        let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        let c_msg = make_c_message(0, 1000, &500i32.to_le_bytes());
+        let stream = build_xrk_stream(&[chs_frame], &[c_msg]);
+        let result = parse_xrk(&stream, None).unwrap();
+        let ch = &result.channel_data[&0];
+        assert_eq!(ch.timecodes.len(), 1);
+        match &ch.values {
+            ChannelValues::Int32(v) => assert_eq!(v[0], 500),
+            _ => panic!("expected Int32"),
+        }
+    }
+
+    #[test]
+    fn test_parse_xrk_float32_decoder() {
+        // decoder_type=6 → f32
+        let chs_bytes = make_chs_bytes(0, "TEMP", "Temperature", 6, 4, 17, 0);
+        let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        let sample = 98.6f32.to_le_bytes();
+        let s_msg = make_s_message(1000, 0, &sample);
+        let stream = build_xrk_stream(&[chs_frame], &[s_msg]);
+        let result = parse_xrk(&stream, None).unwrap();
+        let ch = &result.channel_data[&0];
+        match &ch.values {
+            ChannelValues::Float32(v) => assert!((v[0] - 98.6).abs() < 0.1),
+            _ => panic!("expected Float32"),
+        }
+    }
+
+    #[test]
+    fn test_parse_xrk_multiple_channels() {
+        let chs0 = make_chs_bytes(0, "RPM", "Engine RPM", 0, 4, 15, 0);
+        let chs1 = make_chs_bytes(1, "TPS", "Throttle", 0, 4, 1, 0);
+        let f0 = make_header_frame("CHS", 0, &chs0);
+        let f1 = make_header_frame("CHS", 0, &chs1);
+        let s0 = make_s_message(1000, 0, &5000i32.to_le_bytes());
+        let s1 = make_s_message(1000, 1, &50i32.to_le_bytes());
+        let stream = build_xrk_stream(&[f0, f1], &[s0, s1]);
+        let result = parse_xrk(&stream, None).unwrap();
+        assert_eq!(result.channels.len(), 2);
+        assert!(result.channel_data.contains_key(&0));
+        assert!(result.channel_data.contains_key(&1));
+    }
+
+    // ── G (group) messages ─────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_xrk_group_message() {
+        // Create two channels in a group
+        let chs0 = make_chs_bytes(0, "RPM", "Engine RPM", 0, 4, 15, 0);
+        let chs1 = make_chs_bytes(1, "TPS", "Throttle", 0, 4, 1, 0);
+        let f0 = make_header_frame("CHS", 0, &chs0);
+        let f1 = make_header_frame("CHS", 0, &chs1);
+        let grp_payload = make_grp_payload(0, &[0, 1]);
+        let f_grp = make_header_frame("GRP", 0, &grp_payload);
+
+        // G message: (G + timecode(4) + index(2) + ch0_data(4) + ch1_data(4) + )
+        let mut g_msg = Vec::new();
+        g_msg.push(b'(');
+        g_msg.push(b'G');
+        g_msg.extend_from_slice(&1000i32.to_le_bytes()); // timecode
+        g_msg.extend_from_slice(&0u16.to_le_bytes()); // group index
+        g_msg.extend_from_slice(&5000i32.to_le_bytes()); // ch0 value
+        g_msg.extend_from_slice(&50i32.to_le_bytes()); // ch1 value
+        g_msg.push(b')');
+
+        let stream = build_xrk_stream(&[f0, f1, f_grp], &[g_msg]);
+        let result = parse_xrk(&stream, None).unwrap();
+        assert!(result.channel_data.contains_key(&0));
+        assert!(result.channel_data.contains_key(&1));
+        match &result.channel_data[&0].values {
+            ChannelValues::Int32(v) => assert_eq!(v[0], 5000),
+            _ => panic!("expected Int32 for RPM"),
+        }
+        match &result.channel_data[&1].values {
+            ChannelValues::Int32(v) => assert_eq!(v[0], 50),
+            _ => panic!("expected Int32 for TPS"),
+        }
+    }
+
+    // ── c-message field validation (C) ─────────────────────────────────
+
+    #[test]
+    fn test_c_message_valid_fields_accepted() {
+        let chs_bytes = make_chs_bytes(0, "EGT", "Exhaust Gas", 0, 4, 17, 0);
+        let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        let c_msg = make_c_message(0, 1000, &100i32.to_le_bytes());
+        let stream = build_xrk_stream(&[chs_frame], &[c_msg]);
+        let result = parse_xrk(&stream, None).unwrap();
+        assert!(result.channel_data.contains_key(&0));
+    }
+
+    #[test]
+    fn test_c_message_invalid_unk1_rejected() {
+        let chs_bytes = make_chs_bytes(0, "EGT", "Exhaust Gas", 0, 4, 17, 0);
+        let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        let c_msg = make_c_message_raw(1, 4, 0x84, 6, 1000, &100i32.to_le_bytes());
+        let stream = build_xrk_stream(&[chs_frame], &[c_msg]);
+        let result = parse_xrk(&stream, None).unwrap();
+        // Invalid c-message should be skipped, no channel data
+        assert!(!result.channel_data.contains_key(&0));
+    }
+
+    #[test]
+    fn test_c_message_invalid_channel_low_bits_rejected() {
+        let chs_bytes = make_chs_bytes(0, "EGT", "Exhaust Gas", 0, 4, 17, 0);
+        let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        // channel_field lower 3 bits = 5 instead of 4
+        let c_msg = make_c_message_raw(0, 5, 0x84, 6, 1000, &100i32.to_le_bytes());
+        let stream = build_xrk_stream(&[chs_frame], &[c_msg]);
+        let result = parse_xrk(&stream, None).unwrap();
+        assert!(!result.channel_data.contains_key(&0));
+    }
+
+    #[test]
+    fn test_c_message_invalid_unk3_rejected() {
+        let chs_bytes = make_chs_bytes(0, "EGT", "Exhaust Gas", 0, 4, 17, 0);
+        let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        let c_msg = make_c_message_raw(0, 4, 0x85, 6, 1000, &100i32.to_le_bytes());
+        let stream = build_xrk_stream(&[chs_frame], &[c_msg]);
+        let result = parse_xrk(&stream, None).unwrap();
+        assert!(!result.channel_data.contains_key(&0));
+    }
+
+    #[test]
+    fn test_c_message_invalid_unk4_rejected() {
+        let chs_bytes = make_chs_bytes(0, "EGT", "Exhaust Gas", 0, 4, 17, 0);
+        let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        let c_msg = make_c_message_raw(0, 4, 0x84, 7, 1000, &100i32.to_le_bytes());
+        let stream = build_xrk_stream(&[chs_frame], &[c_msg]);
+        let result = parse_xrk(&stream, None).unwrap();
+        assert!(!result.channel_data.contains_key(&0));
+    }
+
+    // ── LAP message tests (B) ──────────────────────────────────────────
+
+    fn make_lap_header_messages(laps: &[(u8, u16, u32, u32)]) -> HashMap<u32, Vec<HeaderMessage>> {
+        let mut map = HashMap::new();
+        let lap_token = tokens::lap();
+        let msgs: Vec<HeaderMessage> = laps
+            .iter()
+            .map(|&(segment, lap_num, duration, end_time)| {
+                let payload = make_lap_payload(segment, lap_num, duration, end_time);
+                HeaderMessage {
+                    token: lap_token,
+                    version: 0,
+                    payload,
+                }
+            })
+            .collect();
+        map.insert(lap_token, msgs);
+        map
+    }
+
+    #[test]
+    fn test_lap_sequential_ok() {
+        // Three sequential laps: 1, 2, 3
+        let msgs = make_lap_header_messages(&[
+            (0, 1, 60000, 60000),  // lap 1: 0-60s
+            (0, 2, 55000, 115000), // lap 2: 60s-115s
+            (0, 3, 58000, 173000), // lap 3: 115s-173s
+        ]);
+        let raw = parse_lap_messages(&msgs, 0).unwrap();
+        assert_eq!(raw.lap_nums.len(), 3);
+        // Should be 0-based: [0, 1, 2]
+        assert_eq!(raw.lap_nums, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_lap_gap_of_one_fills() {
+        // Laps 1, 3 (gap of 1) — should infer lap 2
+        let msgs = make_lap_header_messages(&[
+            (0, 1, 60000, 60000),  // lap 1
+            (0, 3, 55000, 170000), // lap 3 (gap from 1 to 3 = gap of 1)
+        ]);
+        let raw = parse_lap_messages(&msgs, 0).unwrap();
+        assert_eq!(raw.lap_nums.len(), 3);
+        assert_eq!(raw.lap_nums, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_lap_gap_too_large_returns_error() {
+        // Laps 1, 4 — gap of 2, should error
+        let msgs = make_lap_header_messages(&[(0, 1, 60000, 60000), (0, 4, 55000, 230000)]);
+        let result = parse_lap_messages(&msgs, 0);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Lap gap"), "error was: {}", err);
+    }
+
+    #[test]
+    fn test_lap_duplicate_skipped() {
+        // Duplicate lap numbers are skipped
+        let msgs = make_lap_header_messages(&[
+            (0, 1, 60000, 60000),
+            (0, 1, 60000, 60000), // duplicate
+            (0, 2, 55000, 115000),
+        ]);
+        let raw = parse_lap_messages(&msgs, 0).unwrap();
+        assert_eq!(raw.lap_nums.len(), 2);
+    }
+
+    #[test]
+    fn test_lap_nonzero_segment_skipped() {
+        // Non-zero segments are filtered out
+        let msgs = make_lap_header_messages(&[
+            (0, 1, 60000, 60000),
+            (1, 1, 30000, 30000), // segment 1 — skipped
+            (0, 2, 55000, 115000),
+        ]);
+        let raw = parse_lap_messages(&msgs, 0).unwrap();
+        assert_eq!(raw.lap_nums.len(), 2);
+    }
+
+    #[test]
+    fn test_lap_no_messages() {
+        let msgs: HashMap<u32, Vec<HeaderMessage>> = HashMap::new();
+        let raw = parse_lap_messages(&msgs, 0).unwrap();
+        assert!(raw.lap_nums.is_empty());
+    }
+
+    #[test]
+    fn test_lap_time_offset_applied() {
+        let msgs = make_lap_header_messages(&[(0, 1, 60000, 160000)]);
+        let raw = parse_lap_messages(&msgs, 100000).unwrap();
+        // end_time = 160000 - 100000 = 60000
+        assert_eq!(raw.end_times[0], 60000);
+        // start_time = end_time - duration = 60000 - 60000 = 0
+        assert_eq!(raw.start_times[0], 0);
+    }
+
+    // ── CHS duplicate name check (D) ───────────────────────────────────
+
+    #[test]
+    fn test_register_chs_duplicate_same_name_ok() {
+        // Re-registering with the same name should not cause issues
+        let chs_bytes = make_chs_bytes(0, "RPM", "Engine RPM", 0, 4, 15, 0);
+        let f1 = make_header_frame("CHS", 0, &chs_bytes);
+        let f2 = make_header_frame("CHS", 0, &chs_bytes); // duplicate, same name
+        let s_msg = make_s_message(1000, 0, &5000i32.to_le_bytes());
+        let stream = build_xrk_stream(&[f1, f2], &[s_msg]);
+        let result = parse_xrk(&stream, None).unwrap();
+        assert_eq!(result.channels.len(), 1);
+        assert!(result.channel_data.contains_key(&0));
+    }
+
+    #[test]
+    fn test_register_chs_duplicate_different_name_skips() {
+        // Re-registering with a different name at the same index warns and skips
+        let chs1 = make_chs_bytes(0, "RPM", "Engine RPM", 0, 4, 15, 0);
+        let chs2 = make_chs_bytes(0, "SPD", "Speed", 0, 4, 16, 0);
+        let f1 = make_header_frame("CHS", 0, &chs1);
+        let f2 = make_header_frame("CHS", 0, &chs2);
+        let s_msg = make_s_message(1000, 0, &5000i32.to_le_bytes());
+        let stream = build_xrk_stream(&[f1, f2], &[s_msg]);
+        let result = parse_xrk(&stream, None).unwrap();
+        // The first registration should stick
+        assert_eq!(result.channels[&0].chs.long_name(), "Engine RPM");
+    }
+
+    // ── V-unit conversion ──────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_xrk_v_unit_conversion() {
+        // unit_type_byte=0x95 (0x80|21) → calibrated mV → V → divide by 1000
+        // decoder_type=0 → i32 → Float64 for V conversion
+        let chs_bytes = make_chs_bytes(0, "BATT", "Battery", 0, 4, 0x95, 0);
+        let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        let sample = 12500i32.to_le_bytes(); // 12500 mV = 12.5 V
+        let s_msg = make_s_message(1000, 0, &sample);
+        let stream = build_xrk_stream(&[chs_frame], &[s_msg]);
+        let result = parse_xrk(&stream, None).unwrap();
+        let ch = &result.channel_data[&0];
+        match &ch.values {
+            ChannelValues::Float64(v) => {
+                assert!((v[0] - 12.5).abs() < 0.001);
+            }
+            _ => panic!("expected Float64 for V-converted int channel"),
+        }
+    }
+
+    // ── ChannelValues type selection ───────────────────────────────────
+
+    #[test]
+    fn test_channel_values_type_selection() {
+        // Normal int32 decoder
+        let v = ChannelValues::new(0, "rpm", false, 10);
+        assert!(matches!(v, ChannelValues::Int32(_)));
+
+        // uint16 decoder
+        let v = ChannelValues::new(1, "%", false, 10);
+        assert!(matches!(v, ChannelValues::UInt16(_)));
+
+        // float32 decoder
+        let v = ChannelValues::new(6, "C", false, 10);
+        assert!(matches!(v, ChannelValues::Float32(_)));
+
+        // uint8 decoder
+        let v = ChannelValues::new(13, "", false, 10);
+        assert!(matches!(v, ChannelValues::UInt8(_)));
+
+        // Manual gear → UInt32
+        let v = ChannelValues::new(0, "", true, 10);
+        assert!(matches!(v, ChannelValues::UInt32(_)));
+
+        // V unit + int decoder → Float64
+        let v = ChannelValues::new(0, "V", false, 10);
+        assert!(matches!(v, ChannelValues::Float64(_)));
+
+        // V unit + float decoder → Float32
+        let v = ChannelValues::new(6, "V", false, 10);
+        assert!(matches!(v, ChannelValues::Float32(_)));
+    }
+
+    #[test]
+    fn test_channel_values_push_and_mv_to_v() {
+        let mut v = ChannelValues::Float64(Vec::new());
+        v.push(crate::decoders::SampleValue::Int32(12500));
+        v.apply_mv_to_v();
+        match v {
+            ChannelValues::Float64(vals) => assert!((vals[0] - 12.5).abs() < 0.001),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    // ── ProcessedLap integration ───────────────────────────────────────
+
+    #[test]
+    fn test_get_processed_laps_from_parse_result() {
+        let chs_bytes = make_chs_bytes(0, "RPM", "Engine RPM", 0, 4, 15, 0);
+        let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        let lap_payload = make_lap_payload(0, 1, 60000, 60000);
+        let lap_frame = make_header_frame("LAP", 0, &lap_payload);
+        let s_msg = make_s_message(1000, 0, &5000i32.to_le_bytes());
+        let stream = build_xrk_stream(&[chs_frame, lap_frame], &[s_msg]);
+        let result = parse_xrk(&stream, None).unwrap();
+        let laps = get_processed_laps(&result).unwrap();
+        assert_eq!(laps.len(), 1);
+        assert_eq!(laps[0].num, 0);
+    }
+
+    // ── time_offset computation ────────────────────────────────────────
+
+    #[test]
+    fn test_time_offset_from_data_messages() {
+        let chs_bytes = make_chs_bytes(0, "RPM", "Engine RPM", 0, 4, 15, 0);
+        let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        let s1 = make_s_message(5000, 0, &100i32.to_le_bytes());
+        let s2 = make_s_message(10000, 0, &200i32.to_le_bytes());
+        let stream = build_xrk_stream(&[chs_frame], &[s1, s2]);
+        let result = parse_xrk(&stream, None).unwrap();
+        // time_offset should be 5000 (minimum timecode)
+        assert_eq!(result.time_offset, 5000);
+        // channel timecodes should be relative: [0, 5000]
+        let ch = &result.channel_data[&0];
+        assert_eq!(ch.timecodes[0], 0);
+        assert_eq!(ch.timecodes[1], 5000);
+    }
+
+    // ── Progress callback ──────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_xrk_with_progress_callback() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let count = AtomicUsize::new(0);
+        let cb = |_current: usize, _total: usize| {
+            count.fetch_add(1, Ordering::Relaxed);
+        };
+        let chs_bytes = make_chs_bytes(0, "RPM", "Engine RPM", 0, 4, 15, 0);
+        let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        let stream = build_xrk_stream(&[chs_frame], &[]);
+        let _ = parse_xrk(&stream, Some(&cb));
+        // Progress callback may or may not fire depending on data size (8MB threshold)
+        // Just verify it doesn't crash
+    }
+
+    // ── Header message parsing ─────────────────────────────────────────
+
+    #[test]
+    fn test_header_message_stored() {
+        let lap_payload = make_lap_payload(0, 1, 60000, 60000);
+        let lap_frame = make_header_frame("LAP", 0, &lap_payload);
+        let result = parse_xrk(&lap_frame, None).unwrap();
+        let lap_token = tokens::lap();
+        assert!(result.header_messages.contains_key(&lap_token));
+        assert_eq!(result.header_messages[&lap_token].len(), 1);
+    }
+
+    // ── M-message mms=0 warning (G) ───────────────────────────────────
+
+    #[test]
+    fn test_m_message_mms_zero_rejected() {
+        // sample_period_us=0 → mms=0 → M messages should be skipped
+        let chs_bytes = make_chs_bytes(0, "TPS", "Throttle", 1, 2, 1, 0);
+        let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        let mut samples = Vec::new();
+        samples.extend_from_slice(&100u16.to_le_bytes());
+        let m_msg = make_m_message(1000, 0, 1, &samples);
+        let stream = build_xrk_stream(&[chs_frame], &[m_msg]);
+        let result = parse_xrk(&stream, None).unwrap();
+        // M-message should be skipped since mms=0
+        assert!(!result.channel_data.contains_key(&0));
+    }
+
+    // ── Decoder types ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_xrk_uint8_decoder() {
+        // decoder_type=13 → u8, byte_size=1
+        let chs_bytes = make_chs_bytes(0, "GEAR", "Gear", 13, 1, 31, 0);
+        let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        let s_msg = make_s_message(1000, 0, &[3]);
+        let stream = build_xrk_stream(&[chs_frame], &[s_msg]);
+        let result = parse_xrk(&stream, None).unwrap();
+        let ch = &result.channel_data[&0];
+        match &ch.values {
+            ChannelValues::UInt8(v) => assert_eq!(v[0], 3),
+            _ => panic!("expected UInt8"),
+        }
+    }
+
+    #[test]
+    fn test_parse_xrk_int16_decoder() {
+        // decoder_type=4 → i16, byte_size=2
+        let chs_bytes = make_chs_bytes(0, "STEER", "Steering", 4, 2, 4, 0);
+        let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        let sample = (-300i16).to_le_bytes();
+        let s_msg = make_s_message(1000, 0, &sample);
+        let stream = build_xrk_stream(&[chs_frame], &[s_msg]);
+        let result = parse_xrk(&stream, None).unwrap();
+        let ch = &result.channel_data[&0];
+        match &ch.values {
+            ChannelValues::Int16(v) => assert_eq!(v[0], -300),
+            _ => panic!("expected Int16"),
+        }
+    }
 }

--- a/crates/libxrk/src/payloads/cal.rs
+++ b/crates/libxrk/src/payloads/cal.rs
@@ -15,7 +15,22 @@ pub struct CalPayload {
 impl CalPayload {
     /// Parse a CAL payload from raw bytes (minimum 40 bytes).
     pub fn parse(data: &[u8]) -> Self {
+        let cal_u32_8 = u32::from_le_bytes([data[8], data[9], data[10], data[11]]);
+        if cal_u32_8 != 1 {
+            eprintln!(
+                "libxrk: unexpected CAL u32[8]={} (expected 1). \
+                 Please report at https://github.com/m3rlin45/libxrk/issues",
+                cal_u32_8
+            );
+        }
         let cal_type = u32::from_le_bytes([data[20], data[21], data[22], data[23]]);
+        if cal_type != 1 && cal_type != 20 {
+            eprintln!(
+                "libxrk: unexpected CAL type {} (expected 1 or 20). \
+                 Please report at https://github.com/m3rlin45/libxrk/issues",
+                cal_type
+            );
+        }
         let raw_1 = f32::from_le_bytes([data[24], data[25], data[26], data[27]]);
         let raw_2 = f32::from_le_bytes([data[28], data[29], data[30], data[31]]);
         let (output_1, output_2) = if cal_type == 1 && data.len() >= 40 {
@@ -33,5 +48,49 @@ impl CalPayload {
             output_1,
             output_2,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_cal_data(cal_u32_8: u32, cal_type: u32, raw1: f32, raw2: f32) -> Vec<u8> {
+        let mut data = vec![0u8; 40];
+        data[8..12].copy_from_slice(&cal_u32_8.to_le_bytes());
+        data[20..24].copy_from_slice(&cal_type.to_le_bytes());
+        data[24..28].copy_from_slice(&raw1.to_le_bytes());
+        data[28..32].copy_from_slice(&raw2.to_le_bytes());
+        data[32..36].copy_from_slice(&100.0f32.to_le_bytes());
+        data[36..40].copy_from_slice(&200.0f32.to_le_bytes());
+        data
+    }
+
+    #[test]
+    fn test_cal_type_1_with_output() {
+        let data = make_cal_data(1, 1, 0.0, 5000.0);
+        let cal = CalPayload::parse(&data);
+        assert_eq!(cal.cal_type, 1);
+        assert_eq!(cal.raw_1, 0.0);
+        assert_eq!(cal.raw_2, 5000.0);
+        assert_eq!(cal.output_1, Some(100.0));
+        assert_eq!(cal.output_2, Some(200.0));
+    }
+
+    #[test]
+    fn test_cal_type_20_no_output() {
+        let data = make_cal_data(1, 20, 1.0, 2.0);
+        let cal = CalPayload::parse(&data);
+        assert_eq!(cal.cal_type, 20);
+        assert!(cal.output_1.is_none());
+        assert!(cal.output_2.is_none());
+    }
+
+    #[test]
+    fn test_cal_raw_values() {
+        let data = make_cal_data(1, 1, 1.5, 2.5);
+        let cal = CalPayload::parse(&data);
+        assert!((cal.raw_1 - 1.5).abs() < 0.01);
+        assert!((cal.raw_2 - 2.5).abs() < 0.01);
     }
 }

--- a/crates/libxrk/src/payloads/gpsr.rs
+++ b/crates/libxrk/src/payloads/gpsr.rs
@@ -16,9 +16,47 @@ impl GpsrPayload {
     pub fn parse(data: &[u8]) -> Self {
         let gps_type = nullterm_string(&data[4..8]);
         let channel_index = u16::from_le_bytes([data[22], data[23]]);
+        if data.len() >= 36 {
+            let u32_32 = u32::from_le_bytes([data[32], data[33], data[34], data[35]]);
+            if u32_32 != 410 {
+                eprintln!(
+                    "libxrk: unexpected GPSR u32[32]={} (expected 410). \
+                     Please report at https://github.com/m3rlin45/libxrk/issues",
+                    u32_32
+                );
+            }
+        }
         GpsrPayload {
             gps_type,
             channel_index,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_gpsr_data(gps_type: &[u8; 4], channel_idx: u16, u32_32: u32) -> Vec<u8> {
+        let mut data = vec![0u8; 36];
+        data[4..8].copy_from_slice(gps_type);
+        data[22..24].copy_from_slice(&channel_idx.to_le_bytes());
+        data[32..36].copy_from_slice(&u32_32.to_le_bytes());
+        data
+    }
+
+    #[test]
+    fn test_gpsr_parse_normal() {
+        let data = make_gpsr_data(b"NAV\0", 42, 410);
+        let gpsr = GpsrPayload::parse(&data);
+        assert_eq!(gpsr.gps_type, "NAV");
+        assert_eq!(gpsr.channel_index, 42);
+    }
+
+    #[test]
+    fn test_gpsr_channel_index() {
+        let data = make_gpsr_data(b"SOL\0", 100, 410);
+        let gpsr = GpsrPayload::parse(&data);
+        assert_eq!(gpsr.channel_index, 100);
     }
 }

--- a/crates/libxrk/src/payloads/grp.rs
+++ b/crates/libxrk/src/payloads/grp.rs
@@ -27,10 +27,80 @@ impl GrpPayload {
             let off = 4 + i * 2;
             channel_indices.push(u16::from_le_bytes([data[off], data[off + 1]]));
         }
+        if channel_indices.len() != count as usize {
+            return Err("GRP channel count mismatch");
+        }
         Ok(GrpPayload {
             index,
             count,
             channel_indices,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_grp_parse_valid() {
+        // index=5, count=2, channels=[10, 11]
+        let data = [
+            5, 0, // index=5
+            2, 0, // count=2
+            10, 0, // channel 10
+            11, 0, // channel 11
+        ];
+        let grp = GrpPayload::parse(&data).unwrap();
+        assert_eq!(grp.index, 5);
+        assert_eq!(grp.count, 2);
+        assert_eq!(grp.channel_indices, vec![10, 11]);
+    }
+
+    #[test]
+    fn test_grp_parse_single_channel() {
+        let data = [
+            0, 0, // index=0
+            1, 0, // count=1
+            42, 0, // channel 42
+        ];
+        let grp = GrpPayload::parse(&data).unwrap();
+        assert_eq!(grp.count, 1);
+        assert_eq!(grp.channel_indices, vec![42]);
+    }
+
+    #[test]
+    fn test_grp_too_short() {
+        let data = [0, 0, 1]; // only 3 bytes
+        assert_eq!(
+            GrpPayload::parse(&data).unwrap_err(),
+            "GRP payload too short"
+        );
+    }
+
+    #[test]
+    fn test_grp_truncated() {
+        // count=2 but only 1 channel provided
+        let data = [
+            0, 0, // index=0
+            2, 0, // count=2
+            10, 0, // only 1 channel
+        ];
+        assert_eq!(
+            GrpPayload::parse(&data).unwrap_err(),
+            "GRP payload truncated"
+        );
+    }
+
+    #[test]
+    fn test_grp_zero_channels() {
+        let data = [
+            3, 0, // index=3
+            0, 0, // count=0
+        ];
+        let grp = GrpPayload::parse(&data).unwrap();
+        assert_eq!(grp.index, 3);
+        assert_eq!(grp.count, 0);
+        assert!(grp.channel_indices.is_empty());
     }
 }

--- a/crates/libxrk/src/payloads/racm.rs
+++ b/crates/libxrk/src/payloads/racm.rs
@@ -19,9 +19,62 @@ impl RacmPayload {
         if data.len() > 1 {
             RacmPayload::Mode(nullterm_string(data))
         } else if !data.is_empty() {
-            RacmPayload::Flag(data[0])
+            let flag = data[0];
+            if flag != 0 {
+                eprintln!(
+                    "libxrk: unexpected RACM flag {} (expected 0). \
+                     Please report at https://github.com/m3rlin45/libxrk/issues",
+                    flag
+                );
+            }
+            RacmPayload::Flag(flag)
         } else {
             RacmPayload::Flag(0)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_racm_mode_string() {
+        let data = b"speed\0";
+        let racm = RacmPayload::parse(data);
+        match racm {
+            RacmPayload::Mode(s) => assert_eq!(s, "speed"),
+            _ => panic!("expected Mode variant"),
+        }
+    }
+
+    #[test]
+    fn test_racm_mode_performance() {
+        let data = b"performance\0";
+        let racm = RacmPayload::parse(data);
+        match racm {
+            RacmPayload::Mode(s) => assert_eq!(s, "performance"),
+            _ => panic!("expected Mode variant"),
+        }
+    }
+
+    #[test]
+    fn test_racm_flag_zero() {
+        let data = [0u8];
+        let racm = RacmPayload::parse(&data);
+        match racm {
+            RacmPayload::Flag(0) => {}
+            _ => panic!("expected Flag(0)"),
+        }
+    }
+
+    #[test]
+    fn test_racm_empty() {
+        let data: [u8; 0] = [];
+        let racm = RacmPayload::parse(&data);
+        match racm {
+            RacmPayload::Flag(0) => {}
+            _ => panic!("expected Flag(0) for empty input"),
         }
     }
 }

--- a/crates/libxrk/src/tables.rs
+++ b/crates/libxrk/src/tables.rs
@@ -34,6 +34,37 @@ pub fn unit_map(unit_type: u8) -> (&'static str, u8) {
     }
 }
 
+/// Check if a unit type byte maps to a known unit in the unit map.
+/// Returns false for unit types not in the Cython `_unit_map` dictionary.
+pub fn is_known_unit(unit_type_byte: u8) -> bool {
+    matches!(
+        unit_type_byte & 0x7F,
+        1 | 3
+            | 4
+            | 5
+            | 6
+            | 9
+            | 11
+            | 12
+            | 14
+            | 15
+            | 16
+            | 17
+            | 18
+            | 19
+            | 20
+            | 21
+            | 22
+            | 24
+            | 26
+            | 27
+            | 30
+            | 31
+            | 33
+            | 43
+    )
+}
+
 /// Resolve the display unit, handling the calibrated flag (high bit of unit_type_byte).
 /// When the calibrated flag is set and base unit is "mV", display as "V".
 pub fn resolve_unit(unit_type_byte: u8) -> &'static str {
@@ -233,5 +264,124 @@ pub fn logger_model_name(model_id: u16) -> Option<&'static str> {
         649 => Some("MXP 1.3"),
         793 => Some("MXm"),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unit_map_known_types() {
+        assert_eq!(unit_map(15), ("rpm", 0));
+        assert_eq!(unit_map(17), ("C", 1));
+        assert_eq!(unit_map(1), ("%", 2));
+        assert_eq!(unit_map(14), ("bar", 2));
+        assert_eq!(unit_map(21), ("mV", 1));
+        assert_eq!(unit_map(43), ("kg", 3));
+    }
+
+    #[test]
+    fn test_unit_map_unknown_returns_empty() {
+        assert_eq!(unit_map(99), ("", 0));
+        assert_eq!(unit_map(0), ("", 0));
+        assert_eq!(unit_map(2), ("", 0));
+    }
+
+    #[test]
+    fn test_unit_map_masks_high_bit() {
+        // unit_type_byte with high bit set should still look up correctly
+        assert_eq!(unit_map(0x80 | 15), ("rpm", 0));
+        assert_eq!(unit_map(0x80 | 21), ("mV", 1));
+    }
+
+    #[test]
+    fn test_is_known_unit() {
+        assert!(is_known_unit(15)); // rpm
+        assert!(is_known_unit(1)); // %
+        assert!(is_known_unit(43)); // kg
+        assert!(!is_known_unit(0));
+        assert!(!is_known_unit(2));
+        assert!(!is_known_unit(99));
+    }
+
+    #[test]
+    fn test_is_known_unit_masks_high_bit() {
+        assert!(is_known_unit(0x80 | 15));
+        assert!(!is_known_unit(0x80 | 2));
+    }
+
+    #[test]
+    fn test_resolve_unit_calibrated_mv_to_v() {
+        // unit_type_byte=21 is mV; with high bit set (calibrated) → "V"
+        assert_eq!(resolve_unit(0x80 | 21), "V");
+    }
+
+    #[test]
+    fn test_resolve_unit_uncalibrated_mv_stays_mv() {
+        assert_eq!(resolve_unit(21), "mV");
+    }
+
+    #[test]
+    fn test_resolve_unit_calibrated_non_mv() {
+        // High bit set but not mV — should return base unit
+        assert_eq!(resolve_unit(0x80 | 15), "rpm");
+    }
+
+    #[test]
+    fn test_decoder_info_known_types() {
+        let d = decoder_info(0).unwrap();
+        assert_eq!(d.format, 'i');
+        assert!(!d.interpolate);
+        assert_eq!(d.byte_size, 4);
+
+        let d = decoder_info(1).unwrap();
+        assert_eq!(d.format, 'H');
+        assert!(d.interpolate);
+        assert_eq!(d.byte_size, 2);
+
+        let d = decoder_info(6).unwrap();
+        assert_eq!(d.format, 'f');
+        assert!(d.interpolate);
+        assert_eq!(d.byte_size, 4);
+
+        let d = decoder_info(13).unwrap();
+        assert_eq!(d.format, 'B');
+        assert!(!d.interpolate);
+        assert_eq!(d.byte_size, 1);
+    }
+
+    #[test]
+    fn test_decoder_info_unknown_returns_none() {
+        assert!(decoder_info(2).is_none());
+        assert!(decoder_info(5).is_none());
+        assert!(decoder_info(255).is_none());
+    }
+
+    #[test]
+    fn test_resolve_function_known() {
+        assert_eq!(resolve_function(0, 0x0f, 0), "Engine RPM");
+        assert_eq!(resolve_function(0, 0x11, 0), "Temperature");
+        assert_eq!(resolve_function(6, 0x06, 0), "Gear");
+        assert_eq!(resolve_function(128, 0x10, 0), "Vehicle Speed");
+    }
+
+    #[test]
+    fn test_resolve_function_device_temperature_override() {
+        assert_eq!(resolve_function(0, 0x11, 1), "Device Temperature");
+        // Same display_format+unit_type but different config_flags → generic
+        assert_eq!(resolve_function(0, 0x11, 0), "Temperature");
+    }
+
+    #[test]
+    fn test_resolve_function_unknown() {
+        assert_eq!(resolve_function(255, 255, 0), "");
+    }
+
+    #[test]
+    fn test_logger_model_name() {
+        assert_eq!(logger_model_name(649), Some("MXP 1.3"));
+        assert_eq!(logger_model_name(793), Some("MXm"));
+        assert_eq!(logger_model_name(0), None);
     }
 }


### PR DESCRIPTION
## Summary

- **Match Cython parser strictness**: The Rust backend now validates data the same way Cython does — GPS data length, LAP gaps, c-message fields, CHS duplicate names, S/c+M conflicts, input consumption, M-message sample periods, and GRP channel counts all produce errors/warnings instead of silently skipping
- **Add 126 Rust unit tests** across 10 modules, covering all new validation paths plus broad coverage of parser, decoders, messages, GPS processing, tables, error types, payloads, and zlib decompression
- **Fix CLAUDE.md** to accurately describe backend build/install behavior

## Test plan

- [x] `just check` passes (lint, clippy, typecheck, 238 Python tests, 98 spec tests)
- [x] `cargo test -p libxrk` passes (126 Rust unit tests + 1 doc-test)
- [x] No clippy warnings
- [x] Cross-backend tests still pass (Rust matches Cython output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)