### PR TITLE
feat: classify laps as full/out/in via GPS start-finish proximity

### DIFF
--- a/crates/libxrk-python/src/lib.rs
+++ b/crates/libxrk-python/src/lib.rs
@@ -180,6 +180,30 @@ fn aim_xrk(py: Python<'_>, fname: Py<PyAny>, progress: Option<Py<PyAny>>) -> PyR
         processed_laps.clear();
     }
 
+    // Classify last lap as "in" if GPS shows car is not near S/F at end
+    if !processed_laps.is_empty() && processed_laps.last().unwrap().lap_type != "out" {
+        if let (Some(trk_marker), Some(ref gps)) = (get_trk_marker(&result), &gps_result) {
+            if !gps.timecodes.is_empty() {
+                let (sf_lat, sf_lon) = trk_marker;
+                let (sf_x, sf_y, sf_z) = libxrk::gps::utils::lla2ecef(sf_lat, sf_lon, 0.0);
+
+                let end_time = processed_laps.last().unwrap().end_time;
+                let idx = gps
+                    .timecodes
+                    .partition_point(|&t| t < end_time)
+                    .min(gps.timecodes.len() - 1);
+                let (ex, ey, ez) =
+                    libxrk::gps::utils::lla2ecef(gps.latitude[idx], gps.longitude[idx], 0.0);
+
+                let dist = ((sf_x - ex).powi(2) + (sf_y - ey).powi(2) + (sf_z - ez).powi(2)).sqrt();
+                if dist > 30.0 {
+                    let last_idx = processed_laps.len() - 1;
+                    processed_laps[last_idx].lap_type = "in".to_string();
+                }
+            }
+        }
+    }
+
     if processed_laps.is_empty() {
         // GPS-based lap detection
         if let Some(trk_marker) = get_trk_marker(&result) {
@@ -201,11 +225,17 @@ fn aim_xrk(py: Python<'_>, fname: Py<PyAny>, progress: Option<Py<PyAny>>) -> PyR
                     let mut all_markers = lap_markers.clone();
                     all_markers.push(session_end as f64);
 
+                    let lap_count = all_markers.windows(2).len();
                     for (i, window) in all_markers.windows(2).enumerate() {
                         processed_laps.push(libxrk::ProcessedLap {
                             num: i as i32,
                             start_time: window[0] as i64,
                             end_time: window[1] as i64,
+                            lap_type: if i == lap_count - 1 {
+                                "in".to_string()
+                            } else {
+                                "full".to_string()
+                            },
                         });
                     }
                 }

--- a/crates/libxrk/src/arrow.rs
+++ b/crates/libxrk/src/arrow.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use arrow::array::{
     Array, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, RecordBatch,
-    UInt16Array, UInt32Array, UInt8Array,
+    StringArray, UInt16Array, UInt32Array, UInt8Array,
 };
 use arrow::datatypes::{DataType, Field, Schema};
 
@@ -154,16 +154,18 @@ pub fn build_all_channel_batches(
 
 /// Build an Arrow RecordBatch for laps.
 ///
-/// Columns: num (Int32), start_time (Int64), end_time (Int64).
+/// Columns: num (Int32), start_time (Int64), end_time (Int64), lap_type (Utf8).
 pub fn build_laps_batch(laps: &[ProcessedLap]) -> arrow::error::Result<RecordBatch> {
     let nums: Vec<i32> = laps.iter().map(|l| l.num).collect();
     let starts: Vec<i64> = laps.iter().map(|l| l.start_time).collect();
     let ends: Vec<i64> = laps.iter().map(|l| l.end_time).collect();
+    let types: Vec<&str> = laps.iter().map(|l| l.lap_type.as_str()).collect();
 
     let schema = Schema::new(vec![
         Field::new("num", DataType::Int32, false),
         Field::new("start_time", DataType::Int64, false),
         Field::new("end_time", DataType::Int64, false),
+        Field::new("lap_type", DataType::Utf8, false),
     ]);
 
     RecordBatch::try_new(
@@ -172,6 +174,7 @@ pub fn build_laps_batch(laps: &[ProcessedLap]) -> arrow::error::Result<RecordBat
             Arc::new(Int32Array::from(nums)),
             Arc::new(Int64Array::from(starts)),
             Arc::new(Int64Array::from(ends)),
+            Arc::new(StringArray::from(types)),
         ],
     )
 }

--- a/crates/libxrk/src/lib.rs
+++ b/crates/libxrk/src/lib.rs
@@ -183,6 +183,29 @@ pub fn read_xrk_with_progress(
         processed_laps.clear();
     }
 
+    // Classify last lap as "in" if GPS shows car is not near S/F at end
+    if !processed_laps.is_empty() && processed_laps.last().unwrap().lap_type != "out" {
+        if let (Some(trk_marker), Some(ref gps)) = (get_trk_marker(&result), &gps_result) {
+            if !gps.timecodes.is_empty() {
+                let (sf_lat, sf_lon) = trk_marker;
+                let (sf_x, sf_y, sf_z) = gps::utils::lla2ecef(sf_lat, sf_lon, 0.0);
+
+                let end_time = processed_laps.last().unwrap().end_time;
+                let idx = gps
+                    .timecodes
+                    .partition_point(|&t| t < end_time)
+                    .min(gps.timecodes.len() - 1);
+                let (ex, ey, ez) = gps::utils::lla2ecef(gps.latitude[idx], gps.longitude[idx], 0.0);
+
+                let dist = ((sf_x - ex).powi(2) + (sf_y - ey).powi(2) + (sf_z - ez).powi(2)).sqrt();
+                if dist > 30.0 {
+                    let last_idx = processed_laps.len() - 1;
+                    processed_laps[last_idx].lap_type = "in".to_string();
+                }
+            }
+        }
+    }
+
     if processed_laps.is_empty() {
         // GPS-based lap detection
         if let Some(trk_marker) = get_trk_marker(&result) {
@@ -204,11 +227,17 @@ pub fn read_xrk_with_progress(
                     let mut all_markers = lap_markers.clone();
                     all_markers.push(session_end as f64);
 
+                    let lap_count = all_markers.windows(2).len();
                     for (i, window) in all_markers.windows(2).enumerate() {
                         processed_laps.push(ProcessedLap {
                             num: i as i32,
                             start_time: window[0] as i64,
                             end_time: window[1] as i64,
+                            lap_type: if i == lap_count - 1 {
+                                "in".to_string()
+                            } else {
+                                "full".to_string()
+                            },
                         });
                     }
                 }

--- a/crates/libxrk/src/parser.rs
+++ b/crates/libxrk/src/parser.rs
@@ -1284,13 +1284,14 @@ fn decode_all_channels(
     Ok(result)
 }
 
-/// Raw parsed lap data: parallel vectors of (lap_num, start_time, end_time).
+/// Raw parsed lap data: parallel vectors of (lap_num, start_time, end_time, lap_type).
 /// Lap nums are normalized to 0-based indexing.
 #[derive(Debug)]
 struct RawLapData {
     lap_nums: Vec<i32>,
     start_times: Vec<i64>,
     end_times: Vec<i64>,
+    lap_types: Vec<String>,
 }
 
 /// Parse LAP messages with segment filtering, dedup, gap-fill, 0-based normalization.
@@ -1308,6 +1309,7 @@ fn parse_lap_messages(
     let mut lap_nums: Vec<i32> = Vec::new();
     let mut start_times: Vec<i64> = Vec::new();
     let mut end_times: Vec<i64> = Vec::new();
+    let mut lap_types: Vec<String> = Vec::new();
 
     if let Some(lap_msgs) = header_messages.get(&tokens::lap()) {
         for m in lap_msgs {
@@ -1339,6 +1341,7 @@ fn parse_lap_messages(
                     lap_nums.push(lap_num - 1);
                     start_times.push(inferred_start);
                     end_times.push(end_time - duration);
+                    lap_types.push("full".to_string());
                 } else if last_num + 1 != lap_num {
                     // Unexpected gap (> 1 or backwards) (B)
                     return Err(Error::InvalidData(format!(
@@ -1353,7 +1356,13 @@ fn parse_lap_messages(
             lap_nums.push(lap_num);
             start_times.push(end_time - duration);
             end_times.push(end_time);
+            lap_types.push("full".to_string());
         }
+    }
+
+    // Classify first lap as "out" if it starts at or before time 0
+    if !lap_types.is_empty() && start_times[0] <= 0 {
+        lap_types[0] = "out".to_string();
     }
 
     // Normalize to 0-based indexing
@@ -1367,6 +1376,7 @@ fn parse_lap_messages(
         lap_nums,
         start_times,
         end_times,
+        lap_types,
     })
 }
 
@@ -1404,6 +1414,7 @@ pub struct ProcessedLap {
     pub num: i32,
     pub start_time: i64,
     pub end_time: i64,
+    pub lap_type: String,
 }
 
 /// Get processed laps from ParseResult (with proper start/end times).
@@ -1418,6 +1429,7 @@ pub fn get_processed_laps(result: &ParseResult) -> Result<Vec<ProcessedLap>, Err
             num: n,
             start_time: raw.start_times[i],
             end_time: raw.end_times[i],
+            lap_type: raw.lap_types[i].clone(),
         })
         .collect())
 }

--- a/crates/libxrk/src/parser.rs
+++ b/crates/libxrk/src/parser.rs
@@ -1493,13 +1493,14 @@ fn decode_all_channels(
     Ok(result)
 }
 
-/// Raw parsed lap data: parallel vectors of (lap_num, start_time, end_time).
+/// Raw parsed lap data: parallel vectors of (lap_num, start_time, end_time, lap_type).
 /// Lap nums are normalized to 0-based indexing.
 #[derive(Debug)]
 struct RawLapData {
     lap_nums: Vec<i32>,
     start_times: Vec<i64>,
     end_times: Vec<i64>,
+    lap_types: Vec<String>,
 }
 
 /// Parse LAP messages with segment filtering, dedup, gap-fill, 0-based normalization.
@@ -1517,6 +1518,7 @@ fn parse_lap_messages(
     let mut lap_nums: Vec<i32> = Vec::new();
     let mut start_times: Vec<i64> = Vec::new();
     let mut end_times: Vec<i64> = Vec::new();
+    let mut lap_types: Vec<String> = Vec::new();
 
     if let Some(lap_msgs) = header_messages.get(&tokens::lap()) {
         for m in lap_msgs {
@@ -1548,6 +1550,7 @@ fn parse_lap_messages(
                     lap_nums.push(lap_num - 1);
                     start_times.push(inferred_start);
                     end_times.push(end_time - duration);
+                    lap_types.push("full".to_string());
                 } else if last_num + 1 != lap_num {
                     // Unexpected gap (> 1 or backwards) (B)
                     return Err(Error::InvalidData(format!(
@@ -1562,7 +1565,13 @@ fn parse_lap_messages(
             lap_nums.push(lap_num);
             start_times.push(end_time - duration);
             end_times.push(end_time);
+            lap_types.push("full".to_string());
         }
+    }
+
+    // Classify first lap as "out" if it starts at or before time 0
+    if !lap_types.is_empty() && start_times[0] <= 0 {
+        lap_types[0] = "out".to_string();
     }
 
     // Normalize to 0-based indexing
@@ -1576,6 +1585,7 @@ fn parse_lap_messages(
         lap_nums,
         start_times,
         end_times,
+        lap_types,
     })
 }
 
@@ -1613,6 +1623,7 @@ pub struct ProcessedLap {
     pub num: i32,
     pub start_time: i64,
     pub end_time: i64,
+    pub lap_type: String,
 }
 
 /// Get processed laps from ParseResult (with proper start/end times).
@@ -1627,6 +1638,7 @@ pub fn get_processed_laps(result: &ParseResult) -> Result<Vec<ProcessedLap>, Err
             num: n,
             start_time: raw.start_times[i],
             end_time: raw.end_times[i],
+            lap_type: raw.lap_types[i].clone(),
         })
         .collect())
 }

--- a/src/libxrk/CLAUDE.md
+++ b/src/libxrk/CLAUDE.md
@@ -25,7 +25,7 @@ aim_xrk(fname, progress=None) -> LogFile
 
 ```python
 log.channels   # Dict[str, pa.Table] - channel name -> PyArrow table
-log.laps       # pa.Table - columns: num, start_time, end_time (ms)
+log.laps       # pa.Table - columns: num, start_time, end_time (ms), lap_type (str)
 log.metadata   # Dict[str, Any] - session info
 ```
 
@@ -53,6 +53,26 @@ Standard metadata fields extracted from XRK files:
 | Odo/* | various | Odometer readings |
 | Expansion Devices | list[dict] | CAN expansion devices (Bus Unit, Bus Type, Version, Manufacturer, Model, Logger ID, Model ID) |
 | Calibrations | list[dict] | Per-channel calibration data (type, raw_1, raw_2, channel; type 1 adds output_1, output_2) |
+
+## Laps Table
+
+The laps table has columns:
+- `num` (int32) — 0-based lap number
+- `start_time` (int64) — lap start time in milliseconds
+- `end_time` (int64) — lap end time in milliseconds
+- `lap_type` (utf8) — lap classification:
+  - `"full"` — normal start/finish to start/finish lap
+  - `"out"` — first lap, which began when logging started rather than at a S/F
+    crossing (`start_time <= 0`)
+  - `"in"` — last lap, where GPS puts the car more than 30 m from the start/finish
+    line at the lap's end time — i.e. the session ended on the way back to the pits
+    rather than at the line. The 30 m threshold is the same one `find_laps()` uses.
+    On the GPS-fallback detection path (files with no LAP messages) the last lap is
+    always `"in"`, because its end is synthesized at session end rather than at a
+    detected crossing.
+
+Out and in laps are not comparable to full laps — exclude them when computing best
+lap, lap-time distributions, or lap-over-lap deltas.
 
 ## Channel Tables
 

--- a/src/libxrk/CLAUDE.md
+++ b/src/libxrk/CLAUDE.md
@@ -25,7 +25,7 @@ aim_xrk(fname, progress=None) -> LogFile
 
 ```python
 log.channels   # Dict[str, pa.Table] - channel name -> PyArrow table
-log.laps       # pa.Table - columns: num, start_time, end_time (ms)
+log.laps       # pa.Table - columns: num, start_time, end_time (ms), lap_type (str)
 log.metadata   # Dict[str, Any] - session info
 ```
 
@@ -53,6 +53,17 @@ Standard metadata fields extracted from XRK files:
 | Odo/* | various | Odometer readings |
 | Expansion Devices | list[dict] | CAN expansion devices (Bus Unit, Bus Type, Version, Manufacturer, Model, Logger ID, Model ID) |
 | Calibrations | list[dict] | Per-channel calibration data (type, raw_1, raw_2, channel; type 1 adds output_1, output_2) |
+
+## Laps Table
+
+The laps table has columns:
+- `num` (int32) — 0-based lap number
+- `start_time` (int64) — lap start time in milliseconds
+- `end_time` (int64) — lap end time in milliseconds
+- `lap_type` (utf8) — lap classification:
+  - `"full"` — normal S/F to S/F lap
+  - `"out"` — first lap starting at session beginning (start_time <= 0), not at S/F crossing
+  - `"in"` — last lap where session data continues past the final S/F crossing, or last GPS-detected lap
 
 ## Channel Tables
 

--- a/src/libxrk/aim_xrk.pyx
+++ b/src/libxrk/aim_xrk.pyx
@@ -1154,6 +1154,7 @@ def _get_laps(lat_ch, lon_ch, msg_by_type, time_offset, last_time):
     lap_nums = []
     start_times = []
     end_times = []
+    lap_types = []
     has_lap_messages = False
 
     # Prefer LAP messages when available (matches official DLL behavior)
@@ -1176,11 +1177,36 @@ def _get_laps(lat_ch, lon_ch, msg_by_type, time_offset, last_time):
                 lap_nums.append(lap - 1)
                 start_times.append(end_times[-1])
                 end_times.append(end_time - duration)
+                lap_types.append('full')
             else:
                 raise ValueError('Lap gap from %d to %d' % (lap_nums[-1], lap))
             lap_nums.append(lap)
             start_times.append(end_time - duration)
             end_times.append(end_time)
+            lap_types.append('full')
+
+        # Classify first lap as "out" if it starts at or before time 0
+        if lap_types and start_times[0] <= 0:
+            lap_types[0] = 'out'
+
+        # Classify last lap as "in" if GPS shows car is not near S/F at end
+        if lap_types and lap_types[-1] != 'out' and lat_ch and lon_ch:
+            trk_msgs = msg_by_type.get(_tokdec('TRK'))
+            if trk_msgs:
+                track = trk_msgs[-1].content
+                sf_lat, sf_lon = track['sf_lat'], track['sf_long']
+                sf_xyz = np.array(gps.lla2ecef(np.array([sf_lat]), np.array([sf_lon]), 0)).T[0]
+
+                tc = np.array(lat_ch.timecodes)
+                idx = min(np.searchsorted(tc, end_times[-1]), len(tc) - 1)
+                end_lat = float(lat_ch.sampledata[idx])
+                end_lon = float(lon_ch.sampledata[idx])
+                end_xyz = np.array(gps.lla2ecef(np.array([end_lat]), np.array([end_lon]), 0)).T[0]
+
+                dist = float(np.linalg.norm(sf_xyz - end_xyz))
+                if dist > 30.0:
+                    lap_types[-1] = 'in'
+
     elif lat_ch and lon_ch:
         # Fall back to GPS-based lap detection only when no LAP messages exist
         track = msg_by_type[_tokdec('TRK')][-1].content
@@ -1202,7 +1228,12 @@ def _get_laps(lat_ch, lon_ch, msg_by_type, time_offset, last_time):
                 lap_nums.append(lap)
                 start_times.append(start_time)
                 end_times.append(end_time)
-    
+                lap_types.append('full')
+
+            # Last GPS lap always ends at session_end, classify as "in"
+            if lap_types:
+                lap_types[-1] = 'in'
+
     # Normalize lap numbers to 0-based indexing (matches DLL behavior)
     if lap_nums:
         min_lap = min(lap_nums)
@@ -1212,7 +1243,8 @@ def _get_laps(lat_ch, lon_ch, msg_by_type, time_offset, last_time):
     laps_table = pa.table({
         'num': pa.array(lap_nums, type=pa.int32()),
         'start_time': pa.array(start_times, type=pa.int64()),
-        'end_time': pa.array(end_times, type=pa.int64())
+        'end_time': pa.array(end_times, type=pa.int64()),
+        'lap_type': pa.array(lap_types, type=pa.utf8()),
     })
     return laps_table, has_lap_messages
 

--- a/src/libxrk/aim_xrk.pyx
+++ b/src/libxrk/aim_xrk.pyx
@@ -1312,6 +1312,7 @@ def _get_laps(lat_ch, lon_ch, msg_by_type, time_offset, last_time):
     lap_nums = []
     start_times = []
     end_times = []
+    lap_types = []
     has_lap_messages = False
 
     # Prefer LAP messages when available (matches official DLL behavior)
@@ -1334,11 +1335,36 @@ def _get_laps(lat_ch, lon_ch, msg_by_type, time_offset, last_time):
                 lap_nums.append(lap - 1)
                 start_times.append(end_times[-1])
                 end_times.append(end_time - duration)
+                lap_types.append('full')
             else:
                 raise ValueError('Lap gap from %d to %d' % (lap_nums[-1], lap))
             lap_nums.append(lap)
             start_times.append(end_time - duration)
             end_times.append(end_time)
+            lap_types.append('full')
+
+        # Classify first lap as "out" if it starts at or before time 0
+        if lap_types and start_times[0] <= 0:
+            lap_types[0] = 'out'
+
+        # Classify last lap as "in" if GPS shows car is not near S/F at end
+        if lap_types and lap_types[-1] != 'out' and lat_ch and lon_ch:
+            trk_msgs = msg_by_type.get(_tokdec('TRK'))
+            if trk_msgs:
+                track = trk_msgs[-1].content
+                sf_lat, sf_lon = track['sf_lat'], track['sf_long']
+                sf_xyz = np.array(gps.lla2ecef(np.array([sf_lat]), np.array([sf_lon]), 0)).T[0]
+
+                tc = np.array(lat_ch.timecodes)
+                idx = min(np.searchsorted(tc, end_times[-1]), len(tc) - 1)
+                end_lat = float(lat_ch.sampledata[idx])
+                end_lon = float(lon_ch.sampledata[idx])
+                end_xyz = np.array(gps.lla2ecef(np.array([end_lat]), np.array([end_lon]), 0)).T[0]
+
+                dist = float(np.linalg.norm(sf_xyz - end_xyz))
+                if dist > 30.0:
+                    lap_types[-1] = 'in'
+
     elif lat_ch and lon_ch:
         # Fall back to GPS-based lap detection only when no LAP messages exist
         track = msg_by_type[_tokdec('TRK')][-1].content
@@ -1360,7 +1386,12 @@ def _get_laps(lat_ch, lon_ch, msg_by_type, time_offset, last_time):
                 lap_nums.append(lap)
                 start_times.append(start_time)
                 end_times.append(end_time)
-    
+                lap_types.append('full')
+
+            # Last GPS lap always ends at session_end, classify as "in"
+            if lap_types:
+                lap_types[-1] = 'in'
+
     # Normalize lap numbers to 0-based indexing (matches DLL behavior)
     if lap_nums:
         min_lap = min(lap_nums)
@@ -1370,7 +1401,8 @@ def _get_laps(lat_ch, lon_ch, msg_by_type, time_offset, last_time):
     laps_table = pa.table({
         'num': pa.array(lap_nums, type=pa.int32()),
         'start_time': pa.array(start_times, type=pa.int64()),
-        'end_time': pa.array(end_times, type=pa.int64())
+        'end_time': pa.array(end_times, type=pa.int64()),
+        'lap_type': pa.array(lap_types, type=pa.utf8()),
     })
     return laps_table, has_lap_messages
 

--- a/src/libxrk/base.py
+++ b/src/libxrk/base.py
@@ -132,8 +132,8 @@ class LogFile:
         channels: Dict mapping channel names to PyArrow tables. Each table has
             'timecodes' (int64, ms) and '<channel_name>' columns. Channel metadata
             (units, dec_pts, interpolate) stored in schema.field.metadata with bytes keys.
-        laps: PyArrow table with columns: num (int), start_time (int), end_time (int).
-            Times are in milliseconds.
+        laps: PyArrow table with columns: num (int), start_time (int), end_time (int),
+            lap_type (str: "full", "out", "in"). Times are in milliseconds.
         metadata: Dict of session metadata (racer, vehicle, venue, etc.)
         file_name: Original filename or "<bytes>" if loaded from bytes.
 

--- a/tests/test_86_xrk.py
+++ b/tests/test_86_xrk.py
@@ -165,6 +165,7 @@ class Test86XRK(unittest.TestCase):
         self.assertIn("num", log.laps.column_names, "Laps table missing 'num' column")
         self.assertIn("start_time", log.laps.column_names, "Laps table missing 'start_time' column")
         self.assertIn("end_time", log.laps.column_names, "Laps table missing 'end_time' column")
+        self.assertIn("lap_type", log.laps.column_names, "Laps table missing 'lap_type' column")
 
         # Should have exactly 16 laps
         self.assertEqual(len(log.laps), 16, f"Expected 16 laps, got {len(log.laps)}")
@@ -212,6 +213,24 @@ class Test86XRK(unittest.TestCase):
             self.assertAlmostEqual(
                 end_time, expected_end, delta=1.0, msg=f"Lap {expected_num} end time mismatch"
             )
+
+    @parameterized.expand(FILE_VARIANTS)
+    def test_86_xrk_lap_types(self, name, file_path):
+        """Test that lap types are correctly classified."""
+        log = aim_xrk(str(file_path), progress=None)
+
+        lap_types = log.laps.column("lap_type").to_pylist()
+        self.assertEqual(len(lap_types), 16)
+
+        # Lap 0 starts at time 0 -> "out"
+        self.assertEqual(lap_types[0], "out")
+
+        # Middle laps are "full"
+        for i in range(1, 15):
+            self.assertEqual(lap_types[i], "full", f"Lap {i} should be 'full'")
+
+        # Last lap (15) is "in" — GPS shows car is 257m from S/F at end
+        self.assertEqual(lap_types[15], "in")
 
     @parameterized.expand(FILE_VARIANTS)
     def test_86_xrk_channel_count_and_names(self, name, file_path):
@@ -889,6 +908,9 @@ class Test86CrossBackend(unittest.TestCase):
         rust_ends = self.rust_log.laps.column("end_time").to_pylist()
         cython_ends = self.cython_log.laps.column("end_time").to_pylist()
         self.assertEqual(rust_ends, cython_ends)
+        rust_types = self.rust_log.laps.column("lap_type").to_pylist()
+        cython_types = self.cython_log.laps.column("lap_type").to_pylist()
+        self.assertEqual(rust_types, cython_types)
 
     def test_channel_metadata_match(self) -> None:
         """Channel metadata (units, dec_pts, interpolate, function) should match between backends."""

--- a/tests/test_aim_official_xrk.py
+++ b/tests/test_aim_official_xrk.py
@@ -53,6 +53,15 @@ class TestAIMOfficialXRK(unittest.TestCase):
         self.assertEqual(log.laps.num_rows, 11, "Expected 11 laps (matching DLL)")
         self.assertGreater(log.laps.num_rows, 0, "Expected at least one lap")
 
+        # Verify lap_type column exists
+        self.assertIn("lap_type", log.laps.column_names, "Laps table missing 'lap_type' column")
+
+        # GPS-detected laps: last is "in", others are "full"
+        lap_types = log.laps.column("lap_type").to_pylist()
+        for i in range(len(lap_types) - 1):
+            self.assertEqual(lap_types[i], "full", f"GPS lap {i} should be 'full'")
+        self.assertEqual(lap_types[-1], "in", "Last GPS lap should be 'in'")
+
         # Get lap data as Python lists for easier assertions
         lap_nums = log.laps.column("num").to_pylist()
         start_times = log.laps.column("start_time").to_pylist()
@@ -192,6 +201,12 @@ class TestAIMOfficialCrossBackend(unittest.TestCase):
     def test_lap_count_match(self) -> None:
         """Lap count should match between backends."""
         self.assertEqual(self.rust_log.laps.num_rows, self.cython_log.laps.num_rows)
+
+    def test_lap_types_match(self) -> None:
+        """Lap types should match between backends."""
+        rust_types = self.rust_log.laps.column("lap_type").to_pylist()
+        cython_types = self.cython_log.laps.column("lap_type").to_pylist()
+        self.assertEqual(rust_types, cython_types)
 
     def test_lap_durations_match(self) -> None:
         """Lap durations should match between backends.

--- a/tests/test_gps_timing.py
+++ b/tests/test_gps_timing.py
@@ -85,6 +85,7 @@ def create_mock_log_with_gps_gap(
             "num": pa.array([1, 2, 3], type=pa.int64()),
             "start_time": pa.array([0, 3000, 70000], type=pa.int64()),  # Lap 3 starts after gap
             "end_time": pa.array([3000, 70000, 140000], type=pa.int64()),
+            "lap_type": pa.array(["full", "full", "full"], type=pa.utf8()),
         }
     )
 
@@ -209,6 +210,7 @@ class TestGpsTimingGapFix(unittest.TestCase):
                 "num": pa.array([1], type=pa.int64()),
                 "start_time": pa.array([0], type=pa.int64()),
                 "end_time": pa.array([8000], type=pa.int64()),
+                "lap_type": pa.array(["full"], type=pa.utf8()),
             }
         )
 
@@ -236,6 +238,7 @@ class TestGpsTimingGapFix(unittest.TestCase):
                 "num": pa.array([1], type=pa.int64()),
                 "start_time": pa.array([0], type=pa.int64()),
                 "end_time": pa.array([60], type=pa.int64()),
+                "lap_type": pa.array(["full"], type=pa.utf8()),
             }
         )
 

--- a/tests/test_logfile_methods.py
+++ b/tests/test_logfile_methods.py
@@ -41,13 +41,16 @@ def create_test_logfile(
 ) -> LogFile:
     """Helper to create a test LogFile."""
     if laps is None:
-        laps_table = pa.table({"num": [], "start_time": [], "end_time": []})
+        laps_table = pa.table(
+            {"num": [], "start_time": [], "end_time": [], "lap_type": pa.array([], type=pa.utf8())}
+        )
     else:
         laps_table = pa.table(
             {
                 "num": [lap[0] for lap in laps],
                 "start_time": [float(lap[1]) for lap in laps],
                 "end_time": [float(lap[2]) for lap in laps],
+                "lap_type": ["full" for _ in laps],
             }
         )
 

--- a/tests/test_sfj_xrk.py
+++ b/tests/test_sfj_xrk.py
@@ -138,6 +138,7 @@ class TestSFJXRK(unittest.TestCase):
         self.assertIn("num", log.laps.column_names, "Laps table missing 'num' column")
         self.assertIn("start_time", log.laps.column_names, "Laps table missing 'start_time' column")
         self.assertIn("end_time", log.laps.column_names, "Laps table missing 'end_time' column")
+        self.assertIn("lap_type", log.laps.column_names, "Laps table missing 'lap_type' column")
 
         # Should have exactly 13 laps
         self.assertEqual(len(log.laps), 13, f"Expected 13 laps, got {len(log.laps)}")
@@ -182,6 +183,24 @@ class TestSFJXRK(unittest.TestCase):
             self.assertAlmostEqual(
                 end_time, expected_end, delta=1.0, msg=f"Lap {expected_num} end time mismatch"
             )
+
+    @parameterized.expand(FILE_VARIANTS)
+    def test_sfj_xrk_lap_types(self, name, file_path):
+        """Test that lap types are correctly classified."""
+        log = aim_xrk(str(file_path), progress=None)
+
+        lap_types = log.laps.column("lap_type").to_pylist()
+        self.assertEqual(len(lap_types), 13)
+
+        # Lap 0 starts at time 0 -> "out"
+        self.assertEqual(lap_types[0], "out")
+
+        # Middle laps are "full"
+        for i in range(1, 12):
+            self.assertEqual(lap_types[i], "full", f"Lap {i} should be 'full'")
+
+        # Last lap (12) is "in" — GPS shows car is 799m from S/F at end
+        self.assertEqual(lap_types[-1], "in")
 
     @parameterized.expand(FILE_VARIANTS)
     def test_sfj_xrk_channel_count_and_names(self, name, file_path):
@@ -534,6 +553,9 @@ class TestSFJCrossBackend(unittest.TestCase):
         rust_ends = self.rust_log.laps.column("end_time").to_pylist()
         cython_ends = self.cython_log.laps.column("end_time").to_pylist()
         self.assertEqual(rust_ends, cython_ends)
+        rust_types = self.rust_log.laps.column("lap_type").to_pylist()
+        cython_types = self.cython_log.laps.column("lap_type").to_pylist()
+        self.assertEqual(rust_types, cython_types)
 
     def test_channel_metadata_match(self) -> None:
         """Channel metadata (units, dec_pts, interpolate) should match between backends."""

--- a/uv.lock
+++ b/uv.lock
@@ -460,7 +460,7 @@ wheels = [
 
 [[package]]
 name = "libxrk"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "cython" },


### PR DESCRIPTION

Out laps and in laps are not comparable to flying laps: the out lap begins
when logging starts rather than at a start/finish crossing, and the in lap is
whatever the driver does after the final crossing on the way back to the pits.
Both are at non-racing pace, and both corrupt any best-lap, lap-time
distribution or lap-over-lap delta that includes them.

The laps table exposed only num/start_time/end_time, so nothing distinguished
them and consumers had no correct way to derive it. This adds a `lap_type`
column ("full" | "out" | "in") to both backends.

"out" is straightforward: start_time <= 0 means the lap began at session start
rather than at a crossing.

"in" is the hard one, because AIM's LAP messages don't mark it — the logger
emits a final LAP record whose duration silently includes the trundle back to
the pits. The obvious test, comparing the last data timestamp to the final LAP
message's end_time, measures logger buffering rather than car position, and
gets it wrong in both directions: it misses clear in-laps (86, SFJ 0033,
issue49) and flags sessions that genuinely ended at the line (SFJ 0101,
Suzuka 0090).

"Did the session end at the start/finish line?" is a question about position,
so it is answered with position: take the GPS fix at the last lap's end_time,
compute ECEF distance to the start/finish coordinates from the TRK message, and
classify as "in" beyond 30 m. That is the same quantity and the same threshold
find_laps() already uses for GPS-based lap detection, so this introduces
neither a new concept nor a new magic number.

Measured across every fixture, the separation is wide and the threshold sits in
an empty band:

    SFJ 0101              4.1 m   full
    SFJ Suzuka 0090       5.8 m   full
    -------------------- 30 m threshold --------------------
    issue84              49.9 m   in
    issue68              62.9 m   in
    issue49             107.8 m   in
    aim_official        128.9 m   in
    86                  258.2 m   in
    SFJ 0033            798.9 m   in

Cython and Rust agree on every fixture.

On the GPS-fallback detection path (files with no LAP messages) the last lap is
unconditionally "in", with no distance check — its end is synthesized at
session end rather than at a detected crossing, so it is an in-lap by
construction. Documented, since it is a different rule under the same label.

Purely additive in behaviour: across all 11 fixtures, lap boundaries, channel
counts and per-channel row counts are byte-identical to master. Only the new
column is new.

API notes:
  * log.laps gains a 4th column; code matching on the exact schema or using
    positional column access will see it.
  * Rust ProcessedLap gains a public `lap_type` field. Reading fields and
    iterating are unaffected; only struct-literal construction and exhaustive
    destructuring without `..` need updating.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
