### PR TITLE
release: bump version to 1.0.0 for the first stable release

### DIFF
--- a/crates/libxrk-python/Cargo.toml
+++ b/crates/libxrk-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libxrk-python"
-version = "0.11.0"
+version = "1.0.0"
 edition = "2021"
 publish = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libxrk"
-version = "0.11.1"
+version = "1.0.0"
 description = "Library for reading AIM XRK files from AIM automotive data loggers"
 authors = [
     {name = "Christopher Dewan",email = "chris.dewan@m3rlin.net"}

--- a/uv.lock
+++ b/uv.lock
@@ -460,7 +460,7 @@ wheels = [
 
 [[package]]
 name = "libxrk"
-version = "0.11.1"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "cython" },


### PR DESCRIPTION

The major shock-pot fix from issue #68 brings the library's channel
coverage to parity with RaceStudio across both current AIM logger
generations. Couple that with the Construct-based executable spec
(now designated as the canonical wire-format reference), byte-identical
cross-backend output on the 10 expansion channels, and the five-commit
stack landing in this release cycle, and the library is ready to shed
its 0.x preview status.

Version bumps:
  - pyproject.toml:              0.11.1 -> 1.0.0
  - crates/libxrk-python:        0.11.0 -> 1.0.0
  - uv.lock:                     refreshed

The internal crates/libxrk crate stays at 0.1.0; it's unpublished and
not user-facing.
