### PR TITLE
fix: accept unk3=0x04 in (c) messages for AIM expansion-module loggers

### DIFF
--- a/crates/libxrk/src/parser.rs
+++ b/crates/libxrk/src/parser.rs
@@ -633,9 +633,11 @@ fn prescan(data: &[u8], state: &mut ParserState) -> PrescanResult {
                         let channel_field = u16::from_le_bytes([data[pos + 3], data[pos + 4]]);
                         let unk3 = data[pos + 5];
                         let unk4 = data[pos + 6];
-                        if unk3 == 0x84 {
+                        if matches!(unk3, 0x84 | 0x04) {
                             // V1 prescan (existing): count payload bytes for
                             // the resolved channel_index's gc_data[2] slot.
+                            // unk3=0x04 is emitted by AIM expansion-module
+                            // loggers (brake PSI, rotor temp, EGT, etc.).
                             if unk1 == 0 && unk4 == 6 && (channel_field & 7) == 4 {
                                 let index = (channel_field >> 3) as usize;
                                 if index < state.gc_data[2].len() {
@@ -1085,7 +1087,9 @@ fn try_parse_c_message(data: &[u8], pos: usize, state: &mut ParserState) -> Opti
     let channel_field = u16::from_le_bytes([data[pos + 3], data[pos + 4]]);
     let unk3 = data[pos + 5];
     let unk4 = data[pos + 6];
-    if unk3 != 0x84 {
+    // 0x84 is the standard value; 0x04 is emitted by AIM expansion-module
+    // loggers (brake PSI, rotor temp, EGT, steering, etc.).
+    if !matches!(unk3, 0x84 | 0x04) {
         return None;
     }
 
@@ -2028,10 +2032,27 @@ mod tests {
     fn test_c_message_invalid_unk3_rejected() {
         let chs_bytes = make_chs_bytes(0, "EGT", "Exhaust Gas", 0, 4, 17, 0);
         let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        // 0x85 is not in the accepted set {0x84, 0x04}; must be skipped.
         let c_msg = make_c_message_raw(0, 4, 0x85, 6, 1000, &100i32.to_le_bytes());
         let stream = build_xrk_stream(&[chs_frame], &[c_msg]);
         let result = parse_xrk(&stream, None).unwrap();
         assert!(!result.channel_data.contains_key(&0));
+    }
+
+    #[test]
+    fn test_c_message_unk3_0x04_accepted() {
+        // AIM expansion-module loggers emit unk3=0x04 instead of 0x84.
+        // The (unk1=0, unk4=6) pair is the true V1 discriminator; unk3 is
+        // a secondary flag that must be accepted when it is 0x04.
+        let chs_bytes = make_chs_bytes(0, "LFBT", "LF Rotor Temp", 0, 4, 17, 0);
+        let chs_frame = make_header_frame("CHS", 0, &chs_bytes);
+        let c_msg = make_c_message_raw(0, 4, 0x04, 6, 1000, &100i32.to_le_bytes());
+        let stream = build_xrk_stream(&[chs_frame], &[c_msg]);
+        let result = parse_xrk(&stream, None).unwrap();
+        assert!(
+            result.channel_data.contains_key(&0),
+            "unk3=0x04 c-message should be accepted for expansion-module channels"
+        );
     }
 
     #[test]

--- a/spec/docs/unknown_regions.md
+++ b/spec/docs/unknown_regions.md
@@ -201,7 +201,13 @@ Each 64-byte record:
 ## (c) Expansion Data Messages
 
 Three variants coexist. The `(unk1, unk4)` pair at offsets [2] and [6] acts
-as a variant tag; `unk3` at [5] is `0x84` in all known variants. See also
+as the variant discriminator. `unk3` at [5] is `0x84` on standard AIM loggers
+(MXP, MXm, and the corpus files in `tests/test_data/`). AIM expansion-module
+loggers (brake PSI, rotor temperature, EGT, steering sensors) emit `0x04`
+instead. Both values belong to the same record family and are accepted; any
+other value is rejected as malformed. The field's semantic meaning is still
+under investigation — it may encode a hardware capability flag or a CAN-bus
+attribute of the source expansion module. See also
 `scripts/investigate_missing_data/c_variant_scanner.py` for the RE that
 established the channel_field mapping and timing rules.
 

--- a/spec/tests/test_expansion_unk3.py
+++ b/spec/tests/test_expansion_unk3.py
@@ -1,0 +1,277 @@
+"""Tests for (c) messages with unk3=0x04 (AIM expansion-module loggers).
+
+AIM expansion-module loggers (brake PSI sensors, rotor temperature sensors,
+EGT modules, steering sensors, etc.) emit (c) data records with unk3=0x04
+rather than the 0x84 seen on standard AIM loggers such as MXP and MXm.
+
+The (unk1, unk4) pair is the true variant discriminator for (c) messages.
+unk3 is a secondary flag. Both 0x84 and 0x04 belong to the same record
+family and must be accepted.
+
+These tests use synthetic byte streams — no real XRK fixture is needed.
+The wire layout follows spec/xrk_format.py and is described in
+spec/docs/unknown_regions.md § (c) Expansion Data Messages.
+"""
+
+import struct
+import unittest
+
+from construct import Container
+
+from spec.xrk_format import (
+    cMessageV1Compiled,
+    cMessageV2Compiled,
+    cMessageV3Compiled,
+    _C_MSG_UNK3_VALID,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build synthetic (c) frames
+# ---------------------------------------------------------------------------
+
+
+def _make_v1_frame(channel_field: int, unk3: int, timecode: int, payload: bytes) -> bytes:
+    """Build a raw V1 (c) frame: (c + unk1 + channel_field + unk3 + unk4 + tc + payload + )"""
+    return (
+        b"(c"
+        + struct.pack("<BHHBI", 0x00, channel_field, unk3, 0x06, timecode)[:7]
+        + payload
+        + b")"
+    )
+
+
+def _v1_frame(channel_field: int, unk3: int, timecode: int, payload: bytes) -> bytes:
+    """Pack a V1 frame using the same byte layout the parser expects.
+
+    Layout (12 + len(payload) bytes):
+      [0:2]  b'(c'
+      [2]    unk1 = 0x00
+      [3:5]  channel_field (LE uint16)
+      [5]    unk3
+      [6]    unk4 = 0x06
+      [7:11] timecode (LE int32)
+      [11:]  payload (len = channel_size)
+      [-1]   b')'
+    """
+    return (
+        b"(c"
+        + struct.pack("B", 0x00)
+        + struct.pack("<H", channel_field)
+        + struct.pack("B", unk3)
+        + struct.pack("B", 0x06)
+        + struct.pack("<i", timecode)
+        + payload
+        + b")"
+    )
+
+
+def _v2_frame(channel_field: int, unk3: int, timecode: int, fp16_a: bytes, fp16_b: bytes) -> bytes:
+    """Pack a V2 frame (16 bytes).
+
+    Layout:
+      [0:2]  b'(c'
+      [2]    unk1 = 0x00
+      [3:5]  channel_field (LE uint16)
+      [5]    unk3
+      [6]    unk4 = 0x08
+      [7:11] timecode (LE int32)
+      [11:13] fp16 sample A
+      [13:15] fp16 sample B
+      [15]   b')'
+    """
+    return (
+        b"(c"
+        + struct.pack("B", 0x00)
+        + struct.pack("<H", channel_field)
+        + struct.pack("B", unk3)
+        + struct.pack("B", 0x08)
+        + struct.pack("<i", timecode)
+        + fp16_a
+        + fp16_b
+        + b")"
+    )
+
+
+def _v3_frame(channel_field: int, unk3: int, fp16: bytes) -> bytes:
+    """Pack a V3 frame (10 bytes).
+
+    Layout:
+      [0:2]  b'(c'
+      [2]    unk1 = 0x01
+      [3:5]  channel_field (LE uint16)
+      [5]    unk3
+      [6]    unk4 = 0x02
+      [7:9]  fp16 sample
+      [9]    b')'
+    """
+    return (
+        b"(c"
+        + struct.pack("B", 0x01)
+        + struct.pack("<H", channel_field)
+        + struct.pack("B", unk3)
+        + struct.pack("B", 0x02)
+        + fp16
+        + b")"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — spec structs parse unk3=0x04
+# ---------------------------------------------------------------------------
+
+
+class TestUnk3ValidValues(unittest.TestCase):
+    """_C_MSG_UNK3_VALID must include both 0x84 and 0x04."""
+
+    def test_valid_set_contains_0x84(self):
+        self.assertIn(b"\x84", _C_MSG_UNK3_VALID)
+
+    def test_valid_set_contains_0x04(self):
+        self.assertIn(b"\x04", _C_MSG_UNK3_VALID)
+
+    def test_valid_set_does_not_contain_other_bytes(self):
+        for bad in (b"\x00", b"\x01", b"\x85", b"\x08", b"\xff"):
+            self.assertNotIn(bad, _C_MSG_UNK3_VALID, f"{bad!r} should not be in _C_MSG_UNK3_VALID")
+
+
+class TestV1Unk3(unittest.TestCase):
+    """cMessageV1Compiled must accept unk3 in {0x84, 0x04} and reject others."""
+
+    # channel_field >> 3 gives the channel index; low 3 bits must be 4.
+    # channel_field = (0 << 3) | 4 = 4  (channel index 0, payload = 4 bytes)
+    _CHANNEL_FIELD = 4
+    _PAYLOAD = b"\x00\x00\x00\x00"  # 4-byte int32 sample
+    _CHANNEL_SIZES = {0: 4}
+    _TC = 1000
+
+    def _parse_v1(self, unk3: int):
+        frame = _v1_frame(self._CHANNEL_FIELD, unk3, self._TC, self._PAYLOAD)
+        return cMessageV1Compiled.parse(frame, channel_sizes=self._CHANNEL_SIZES)
+
+    def test_unk3_0x84_accepted(self):
+        """Standard value 0x84 must be accepted."""
+        result = self._parse_v1(0x84)
+        self.assertEqual(result.unk3, b"\x84")
+        self.assertEqual(result.channel_field, self._CHANNEL_FIELD)
+        self.assertEqual(result.timecode, self._TC)
+        self.assertEqual(bytes(result.data), self._PAYLOAD)
+
+    def test_unk3_0x04_accepted(self):
+        """Expansion-module value 0x04 must be accepted."""
+        result = self._parse_v1(0x04)
+        self.assertEqual(result.unk3, b"\x04")
+        self.assertEqual(result.channel_field, self._CHANNEL_FIELD)
+        self.assertEqual(result.timecode, self._TC)
+        self.assertEqual(bytes(result.data), self._PAYLOAD)
+
+    def test_unk3_0x85_rejected(self):
+        """Any value outside {0x84, 0x04} must raise on parse."""
+        from construct import ConstructError
+
+        frame = _v1_frame(self._CHANNEL_FIELD, 0x85, self._TC, self._PAYLOAD)
+        with self.assertRaises(ConstructError):
+            cMessageV1Compiled.parse(frame, channel_sizes=self._CHANNEL_SIZES)
+
+    def test_v1_unk3_0x04_round_trip(self):
+        """A frame with unk3=0x04 must survive parse → build byte-identically."""
+        frame = _v1_frame(self._CHANNEL_FIELD, 0x04, self._TC, self._PAYLOAD)
+        parsed = cMessageV1Compiled.parse(frame, channel_sizes=self._CHANNEL_SIZES)
+        rebuilt = cMessageV1Compiled.build(
+            Container(
+                channel_field=parsed.channel_field,
+                unk3=parsed.unk3,
+                timecode=parsed.timecode,
+                data=parsed.data,
+            ),
+            channel_sizes=self._CHANNEL_SIZES,
+        )
+        self.assertEqual(rebuilt, frame, "V1 unk3=0x04 round-trip must be byte-identical")
+
+    def test_v1_unk3_0x84_round_trip(self):
+        """A frame with unk3=0x84 must survive parse → build byte-identically."""
+        frame = _v1_frame(self._CHANNEL_FIELD, 0x84, self._TC, self._PAYLOAD)
+        parsed = cMessageV1Compiled.parse(frame, channel_sizes=self._CHANNEL_SIZES)
+        rebuilt = cMessageV1Compiled.build(
+            Container(
+                channel_field=parsed.channel_field,
+                unk3=parsed.unk3,
+                timecode=parsed.timecode,
+                data=parsed.data,
+            ),
+            channel_sizes=self._CHANNEL_SIZES,
+        )
+        self.assertEqual(rebuilt, frame, "V1 unk3=0x84 round-trip must be byte-identical")
+
+
+class TestV2Unk3(unittest.TestCase):
+    """cMessageV2Compiled must accept unk3 in {0x84, 0x04}."""
+
+    _CHANNEL_FIELD = 0x10  # arbitrary
+    _TC = 2000
+    _FP16_A = b"\x00\x42"  # arbitrary fp16
+    _FP16_B = b"\x00\x41"
+
+    def _parse_v2(self, unk3: int):
+        frame = _v2_frame(self._CHANNEL_FIELD, unk3, self._TC, self._FP16_A, self._FP16_B)
+        return cMessageV2Compiled.parse(frame, channel_sizes={})
+
+    def test_unk3_0x84_accepted(self):
+        result = self._parse_v2(0x84)
+        self.assertEqual(result.unk3, b"\x84")
+        self.assertEqual(result.timecode, self._TC)
+
+    def test_unk3_0x04_accepted(self):
+        result = self._parse_v2(0x04)
+        self.assertEqual(result.unk3, b"\x04")
+        self.assertEqual(result.timecode, self._TC)
+
+    def test_v2_unk3_0x04_round_trip(self):
+        frame = _v2_frame(self._CHANNEL_FIELD, 0x04, self._TC, self._FP16_A, self._FP16_B)
+        parsed = cMessageV2Compiled.parse(frame, channel_sizes={})
+        rebuilt = cMessageV2Compiled.build(
+            Container(
+                channel_field=parsed.channel_field,
+                unk3=parsed.unk3,
+                timecode=parsed.timecode,
+                data=parsed.data,
+            ),
+            channel_sizes={},
+        )
+        self.assertEqual(rebuilt, frame, "V2 unk3=0x04 round-trip must be byte-identical")
+
+
+class TestV3Unk3(unittest.TestCase):
+    """cMessageV3Compiled must accept unk3 in {0x84, 0x04}."""
+
+    _CHANNEL_FIELD = 0x14
+    _FP16 = b"\x80\x3c"
+
+    def _parse_v3(self, unk3: int):
+        frame = _v3_frame(self._CHANNEL_FIELD, unk3, self._FP16)
+        return cMessageV3Compiled.parse(frame, channel_sizes={})
+
+    def test_unk3_0x84_accepted(self):
+        result = self._parse_v3(0x84)
+        self.assertEqual(result.unk3, b"\x84")
+
+    def test_unk3_0x04_accepted(self):
+        result = self._parse_v3(0x04)
+        self.assertEqual(result.unk3, b"\x04")
+
+    def test_v3_unk3_0x04_round_trip(self):
+        frame = _v3_frame(self._CHANNEL_FIELD, 0x04, self._FP16)
+        parsed = cMessageV3Compiled.parse(frame, channel_sizes={})
+        rebuilt = cMessageV3Compiled.build(
+            Container(
+                channel_field=parsed.channel_field,
+                unk3=parsed.unk3,
+                data=parsed.data,
+            ),
+            channel_sizes={},
+        )
+        self.assertEqual(rebuilt, frame, "V3 unk3=0x04 round-trip must be byte-identical")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/spec/tests/test_round_trip.py
+++ b/spec/tests/test_round_trip.py
@@ -364,8 +364,9 @@ class TestCMessageRoundTrip:
     def _rebuild_c_variant(self, parsed, channel_sizes):
         """Build a c-message frame from a parsed dict for its variant.
 
-        Const fields (unk1/unk3/unk4) are written from the struct's
-        hardcoded values — no need to supply them in the Container.
+        unk3 is now a OneOf field (not Const) so the stored value must be
+        supplied explicitly to preserve round-trip byte-identity, especially
+        for expansion-module files that emit 0x04 instead of 0x84.
         """
         from construct import Container
 
@@ -374,6 +375,7 @@ class TestCMessageRoundTrip:
         container = Container(
             channel_field=parsed["channel_field"],
             data=parsed["data"],
+            unk3=parsed.get("unk3", b"\x84"),
         )
         if variant in ("V1", "V2"):
             container["timecode"] = parsed["timecode"]
@@ -397,7 +399,7 @@ class TestCMessageRoundTrip:
             unk1 = data_bytes[i + 2]
             unk3 = data_bytes[i + 5]
             unk4 = data_bytes[i + 6]
-            if unk3 != 0x84:
+            if unk3 not in (0x84, 0x04):
                 i += 1
                 continue
             # Classify — must match variant shape AND close byte.

--- a/spec/xrk_format.py
+++ b/spec/xrk_format.py
@@ -41,6 +41,7 @@ from construct import (
     Int16ul,
     Int32sl,
     Int32ul,
+    OneOf,
     PaddedString,
     Peek,
     Rebuild,
@@ -596,13 +597,20 @@ MMessageCompiled = MMessage.compile()
 # produced the channel_field → channel_index mapping and timing rules.
 
 # V1 — legacy 12-byte header + CHS-sized payload.
+# unk3 is 0x84 on all corpus files to date. AIM expansion-module loggers
+# (brake PSI, rotor temp, EGT, steering, etc.) emit 0x04 instead.
+# Both values belong to the V1 record family — the (unk1=0, unk4=6) pair
+# is the true variant discriminator; unk3 is a secondary flag whose
+# semantics are under investigation (see unknown_regions.md § (c) messages).
+_C_MSG_UNK3_VALID = [b"\x84", b"\x04"]
+
 cMessageV1 = Struct(
     Const(b"\x28\x63"),  # '(c'
     "msg_type" / Computed("c"),
     "variant" / Computed("V1"),
     "unk1" / Const(b"\x00"),
     "channel_field" / Int16ul,
-    "unk3" / Const(b"\x84"),
+    "unk3" / OneOf(Bytes(1), _C_MSG_UNK3_VALID),
     "unk4" / Const(b"\x06"),
     "timecode" / Int32sl,
     "channel_index" / Computed(this.channel_field >> 3),
@@ -620,7 +628,7 @@ cMessageV2 = Struct(
     "variant" / Computed("V2"),
     "unk1" / Const(b"\x00"),
     "channel_field" / Int16ul,
-    "unk3" / Const(b"\x84"),
+    "unk3" / OneOf(Bytes(1), _C_MSG_UNK3_VALID),
     "unk4" / Const(b"\x08"),
     "timecode" / Int32sl,
     "channel_index" / Computed(-1),  # resolved post-parse
@@ -637,7 +645,7 @@ cMessageV3 = Struct(
     "variant" / Computed("V3"),
     "unk1" / Const(b"\x01"),
     "channel_field" / Int16ul,
-    "unk3" / Const(b"\x84"),
+    "unk3" / OneOf(Bytes(1), _C_MSG_UNK3_VALID),
     "unk4" / Const(b"\x02"),
     "timecode" / Computed(-1),  # synthesized post-parse
     "channel_index" / Computed(-1),  # resolved post-parse

--- a/src/libxrk/aim_xrk.pyx
+++ b/src/libxrk/aim_xrk.pyx
@@ -281,7 +281,7 @@ cdef packed struct cmsg_hdr:  # covers c messages
     cython.ushort op
     cython.uchar unk1 # always 0?
     cython.ushort channel # bottom 3 bits always 4?
-    cython.uchar unk3 # always 0x84?
+    cython.uchar unk3 # 0x84 (standard) or 0x04 (AIM expansion-module loggers)
     cython.uchar unk4 # always 6?
     cython.int timecode
     # data field follows, size depends on type
@@ -421,7 +421,7 @@ def _decode_sequence(s, progress=None):
                                            &sv[pos])
                     pos += 1
                 elif typ == ord_op_c:
-                    if msg.c.unk3 != 0x84:
+                    if msg.c.unk3 not in (0x84, 0x04):
                         raise ValueError('Unexpected c.unk3: %x' % msg.c.unk3)
                     if msg.c.unk1 == 0 and msg.c.unk4 == 6:
                         # V1 — existing format, channel_index = channel_field >> 3


### PR DESCRIPTION
## Problem

AIM expansion-module loggers (brake PSI sensors, rotor temperature sensors, EGT modules, steering sensors, etc.) emit `(c` data records with `unk3=0x04` instead of the `0x84` seen on standard MXP/MXm loggers. `libxrk 0.12.0` hard-codes `Const(b"\x84")` in the V1/V2/V3 spec structs and `!= 0x84` guards in both the Cython and Rust parsers, so those channels produce channel *definitions* with zero *samples* — silently dropping all expansion-module data.

## Evidence

Tested against a real AIM `.xrk` file captured from a pro-am racing session that includes expansion hardware IDs such as `hw_id=2011`. Before this fix, AIM Race Studio (the reference) showed channels with samples that `libxrk` could not read. The fix was first verified as a throwaway local patch.

Channels unlocked by accepting `0x04`:

| Channel | Units | Notes |
| --- | --- | --- |
| LF/RF Rotor Temp | C | 500 ms sample period |
| LF/RF Brake PSI | bar | plausibly shaped for brake pressure |
| LF/RF Caliper Temp | C | |
| Steering | deg | |
| EGT1-4 | C | exhaust gas temperature |
| Oil / Water / Diff / Trans temps | C | pre/post cooler pairs |
| CHX expansion channels | — | raw expansion-bus channels |

No fixture binaries are included — these channels were observed on a private fixture not licensed for redistribution.

## Root Cause

The `(unk1, unk4)` pair is the true variant discriminator for `(c` messages:

| Variant | unk1 | unk4 | Description |
| --- | --- | --- | --- |
| V1 | 0x00 | 0x06 | CHS-sized payload |
| V2 | 0x00 | 0x08 | 16-byte, 2xfp16 |
| V3 | 0x01 | 0x02 | 10-byte, 1xfp16 |

`unk3` is a secondary field at byte offset [5]. Its semantic meaning is not fully understood. What is clear is that both `0x84` and `0x04` belong to the same record family.

The one-line fix in the Cython parser:

```diff
- if msg.c.unk3 != 0x84:
+ if msg.c.unk3 not in (0x84, 0x04):
      raise ValueError('Unexpected c.unk3: %x' % msg.c.unk3)
```

## Changes

Following the spec-first contract in `CLAUDE.md`:

1. **`spec/xrk_format.py`** (source of truth): introduces `_C_MSG_UNK3_VALID = [b"\x84", b"\x04"]` and replaces `Const(b"\x84")` with `OneOf(Bytes(1), _C_MSG_UNK3_VALID)` in all three variant structs.

2. **`spec/tests/test_round_trip.py`**: updates `_rebuild_c_variant` to pass `unk3` from the parsed dict (required now that it is a data field rather than a Const), and updates `_find_raw_c_frames` to pass `0x04` frames through the scanner.

3. **`spec/tests/test_expansion_unk3.py`** (new): synthetic-fixture test suite covering parse and byte-identical round-trip for V1/V2/V3 with both `0x84` and `0x04`, plus rejection of `0x85`. No real fixture data required.

4. **`src/libxrk/aim_xrk.pyx`**: guard updated to `not in (0x84, 0x04)`.

5. **`crates/libxrk/src/parser.rs`**: both `unk3` checks updated to `matches!(unk3, 0x84 | 0x04)`; new `test_c_message_unk3_0x04_accepted` Rust test added.

6. **`spec/docs/unknown_regions.md`**: documents the two accepted values and the open question about semantic meaning.

## Open Question

Does `0x04` appear in `.xrk` files from loggers that do **not** have expansion modules attached?

I have one fixture with `0x04` that definitely uses expansion hardware. If the maintainer prefers a more conservative approach:

- **Option A (this PR)**: accept `{0x84, 0x04}` unconditionally. Any value outside the set is still rejected.
- **Option B**: gate on `hw_id != 0` in the CHS record. This would restrict `0x04` acceptance to channels already tagged as expansion hardware, at the cost of a two-pass design.

Happy to revise to Option B if preferred. My instinct is that Option A is safer for users encountering new logger variants in the future.