### PR TITLE
release: correct version to 0.12.0 (was 1.0.0 in error)

### DIFF
--- a/crates/libxrk-python/Cargo.toml
+++ b/crates/libxrk-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libxrk-python"
-version = "1.0.0"
+version = "0.12.0"
 edition = "2021"
 publish = false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libxrk"
-version = "1.0.0"
+version = "0.12.0"
 description = "Library for reading AIM XRK files from AIM automotive data loggers"
 authors = [
     {name = "Christopher Dewan",email = "chris.dewan@m3rlin.net"}

--- a/uv.lock
+++ b/uv.lock
@@ -460,7 +460,7 @@ wheels = [
 
 [[package]]
 name = "libxrk"
-version = "1.0.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "cython" },


### PR DESCRIPTION

The preceding landed commit set the version to 1.0.0, but the intended
release cadence is minor bumps from 0.11.1 → 0.12.0, not a major
jump. The library isn't declaring stability commitments that warrant
a 1.0 label yet; the shock-pot fix from issue #68 is a feature bump,
not a stability milestone. Correcting the three places that carried
the wrong version:

  - pyproject.toml:              1.0.0 -> 0.12.0
  - crates/libxrk-python:        1.0.0 -> 0.12.0
  - uv.lock:                     refreshed

Previous released version was v0.11.1 (published Mar 1, 2026).
