### PR TITLE
ci: attach Pyodide WASM wheels to GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,6 +127,33 @@ jobs:
       env:
         LIBXRK_BACKEND: rust
 
+  pyodide:
+    uses: ./.github/workflows/pyodide.yml
+
+  upload-pyodide:
+    name: Upload Pyodide wheels to GitHub Release
+    runs-on: ubuntu-latest
+    needs: [pyodide]
+    if: github.event_name == 'release'
+    permissions:
+      contents: write
+
+    steps:
+    - name: Download Pyodide wheels
+      uses: actions/download-artifact@v4
+      with:
+        pattern: pyodide-wheel-*
+        path: dist/
+        merge-multiple: true
+
+    - name: List wheels
+      run: ls -la dist/
+
+    - name: Upload to GitHub Release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber --repo "${{ github.repository }}"
+
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
@@ -141,11 +168,18 @@ jobs:
       contents: write  # Required for uploading release assets
 
     steps:
-    - name: Download all artifacts
+    - name: Download CPython wheels
       uses: actions/download-artifact@v4
       with:
+        pattern: wheel-*
         path: dist/
         merge-multiple: true
+
+    - name: Download sdist
+      uses: actions/download-artifact@v4
+      with:
+        name: sdist
+        path: dist/
 
     - name: List artifacts
       run: ls -la dist/

--- a/.github/workflows/pyodide.yml
+++ b/.github/workflows/pyodide.yml
@@ -1,10 +1,7 @@
 name: Pyodide (WebAssembly) Tests
 
 on:
-  push:
-    branches: [ master, main ]
-  pull_request:
-    branches: [ master, main ]
+  workflow_call:
 
 jobs:
   pyodide-build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libxrk"
-version = "0.11.0"
+version = "0.11.1"
 description = "Library for reading AIM XRK files from AIM automotive data loggers"
 authors = [
     {name = "Christopher Dewan",email = "chris.dewan@m3rlin.net"}


### PR DESCRIPTION

Make pyodide.yml a reusable workflow (workflow_call only) and invoke it
from publish.yml on all events. Add upload-pyodide job to attach Pyodide
wheels to GitHub releases on release events.

Also scope the publish job's artifact download to only CPython wheels and
sdist, preventing Pyodide wheels from being accidentally uploaded to PyPI.

Closes #64
