### PR TITLE
libxrk(rust): conform c-message handler to the spec's three variants (closes #68)

### DIFF
--- a/crates/libxrk/src/parser.rs
+++ b/crates/libxrk/src/parser.rs
@@ -210,6 +210,7 @@ pub fn parse_xrk(
             data.len()
         )));
     }
+    resolve_c_variants(&mut state);
     state.finalize()
 }
 
@@ -232,6 +233,17 @@ struct ParserState {
     last_time: Option<i64>,
     /// ENF sub-messages: each entry is the sub-parsed messages from one ENF message
     enf_sub_messages: Vec<HashMap<u32, Vec<HeaderMessage>>>,
+    /// Buffer for V2/V3 (c)-message variants — see spec/xrk_format.py
+    /// :_resolve_c_variants. Keyed by channel_field. Entries are
+    /// (synthesized_or_embedded_tc, sample_bytes, priority, file_order).
+    /// priority: 3 = V2(base), 2 = V3, 1 = V2(+4). Higher wins at tc collision.
+    v2v3_by_cf: HashMap<u16, Vec<(i32, Vec<u8>, u8, u32)>>,
+    /// Most-recent V2(base).tc per base ch_field (for V3 tc synthesis).
+    last_v2_base_tc: HashMap<u16, (i32, u32)>,
+    /// Most-recent V2(+4).tc per plus4 ch_field.
+    last_v2_plus4_tc: HashMap<u16, (i32, u32)>,
+    /// File-order counter for c-message variants.
+    c_var_pos: u32,
 }
 
 /// Pre-scan results used to pre-allocate accumulator capacity.
@@ -288,6 +300,10 @@ impl ParserState {
             time_offset: None,
             last_time: None,
             enf_sub_messages: Vec::new(),
+            v2v3_by_cf: HashMap::new(),
+            last_v2_base_tc: HashMap::new(),
+            last_v2_plus4_tc: HashMap::new(),
+            c_var_pos: 0,
         }
     }
 
