### PR TITLE
docs: surface spec/xrk_format.py as the reference implementation (refs #68)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,19 +16,32 @@ just test            # pytest
 uv build             # Build wheel
 ```
 
+## Reference Implementation / Wire Format Spec
+
+`spec/xrk_format.py` is the **single source of truth for the XRK wire format**, built with the Construct library. It parses real XRK/XRZ files and round-trips bytes byte-identically (every message type has a `TestXxxRoundTrip` in `spec/tests/test_round_trip.py` asserting `build(parse(raw)) == raw`).
+
+**Any change to how the wire format is interpreted must land in `spec/xrk_format.py` first.** The Cython and Rust backends then conform to the spec — not the other way around. Cross-implementation tests in `spec/tests/test_spec.py` compare the spec's output against the Cython parser and, when available, the official AIM DLL (via Wine, in `tests/reference_dll/`) as ground truth.
+
+When you find data parsing differs from AIM's RaceStudio output, start by reading `spec/xrk_format.py` and `spec/docs/`. Do not patch the Cython or Rust parsers without first updating the spec.
+
 ## Code Structure
 
-- `src/libxrk/aim_xrk.pyx` - Cython binary parser (default backend)
+- `spec/xrk_format.py` - Construct-based executable spec (**reference implementation** — the wire format lives here)
+- `spec/tests/` - spec tests: round-trip + cross-impl vs Cython and the AIM DLL
+- `spec/docs/companion.md` - application-level algorithms (GPS timing, lap detection, decoder dispatch)
+- `spec/docs/unknown_regions.md` - catalog of under-reverse-engineered byte ranges per message type
+- `src/libxrk/aim_xrk.pyx` - Cython binary parser (default backend, conforms to spec)
 - `src/libxrk/aim_xrk.pyi` - Type stubs for Cython module
-- `crates/` - Rust+PyO3 parser (~2x faster)
+- `crates/` - Rust+PyO3 parser (~2x faster, conforms to spec)
 - `src/libxrk/_aim_xrk_rs.pyi` - Type stubs for Rust module
 - `src/libxrk/base.py` - LogFile dataclass, channel merging
 - `src/libxrk/gps.py` - GPS utilities, lap detection, timing fix
 - `tests/` - pytest tests with real XRK data in `tests/test_data/`
+- `tests/reference_dll/` - official AIM parser (via Wine) used as ground truth for spec cross-checks
 
 ## Parser Backends
 
-The library has two parser backends with identical APIs. Both are included in all published wheels.
+The library has two parser backends with identical APIs. Both are included in all published wheels. **Both backends implement the wire format defined by `spec/xrk_format.py` — the Construct spec is the reference. If parsing changes, update the spec first.**
 
 - **Cython** (default): `src/libxrk/aim_xrk.pyx` — mature, well-tested
 - **Rust**: `crates/` — ~2x faster

--- a/spec/docs/unknown_regions.md
+++ b/spec/docs/unknown_regions.md
@@ -200,21 +200,25 @@ Each 64-byte record:
 
 ## (c) Expansion Data Messages
 
+**Under active investigation — see issue #68.** New AIM loggers emit c-message variants whose `unk1`, `unk4`, and the low 3 bits of `channel_field` take values other than the constants previously observed. The fields below are documented as they appear on the older MXP/MXm-class files in `tests/test_data/{SFJ,86,aim_official,issue49}/`. The forthcoming fix will replace this section with a full V1/V2/V3 variant table once the new variants are reverse-engineered.
+
 ### Byte [2] `unk1` (uint8)
-- **Observed**: Always 0x00
-- **Status**: Validated as zero (assertion in parser)
+- **Observed on older files**: 0x00
+- **Observed on new loggers (issue #68)**: also 0x01 in a new short-form variant
+- **Status**: No longer a constant — variant tag
 
 ### Byte [5] `unk3` (uint8)
-- **Observed**: Always 0x84
+- **Observed**: 0x84 across all files seen so far
 - **Hypothesis**: Message subtype or expansion bus ID
-- **Status**: Constant; validated as 0x84
+- **Status**: Still a constant in practice, but treat as variant tag until confirmed
 
 ### Byte [6] `unk4` (uint8)
-- **Observed**: Always 0x06
-- **Hypothesis**: Protocol version or message format indicator
-- **Status**: Constant; validated as 0x06
+- **Observed on older files**: 0x06
+- **Observed on new loggers (issue #68)**: 0x06 (existing), 0x08 (new long variant), 0x02 (new short variant)
+- **Hypothesis**: Variant tag selecting message layout
+- **Status**: No longer a constant — variant tag
 
 ### Bits [0:3] of `channel_field` (uint16 at offset [3])
-- **Observed**: Always 0x4 (binary 100)
-- **Hypothesis**: Message variant flag
-- **Status**: Validated; actual channel index is `channel_field >> 3`
+- **Observed on older files**: 0x4 (binary 100)
+- **Observed on new loggers (issue #68)**: also 0x0, 0x8, 0xc — pattern not yet decoded
+- **Status**: No longer a constant; the `channel_field >> 3` index rule only holds for the older (unk4=0x06) variant


### PR DESCRIPTION

The repo-level CLAUDE.md didn't mention spec/ at all. Its "Code Structure"
section listed src/libxrk/, crates/, tests/ — but not the Construct-based
executable spec that is actually the single source of truth for the wire
format. An investigator starting from CLAUDE.md would naturally land on
src/ and crates/ and never discover the spec, which is exactly the trap
that led to a misdirected fix attempt for issue #68.

Changes:
- Add a "Reference Implementation / Wire Format Spec" section to CLAUDE.md
  stating that spec/xrk_format.py is the reference and both backends
  conform to it. If parsing changes, update the spec first.
- List spec/xrk_format.py, spec/tests/, spec/docs/*.md, and
  tests/reference_dll/ in the Code Structure section.
- Note in the Parser Backends section that both implement the spec.
- Correct spec/docs/unknown_regions.md's (c) Expansion Data Messages
  section — the claims that unk1/unk3/unk4 and channel_field low bits
  are "always" their observed constants are factually wrong on new
  logger files (per issue #68). Mark the fields as variant tags and
  point forward to the upcoming variant-table fix.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/libxrk/pull/70).
* #75
* #74
* #73
* #72
* #71
* __->__ #70