@@ -612,24 +628,42 @@ fn prescan(data: &[u8], state: &mut ParserState) -> PrescanResult {
                     }
                 }
                 b'c' => {
-                    if pos + 12 <= len {
+                    if pos + 7 <= len {
                         let unk1 = data[pos + 2];
                         let channel_field = u16::from_le_bytes([data[pos + 3], data[pos + 4]]);
                         let unk3 = data[pos + 5];
                         let unk4 = data[pos + 6];
-                        // Validate c-message fields (C)
-                        if unk1 == 0 && (channel_field & 7) == 4 && unk3 == 0x84 && unk4 == 6 {
-                            let index = (channel_field >> 3) as usize;
-                            if index < state.gc_data[2].len() {
-                                let total_size = state.gc_data[2][index].add_helper;
-                                if total_size > 8
-                                    && pos + total_size <= len
-                                    && data[pos + total_size - 1] == b')'
-                                {
-                                    hints.add_data_bytes(2, index, total_size - 8);
-                                    pos += total_size;
-                                    continue;
+                        if unk3 == 0x84 {
+                            // V1 prescan (existing): count payload bytes for
+                            // the resolved channel_index's gc_data[2] slot.
+                            if unk1 == 0 && unk4 == 6 && (channel_field & 7) == 4 {
+                                let index = (channel_field >> 3) as usize;
+                                if index < state.gc_data[2].len() {
+                                    let total_size = state.gc_data[2][index].add_helper;
+                                    if total_size > 8
+                                        && pos + total_size <= len
+                                        && data[pos + total_size - 1] == b')'
+                                    {
+                                        hints.add_data_bytes(2, index, total_size - 8);
+                                        pos += total_size;
+                                        continue;
+                                    }
                                 }
+                            }
+                            // V2/V3 prescan: we don't know channel_index yet
+                            // (resolved after the full scan), so we can't
+                            // attribute bytes to a specific gc_data[2] slot.
+                            // Just advance past the known-size frame so the
+                            // scanner doesn't fall into bad-bytes recovery.
+                            // Over/under-allocation of the target slot is
+                            // harmless — organic Vec growth covers it.
+                            if unk1 == 0 && unk4 == 8 && pos + 16 <= len && data[pos + 15] == b')' {
+                                pos += 16;
+                                continue;
+                            }
+                            if unk1 == 1 && unk4 == 2 && pos + 10 <= len && data[pos + 9] == b')' {
+                                pos += 10;
+                                continue;
                             }
                         }
                     }
@@ -1037,45 +1071,220 @@ fn try_parse_m_message(data: &[u8], pos: usize, state: &mut ParserState) -> Opti
 }
 
 /// Try to parse a c (expansion channel) message.
+///
+/// Three variants coexist on AIM loggers — see spec/docs/unknown_regions.md
+/// and spec/xrk_format.py:_resolve_c_variants. Dispatches on (unk1, unk4);
+/// V1 writes into gc_data[2] directly, V2/V3 buffer into v2v3_by_cf for
+/// post-parse channel_index resolution and tc synthesis.
 fn try_parse_c_message(data: &[u8], pos: usize, state: &mut ParserState) -> Option<usize> {
-    if pos + 12 > data.len() {
+    if pos + 7 > data.len() {
         return None;
     }
 
-    // c message header: (c + unk1(1) + channel_field(2) + unk3(1) + unk4(1) + timecode(4)
-    // Validate c-message fields (C)
     let unk1 = data[pos + 2];
     let channel_field = u16::from_le_bytes([data[pos + 3], data[pos + 4]]);
     let unk3 = data[pos + 5];
     let unk4 = data[pos + 6];
-    if unk1 != 0 || (channel_field & 7) != 4 || unk3 != 0x84 || unk4 != 6 {
-        return None;
-    }
-    let timecode =
-        i32::from_le_bytes([data[pos + 7], data[pos + 8], data[pos + 9], data[pos + 10]]);
-    let index = (channel_field >> 3) as usize;
-
-    if index >= state.gc_data[2].len() {
+    if unk3 != 0x84 {
         return None;
     }
 
-    let total_size = state.gc_data[2][index].add_helper;
-    if pos + total_size > data.len() {
-        return None;
+    match (unk1, unk4) {
+        // V1: CHS-sized payload, channel_index = channel_field >> 3.
+        (0, 6) => {
+            if pos + 12 > data.len() {
+                return None;
+            }
+            if (channel_field & 7) != 4 {
+                return None;
+            }
+            let timecode =
+                i32::from_le_bytes([data[pos + 7], data[pos + 8], data[pos + 9], data[pos + 10]]);
+            let index = (channel_field >> 3) as usize;
+            if index >= state.gc_data[2].len() {
+                return None;
+            }
+            let total_size = state.gc_data[2][index].add_helper;
+            if pos + total_size > data.len() {
+                return None;
+            }
+            if data[pos + total_size - 1] != b')' {
+                return None;
+            }
+            let acc = &mut state.gc_data[2][index];
+            if timecode > acc.last_timecode {
+                acc.last_timecode = timecode;
+                acc.data
+                    .extend_from_slice(&data[pos + 7..pos + total_size - 1]);
+            }
+            Some(total_size)
+        }
+        // V2 long: 16 bytes, two fp16 samples.
+        //   base ch_field (low nibble 0/8): samples at (tc, tc-4)
+        //   +4 ch_field   (low nibble 4/c): samples at (tc-2, tc-4)
+        (0, 8) => {
+            if pos + 16 > data.len() || data[pos + 15] != b')' {
+                return None;
+            }
+            let timecode =
+                i32::from_le_bytes([data[pos + 7], data[pos + 8], data[pos + 9], data[pos + 10]]);
+            let b0 = data[pos + 11..pos + 13].to_vec();
+            let b1 = data[pos + 13..pos + 15].to_vec();
+            let low = channel_field & 0xF;
+            let entries = state.v2v3_by_cf.entry(channel_field).or_default();
+            let pos_ctr = state.c_var_pos;
+            state.c_var_pos = pos_ctr.wrapping_add(1);
+            if low == 0 || low == 8 {
+                // V2(base): V2[0]@tc, V2[1]@tc-4, priority 3
+                entries.push((timecode, b0, 3, pos_ctr));
+                entries.push((timecode - 4, b1, 3, pos_ctr));
+                state
+                    .last_v2_base_tc
+                    .insert(channel_field, (timecode, pos_ctr));
+            } else {
+                // V2(+4): V2[0]@tc-2, V2[1]@tc-4, priority 1
+                entries.push((timecode - 2, b0, 1, pos_ctr));
+                entries.push((timecode - 4, b1, 1, pos_ctr));
+                state
+                    .last_v2_plus4_tc
+                    .insert(channel_field, (timecode, pos_ctr));
+            }
+            Some(16)
+        }
+        // V3 short: 10 bytes, one fp16 sample, synthesized tc.
+        (1, 2) => {
+            if pos + 10 > data.len() || data[pos + 9] != b')' {
+                return None;
+            }
+            let b = data[pos + 7..pos + 9].to_vec();
+            let base_cf = channel_field ^ 0x4;
+            let base_entry = state.last_v2_base_tc.get(&base_cf).copied();
+            let plus4_entry = state.last_v2_plus4_tc.get(&channel_field).copied();
+            let synth_tc = match (base_entry, plus4_entry) {
+                (Some((tc_b, pos_b)), Some((tc_p, pos_p))) => {
+                    if pos_b >= pos_p {
+                        Some(tc_b - 2)
+                    } else {
+                        Some(tc_p + 2)
+                    }
+                }
+                (Some((tc_b, _)), None) => Some(tc_b - 2),
+                (None, Some((tc_p, _))) => Some(tc_p + 2),
+                (None, None) => None,
+            };
+            if let Some(tc) = synth_tc {
+                let entries = state.v2v3_by_cf.entry(channel_field).or_default();
+                let pos_ctr = state.c_var_pos;
+                entries.push((tc, b, 2, pos_ctr));
+            }
+            state.c_var_pos = state.c_var_pos.wrapping_add(1);
+            Some(10)
+        }
+        // Unknown variant — return None so the bad-bytes recovery advances
+        // one byte at a time. Preserves the "don't silently swallow unknown
+        // variants" invariant from the spec.
+        _ => None,
     }
-    if data[pos + total_size - 1] != b')' {
-        return None;
+}
+
+/// After the main scan completes, resolve V2/V3 channel_fields to channel
+/// indices using the algorithm in spec/xrk_format.py:_resolve_c_variants,
+/// then migrate buffered samples into gc_data[2] (same normalized layout
+/// as V1 rows: tc(4) + data(N)).
+fn resolve_c_variants(state: &mut ParserState) {
+    if state.v2v3_by_cf.is_empty() {
+        return;
     }
 
-    let acc = &mut state.gc_data[2][index];
-    if timecode > acc.last_timecode {
-        acc.last_timecode = timecode;
-        // For c messages, we store timecode(4) + data (skip the c-specific header)
-        acc.data
-            .extend_from_slice(&data[pos + 7..pos + total_size - 1]);
+    // Phase 1 — partition observed V2/V3 channel_fields into pairs and orphans.
+    let cf_set: std::collections::BTreeSet<u16> = state.v2v3_by_cf.keys().copied().collect();
+    let mut pairs: Vec<(u16, u16)> = Vec::new();
+    let mut orphans: Vec<u16> = Vec::new();
+    let mut processed: std::collections::HashSet<u16> = std::collections::HashSet::new();
+    for &cf in &cf_set {
+        if processed.contains(&cf) {
+            continue;
+        }
+        let low = cf & 0xF;
+        if (low == 0x0 || low == 0x8) && cf_set.contains(&(cf | 0x4)) {
+            let partner = cf | 0x4;
+            pairs.push((cf, partner));
+            processed.insert(cf);
+            processed.insert(partner);
+        } else if (low == 0x4 || low == 0xC) && cf_set.contains(&(cf & !0x4)) {
+            // Partner already handled via base pass.
+            continue;
+        } else {
+            orphans.push(cf);
+            processed.insert(cf);
+        }
     }
 
-    Some(total_size)
+    // Phase 2 — identify CHS candidates. Expansion fp16 channels with
+    // hw_id != 0; partition by sample period.
+    let mut paired_candidates: Vec<((u32, u16), u16)> = Vec::new();
+    let mut orphan_candidates: Vec<((u32, u16), u16)> = Vec::new();
+    for (&ch_idx, ch_info) in &state.channels {
+        let chs = &ch_info.chs;
+        if chs.decoder_type != 20 || chs.source_type != 1 || chs.hardware_id == 0 {
+            continue;
+        }
+        let mms = chs.mms();
+        let key = (chs.hardware_ref, chs.source_channel_id);
+        if mms <= 5 {
+            paired_candidates.push((key, ch_idx));
+        } else if 5 < mms && mms <= 15 {
+            orphan_candidates.push((key, ch_idx));
+        }
+    }
+    paired_candidates.sort();
+    orphan_candidates.sort();
+
+    // Phase 3 — build the channel_field → channel_index map.
+    let mut expansion_map: HashMap<u16, u16> = HashMap::new();
+    for ((base, plus4), (_, ch_idx)) in pairs.iter().zip(paired_candidates.iter()) {
+        expansion_map.insert(*base, *ch_idx);
+        expansion_map.insert(*plus4, *ch_idx);
+    }
+    for (cf, (_, ch_idx)) in orphans.iter().zip(orphan_candidates.iter()) {
+        expansion_map.insert(*cf, *ch_idx);
+    }
+
+    // Phase 4 — per-channel sample collection with priority resolution.
+    let mut per_channel: HashMap<u16, HashMap<i32, (Vec<u8>, u8)>> = HashMap::new();
+    for (&cf, entries) in &state.v2v3_by_cf {
+        let Some(&ch_idx) = expansion_map.get(&cf) else {
+            continue;
+        };
+        let bucket = per_channel.entry(ch_idx).or_default();
+        for (tc, bytes, prio, _) in entries {
+            let slot = bucket.entry(*tc).or_insert_with(|| (Vec::new(), 0));
+            if *prio > slot.1 {
+                *slot = (bytes.clone(), *prio);
+            }
+        }
+    }
+
+    // Phase 5 — migrate into gc_data[2] in strictly increasing tc order.
+    // Row layout matches V1: 4 bytes tc + N bytes data. add_helper stays
+    // at size + 12 (set by register_chs).
+    for (ch_idx, samples) in per_channel {
+        let idx = ch_idx as usize;
+        if idx >= state.gc_data[2].len() {
+            continue;
+        }
+        let mut tcs: Vec<i32> = samples.keys().copied().collect();
+        tcs.sort_unstable();
+        let acc = &mut state.gc_data[2][idx];
+        for tc in tcs {
+            if tc <= acc.last_timecode {
+                continue;
+            }
+            acc.last_timecode = tc;
+            acc.data.extend_from_slice(&tc.to_le_bytes());
+            acc.data.extend_from_slice(&samples[&tc].0);
+        }
+    }
 }
 
 /// Decode all channels from raw accumulated data.

--- a/spec/tests/conftest.py
+++ b/spec/tests/conftest.py
@@ -114,6 +114,16 @@ def issue68_cython():
 
 
 @pytest.fixture(scope="session")
+def issue68_rust():
+    """Load the issue68 file via Rust parser once per session."""
+    try:
+        from libxrk._aim_xrk_rs import aim_xrk as rust_aim_xrk
+    except ImportError:
+        pytest.skip("Rust backend not available")
+    return rust_aim_xrk(str(ISSUE68_XRZ))
+
+
+@pytest.fixture(scope="session")
 def issue68_dll():
     """Extract issue68 data from the official AIM DLL."""
     if not _dll_available():

--- a/spec/tests/test_spec.py
+++ b/spec/tests/test_spec.py
@@ -1253,3 +1253,187 @@ class TestIssue68CVariants:
             f"Spec sample count {len(samples)} differs from DLL {len(dll_map)} by "
             f"{count_ratio*100:.2f}% (>1% threshold)"
         )
+
+
+def _decode_c_variant_samples(parsed, ch_idx):
+    """Decode V1/V2/V3 (c)-message samples for one channel using the
+    canonical rules from spec/docs/unknown_regions.md, with the priority
+    resolution Cython and Rust both apply (V2(base)/V1 = 3 > V3 = 2 > V2(+4) = 1).
+
+    Returns {logger_tc: value}. Orphan channels (accels, no pair partner)
+    use V2[0]@tc, V2[1]@tc-2. Paired channels use V2(base)[1]@tc-4 and
+    V2(+4)[0]@tc-2, V2(+4)[1]@tc-4.
+    """
+    import numpy as np
+
+    pair_fields = {}
+    for cf, idx in parsed.expansion_channel_map.items():
+        partner = cf ^ 0x4
+        if partner in parsed.expansion_channel_map and parsed.expansion_channel_map[partner] == idx:
+            pair_fields[idx] = (min(cf, partner), max(cf, partner))
+
+    pair = pair_fields.get(ch_idx)
+    base_cf, plus4_cf = pair if pair else (None, None)
+
+    samples = {}  # tc -> (value, priority)
+
+    def put(tc, val, prio):
+        existing = samples.get(tc)
+        if existing is None or prio > existing[1]:
+            samples[tc] = (val, prio)
+
+    for m in parsed.data_messages():
+        if m.msg_type != "c" or m.parsed.get("channel_index") != ch_idx:
+            continue
+        p = m.parsed
+        variant = p.get("variant")
+        cf = p["channel_field"]
+        data = p["data"]
+        if variant == "V1":
+            tc = p["timecode"]
+            put(tc, float(np.frombuffer(data[:2], dtype=np.float16)[0]), 3)
+        elif variant == "V2":
+            tc = p["timecode"]
+            v0 = float(np.frombuffer(data[0:2], dtype=np.float16)[0])
+            v1 = float(np.frombuffer(data[2:4], dtype=np.float16)[0])
+            if base_cf is not None:
+                if cf == base_cf:
+                    put(tc, v0, 3)
+                    put(tc - 4, v1, 3)
+                else:  # +4
+                    put(tc - 2, v0, 1)
+                    put(tc - 4, v1, 1)
+            else:
+                # Orphan accelerometer: V2[0]@tc, V2[1]@tc-2
+                put(tc, v0, 3)
+                put(tc - 2, v1, 3)
+        elif variant == "V3":
+            tc = p["timecode"]
+            if tc < 0:
+                continue
+            put(tc, float(np.frombuffer(data[:2], dtype=np.float16)[0]), 2)
+
+    return {tc: v for tc, (v, _) in samples.items()}
+
+
+class TestIssue68SpecVsBackends:
+    """Authoritative spec-vs-backend cross-check on the issue68 fixture.
+
+    The spec is the reference wire-format parser. Cython and Rust backends
+    are required to produce output identical to the spec's canonical
+    decode of V1/V2/V3 (c)-message samples — byte-for-byte, every sample.
+    """
+
+    def _spec_chs_index_for_cython(self, parsed, name):
+        """Find the spec CHS index that matches what the backend exposes.
+
+        CHS may carry duplicate long_names (e.g. RotaryMiddle_led appears
+        thrice on this fixture). Cython's `channels={ch.long_name: ch}`
+        dict-overwrite keeps the last CHS with that name; Rust follows
+        suit. Mirror that by returning the highest matching CHS index.
+        """
+        candidates = sorted(i for i, ch in parsed.channels.items() if ch.name == name)
+        return candidates[-1] if candidates else None
+
+    def _decode_spec_channel(self, parsed, ch_idx, expansion_ch_indices, arrays_cache):
+        """Produce the spec's canonical samples for one channel.
+
+        Returns ({tc: value}, 'tc') for expansion (V2/V3) channels whose
+        tcs are absolute logger-clock values; or ({index: value}, 'pos')
+        for ordinary V1/S/M/G channels where the existing builder emits
+        samples in file order without absolute tc info.
+        """
+        if ch_idx in expansion_ch_indices:
+            return _decode_c_variant_samples(parsed, ch_idx), "tc"
+        exhaustive = TestExhaustiveChannelValues()
+        raw = arrays_cache.get(ch_idx, [])
+        if not raw:
+            return None, None
+        values = exhaustive._decode_channel_array(raw, parsed.channels[ch_idx])
+        if values is None:
+            return None, None
+        return values, "pos"
+
+    def _compare_all_channels(self, parsed, backend_log):
+        """Assert every channel present in both spec and backend decodes
+        identically — same count and same values. Expansion channels
+        also check timecode alignment."""
+        expansion_ch_indices = set(parsed.expansion_channel_map.values())
+        arrays_cache = TestExhaustiveChannelValues()._build_channel_arrays(parsed)
+        # CHS names are not always unique — on issue68, RotaryLeft_led,
+        # RotaryMiddle_led and RotaryRight_led each have 3 CHS entries.
+        # Cython (Python dict insertion order) and Rust (HashMap iteration
+        # order) may expose different CHS indices for the same name.
+        # This is a pre-existing cross-backend quirk unrelated to issue #68;
+        # skip duplicate-named CHS channels here.
+        name_counts = {}
+        for ch in parsed.channels.values():
+            name_counts[ch.name] = name_counts.get(ch.name, 0) + 1
+        duplicate_names = {n for n, c in name_counts.items() if c > 1}
+
+        errors = []
+        checked = 0
+
+        for name in backend_log.channels:
+            if name in duplicate_names:
+                continue
+            ch_idx = self._spec_chs_index_for_cython(parsed, name)
+            if ch_idx is None:
+                # GPS-derived channels are synthesized by the backend
+                # outside CHS; they have no spec equivalent here.
+                continue
+            spec, kind = self._decode_spec_channel(
+                parsed, ch_idx, expansion_ch_indices, arrays_cache
+            )
+            if spec is None:
+                continue
+            backend_v = backend_log.channels[name].column(name).to_numpy()
+
+            if kind == "tc":
+                backend_tc = backend_log.channels[name].column("timecodes").to_numpy()
+                if len(backend_tc) == 0 or not spec:
+                    errors.append(
+                        f"{name}: empty one side (spec={len(spec)}, backend={len(backend_tc)})"
+                    )
+                    continue
+                offset = min(spec) - int(backend_tc[0])
+                spec_session = {tc - offset: v for tc, v in spec.items()}
+                if len(spec_session) != len(backend_v):
+                    errors.append(
+                        f"{name}: count spec={len(spec_session)} backend={len(backend_v)}"
+                    )
+                    continue
+                backend_map = dict(zip(backend_tc.tolist(), backend_v.tolist()))
+                diffs = sum(
+                    1
+                    for tc, v in spec_session.items()
+                    if tc not in backend_map or abs(backend_map[tc] - v) > 1e-9
+                )
+                if diffs:
+                    errors.append(f"{name}: {diffs} expansion samples differ")
+            else:
+                # Ordinary channel: spec gives values in file order.
+                if len(spec) != len(backend_v):
+                    errors.append(f"{name}: count spec={len(spec)} backend={len(backend_v)}")
+                    continue
+                diffs = sum(1 for i in range(len(backend_v)) if abs(spec[i] - backend_v[i]) > 1e-9)
+                if diffs:
+                    errors.append(f"{name}: {diffs} values differ")
+            checked += 1
+
+        assert checked > 20, f"Only {checked} channels compared — fixture wiring broken?"
+        assert (
+            not errors
+        ), f"Spec ↔ backend mismatches ({checked} channels compared):\n" + "\n".join(errors)
+
+    def test_spec_matches_cython_exactly(self, issue68_parsed, issue68_cython):
+        """Every channel the Cython backend exposes on issue68 — expansion
+        V2/V3 AND ordinary V1/S/M/G alike — must match the spec's
+        canonical decode byte-for-byte.
+        """
+        self._compare_all_channels(issue68_parsed, issue68_cython)
+
+    def test_spec_matches_rust_exactly(self, issue68_parsed, issue68_rust):
+        """Every channel the Rust backend exposes on issue68 must match
+        the spec's canonical decode byte-for-byte."""
+        self._compare_all_channels(issue68_parsed, issue68_rust)

--- a/tests/test_issue68_xrk.py
+++ b/tests/test_issue68_xrk.py
@@ -1,11 +1,8 @@
 """Tests for issue #68 XRK file.
 
-Validates that the Cython backend decodes the three (c)-message variants
-(V1, V2 long, V3 short) emitted by newer AIM loggers. Before the fix, the
-shock-pot and accelerometer channels were silently dropped.
-
-The Rust backend is not yet updated; cross-backend parity tests will land
-in a follow-up commit once Rust is conformed to the spec.
+Validates that the Cython AND Rust backends decode the three (c)-message
+variants (V1, V2 long, V3 short) emitted by newer AIM loggers. Before the
+fix, the shock-pot and accelerometer channels were silently dropped.
 """
 
 from __future__ import annotations
@@ -14,7 +11,19 @@ import unittest
 from pathlib import Path
 from typing import ClassVar
 
+import numpy as np
+
 from libxrk.base import LogFile
+
+
+def _rust_backend_available() -> bool:
+    try:
+        import libxrk._aim_xrk_rs  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
 
 TEST_DATA_DIR = Path(__file__).parent / "test_data"
 ISSUE68_XRZ_FILE = TEST_DATA_DIR / "issue68" / ("CMD_KK-SII_Tsukuba_Car_Generic testing_a_0101.xrz")
@@ -146,6 +155,68 @@ class TestIssue68XRK(unittest.TestCase):
         log = self.log
         # The good-path check: all 10 channels decoded + session has laps.
         self.assertGreater(log.laps.num_rows, 0, "laps missing — bad-byte path corruption?")
+
+
+@unittest.skipUnless(_rust_backend_available(), "Rust backend not available")
+class TestIssue68CrossBackend(unittest.TestCase):
+    """Cross-backend parity on the issue68 fixture — same 10 channels,
+    identical timecodes, identical fp16 values.
+    """
+
+    rust_log: ClassVar[LogFile]
+    cython_log: ClassVar[LogFile]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        from libxrk._aim_xrk_rs import aim_xrk as rust_aim_xrk
+        from libxrk.aim_xrk import aim_xrk as cython_aim_xrk
+
+        cls.rust_log = rust_aim_xrk(str(ISSUE68_XRZ_FILE))
+        cls.cython_log = cython_aim_xrk(str(ISSUE68_XRZ_FILE))
+
+    def test_channel_names_match(self) -> None:
+        """Both backends produce the same set of channel names."""
+        self.assertEqual(
+            set(self.rust_log.channels.keys()),
+            set(self.cython_log.channels.keys()),
+        )
+
+    def test_expansion_channels_present_in_both(self) -> None:
+        """All 10 previously-dropped channels appear in both backends."""
+        all_new = SHOCK_POT_CHANNELS | ACCEL_CHANNELS | RATE_CHANNELS
+        for name in all_new:
+            self.assertIn(name, self.rust_log.channels, f"Rust missing {name}")
+            self.assertIn(name, self.cython_log.channels, f"Cython missing {name}")
+
+    def test_expansion_channel_timecodes_match(self) -> None:
+        """Per-channel timecodes for the new variant-decoded channels must
+        match exactly between Rust and Cython."""
+        for name in SHOCK_POT_CHANNELS | ACCEL_CHANNELS | RATE_CHANNELS:
+            rust_tc = self.rust_log.channels[name].column("timecodes").to_numpy()
+            cython_tc = self.cython_log.channels[name].column("timecodes").to_numpy()
+            np.testing.assert_array_equal(
+                rust_tc, cython_tc, err_msg=f"{name} timecode stream differs between backends"
+            )
+
+    def test_expansion_channel_values_match(self) -> None:
+        """Per-channel values for the new variant-decoded channels must
+        match exactly between Rust and Cython (both decode the same fp16
+        bytes the same way)."""
+        for name in SHOCK_POT_CHANNELS | ACCEL_CHANNELS | RATE_CHANNELS:
+            rust_vals = self.rust_log.channels[name].column(name).to_numpy(zero_copy_only=False)
+            cython_vals = self.cython_log.channels[name].column(name).to_numpy(zero_copy_only=False)
+            np.testing.assert_array_equal(
+                rust_vals, cython_vals, err_msg=f"{name} value stream differs between backends"
+            )
+
+    def test_expansion_channel_sample_counts_match(self) -> None:
+        """Sample counts match between backends for the 10 new channels."""
+        for name in SHOCK_POT_CHANNELS | ACCEL_CHANNELS | RATE_CHANNELS:
+            self.assertEqual(
+                self.rust_log.channels[name].num_rows,
+                self.cython_log.channels[name].num_rows,
+                f"{name}: rust and cython sample count differ",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

Mirror the Cython changes from the previous commit into the Rust backend
so both conform to spec/xrk_format.py's three (c)-message variants
(V1 existing, V2 long 16-byte, V3 short 10-byte).

Rust changes in crates/libxrk/src/parser.rs:

- try_parse_c_message dispatches on (unk1, unk4). The V1 branch keeps
  the existing behavior (channel_index = channel_field >> 3, CHS-sized
  payload). V2 (16 bytes, 2 fp16 samples) and V3 (10 bytes, 1 fp16
  sample) buffer into new ParserState fields:
    - v2v3_by_cf: HashMap<u16, Vec<(i32, Vec<u8>, u8, u32)>> keyed
      by channel_field, entries (tc, sample_bytes, priority, pos).
    - last_v2_base_tc / last_v2_plus4_tc for V3 tc synthesis.
    - c_var_pos file-order counter.
  Unknown (unk1, unk4) pairs return None, so the bad-bytes recovery
  advances one byte — matches Cython's behavior and the spec's
  "don't silently swallow unknown variants" invariant.

- New resolve_c_variants() runs after scan_stream but before finalize().
  Partitions V2/V3 channel_fields into shock-pot pairs (base, base+4)
  and accelerometer orphans. Sorts CHS candidates (decoder_type=20,
  source_type=1, hardware_id != 0) by (hardware_ref, source_channel_id),
  partitioned by sample period (≤5ms vs 5-15ms). Assigns sorted pairs
  to sorted paired candidates; same for orphans. Applies the priority
  rule (V2(base) > V3 > V2(+4)) to resolve tc collisions, then migrates
  into gc_data[2] in strictly increasing tc order. Same normalized
  tc(4)+data(N) layout as V1 rows, so decode_all_channels stays
  untouched.

- Prescan extended to recognize V2 (16-byte) and V3 (10-byte) frame
  sizes. V2/V3 don't attribute bytes to a specific gc_data[2] slot
  at prescan time (channel_index isn't known yet), so we just skip
  past them to avoid the bad-bytes path; organic Vec growth covers
  the actual allocation during resolve_c_variants.

Tests (tests/test_issue68_xrk.py):

- Add TestIssue68CrossBackend that loads the fixture with both
  backends and asserts byte-identical output on the 10 variant-
  decoded channels: same channel names, same sample counts, same
  timecodes, same fp16 values. Matches the pattern used by
  Test86CrossBackend for the older corpus.

Result: LIBXRK_BACKEND=rust just test and the default-backend just test
both pass the full 253-test suite. The four shock-pot channels plus
three accelerometers now load correctly on Rust, with identical output
to Cython and to the spec.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/libxrk/pull/74).
* #75
* __->__ #74