### PR TITLE
Add xrk-wasm: standalone browser WebAssembly parser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ When you find data parsing differs from AIM's RaceStudio output, start by readin
 - `src/libxrk/aim_xrk.pyx` - Cython binary parser (default backend, conforms to spec)
 - `src/libxrk/aim_xrk.pyi` - Type stubs for Cython module
 - `crates/` - Rust+PyO3 parser (~2x faster, conforms to spec)
+- `crates/xrk-wasm/` - standalone `wasm-bindgen` browser parser over the pure-Rust core (no Python/Pyodide); built out-of-band via `just wasm-build`
 - `src/libxrk/_aim_xrk_rs.pyi` - Type stubs for Rust module
 - `src/libxrk/base.py` - LogFile dataclass, channel merging
 - `src/libxrk/gps.py` - GPS utilities, lap detection, timing fix
@@ -102,6 +103,24 @@ just pyodide-test-0-29     # Build and run tests in Pyodide 0.29.x
 ```
 
 Pyodide test scripts are in `scripts/run_pyodide_tests*.mjs`. They accept `--pyodide-version=0.27` or `--pyodide-version=0.29` to select the version.
+
+## Standalone Browser WASM Parser (`crates/xrk-wasm`)
+
+Separate from the Pyodide wheels, `crates/xrk-wasm` is a thin `wasm-bindgen`
+wrapper over the **pure-Rust** core (`crates/libxrk`) that parses `.xrk`/`.xrz`
+files in the browser with **no Python/Pyodide** — a ~200 KB module exposing a
+single `parse_xrk(Uint8Array)` function. It's an additional tool, not a backend:
+it does not affect the Python package or its Cython/PyO3 backends.
+
+```bash
+just wasm-build      # -> crates/xrk-wasm/pkg/ (wraps scripts/build-xrk-wasm.sh)
+```
+
+Key facts:
+- Depends on `crates/libxrk` **by path** (`default-features = false`, Arrow off), so the wasm always tracks the in-repo parser — nothing to pin.
+- Standalone Cargo workspace (own `[workspace]` table + listed under `[workspace].exclude` in the root `Cargo.toml`), so it keeps its size profile and is ignored by `just check` / `cargo test` / CI.
+- Build is out-of-band (needs the `wasm32-unknown-unknown` target + `wasm-bindgen` 0.2.122; the script bootstraps the CLI). Output `pkg/` is git-ignored.
+- If the pure-Rust public API in `crates/libxrk` changes, keep `crates/xrk-wasm/src/lib.rs` in sync.
 
 ## Cython Rebuild
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,9 @@
 [workspace]
 members = ["crates/libxrk", "crates/libxrk-python"]
+# crates/xrk-wasm is a standalone wasm-bindgen tool with its own workspace and
+# size-optimized profile; it's built out-of-band (just wasm-build), not as part
+# of the main Python/Rust build or CI.
+exclude = ["crates/xrk-wasm"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -193,6 +193,31 @@ just pyodide-test-0-29
 
 Note: Pyodide tests for both 0.27.x and 0.29.x run automatically in CI via GitHub Actions.
 
+### Browser WebAssembly parser (no Python)
+
+In addition to the Pyodide wheels, the repo ships a small standalone
+`wasm-bindgen` build of libxrk's pure-Rust core in
+[`crates/xrk-wasm`](crates/xrk-wasm). It parses AiM `.xrk`/`.xrz` files entirely
+in the browser as a ~200 KB wasm module — **no Pyodide and no Python runtime**.
+Use it when a web app only needs to turn a telemetry file into plain channel
+arrays; reach for the Pyodide wheels when you need the full Python API.
+
+```bash
+# Compile to wasm and emit JS-ready artifacts in crates/xrk-wasm/pkg/
+just wasm-build
+```
+
+```js
+import init, { parse_xrk } from "./pkg/xrk_wasm.js";
+
+await init();
+const parsed = parse_xrk(new Uint8Array(await file.arrayBuffer()));
+// parsed = { channels: [{ name, units, interpolate, timecodes, values }],
+//            laps: [{ num, start, end }], metadata: { Driver, Vehicle, ... } }
+```
+
+See [`crates/xrk-wasm/README.md`](crates/xrk-wasm/README.md) for details.
+
 ### Building
 
 ```bash

--- a/crates/xrk-wasm/.gitignore
+++ b/crates/xrk-wasm/.gitignore
@@ -1,0 +1,5 @@
+# Build output of `scripts/build-xrk-wasm.sh` / `just wasm-build`.
+/target
+/pkg
+# Standalone crate built out-of-band; no lockfile required in-repo.
+Cargo.lock

--- a/crates/xrk-wasm/Cargo.toml
+++ b/crates/xrk-wasm/Cargo.toml
@@ -1,0 +1,36 @@
+# Standalone crate (own `[workspace]` table below) so it keeps its own
+# size-optimised release profile and is built out-of-band by
+# `scripts/build-xrk-wasm.sh` / `just wasm-build` — never by the main
+# Python/Rust workspace or its CI. The root workspace also lists this path under
+# `[workspace].exclude`.
+[package]
+name = "xrk-wasm"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "wasm-bindgen wrapper exposing libxrk's pure-Rust AiM XRK/XRZ parser to the browser."
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "=0.2.122"
+serde = { version = "1", features = ["derive"] }
+serde-wasm-bindgen = "0.6"
+# libxrk's pure-Rust core (no Python), straight from this repo — always in sync
+# with the parser it wraps. `default-features = false` keeps Arrow out of the
+# wasm (the browser only needs plain channel arrays).
+libxrk = { path = "../libxrk", default-features = false }
+
+# Standalone workspace root: keeps this crate out of the parent Python/Rust
+# workspace so its size profile applies and `cargo`/CI at the repo root ignore it.
+[workspace]
+
+# Small, fast wasm: optimise for size, abort on panic (no unwinding tables).
+[profile.release]
+opt-level = "s"
+lto = true
+codegen-units = 1
+panic = "abort"
+strip = true

--- a/crates/xrk-wasm/README.md
+++ b/crates/xrk-wasm/README.md
@@ -1,0 +1,85 @@
+# xrk-wasm
+
+A tiny [`wasm-bindgen`](https://github.com/rustwasm/wasm-bindgen) wrapper that
+exposes libxrk's **pure-Rust** AiM `.xrk`/`.xrz` parser to the browser as a
+standalone WebAssembly module — **no Pyodide, no Python runtime**. The whole
+module is ~200 KB raw (well under 100 KB gzipped), so a web app can parse AiM
+telemetry files entirely client-side.
+
+This is an *additional* build target. It does not change or replace the Python
+package or the two Python backends (Cython + PyO3); it just reuses the same
+`crates/libxrk` core a second way. The Pyodide wheels (`just pyodide-build`)
+remain the way to run the full Python API in the browser — `xrk-wasm` is the
+lightweight option when you only need to parse a file into plain channel arrays.
+
+## How it works
+
+The wrapper depends on `crates/libxrk` by path (`default-features = false`, so
+Arrow is left out of the wasm) and calls its public API — `read_xrk`,
+`decompress_if_zlib`, `parser::ChannelValues`, plus the `XrkFile` /
+`GpsDecodeResult` / `Metadata` / `ProcessedLap` types. Because it's a path
+dependency, the wasm always tracks the parser in this repo; there is no revision
+to pin or bump.
+
+GPS-derived channels (latitude, longitude, speed, lateral/inline acceleration,
+yaw rate, …) are merged into the channel list at their native GPS-fix timebase,
+mirroring what libxrk's Python layer does, so the JS side can resample them onto
+whatever timebase it wants.
+
+## Building
+
+```bash
+just wasm-build              # from the repo root
+# or directly:
+scripts/build-xrk-wasm.sh
+```
+
+Requirements (the script bootstraps the wasm-bindgen CLI for you):
+
+- `rustup` with the `wasm32-unknown-unknown` target
+- `wasm-bindgen` 0.2.122 (auto-downloaded as a prebuilt binary if missing)
+- `wasm-opt` from [binaryen](https://github.com/WebAssembly/binaryen) (optional;
+  shrinks the module further)
+
+Artifacts land in `crates/xrk-wasm/pkg/` (git-ignored):
+
+| File | Purpose |
+|------|---------|
+| `xrk_wasm.js` | ES module loader / glue (`--target web`) |
+| `xrk_wasm.d.ts` | TypeScript types |
+| `xrk_wasm_bg.wasm` | the compiled parser |
+| `xrk_wasm_bg.wasm.d.ts` | wasm import/export types |
+| `THIRD-PARTY-NOTICES.txt` | bundled license notices |
+
+This crate is a standalone Cargo workspace (it has its own `[workspace]` table
+and is listed under `[workspace].exclude` in the root `Cargo.toml`), so it keeps
+its size-optimized release profile and is never touched by `just check`, `cargo
+test`, or the Python/Rust CI at the repo root.
+
+## Usage (JavaScript / TypeScript)
+
+```js
+import init, { parse_xrk } from "./pkg/xrk_wasm.js";
+
+await init();                                  // load the wasm module once
+
+const buf = await file.arrayBuffer();          // file: a File / Blob
+const parsed = parse_xrk(new Uint8Array(buf)); // throws a string on bad input
+
+// parsed = {
+//   channels: [{ name, units, interpolate, timecodes: number[], values: number[] }],
+//   laps:     [{ num, start, end }],          // milliseconds
+//   metadata: { Driver, Vehicle, Venue, ... } // plain object, present keys only
+// }
+```
+
+`parse_xrk` is synchronous and CPU-bound, so for large files run it inside a Web
+Worker to keep the UI responsive. Timecodes are in milliseconds. Each channel
+arrives at its native sample rate; `interpolate` is `true` for continuous
+signals (linear interpolation on resample) and `false` for discrete/state
+signals (forward-fill).
+
+## License
+
+MIT — same as libxrk. See the repository `LICENSE` and the generated
+`pkg/THIRD-PARTY-NOTICES.txt` for the full set of bundled-crate notices.

--- a/crates/xrk-wasm/src/lib.rs
+++ b/crates/xrk-wasm/src/lib.rs
@@ -1,0 +1,127 @@
+//! wasm-bindgen wrapper over libxrk's pure-Rust core (`read_xrk`), exposing AiM
+//! XRK/XRZ parsing to the browser as a small standalone wasm module — no Pyodide,
+//! no Python. Returns every channel at its native sample rate (GPS-derived
+//! channels merged in, mirroring what libxrk's Python layer does); the JS side is
+//! left to resample onto whichever timebase it wants (e.g. the GPS fix timebase).
+
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+use libxrk::parser::ChannelValues;
+use libxrk::{decompress_if_zlib, read_xrk};
+
+#[derive(Serialize)]
+struct ChannelOut {
+    name: String,
+    units: String,
+    /// True when the channel should be linearly interpolated on resample
+    /// (continuous signals); false means forward-fill (discrete/state signals).
+    interpolate: bool,
+    /// Sample timestamps in milliseconds.
+    timecodes: Vec<f64>,
+    values: Vec<f64>,
+}
+
+#[derive(Serialize)]
+struct LapOut {
+    num: i32,
+    start: f64,
+    end: f64,
+}
+
+#[derive(Serialize)]
+struct ParsedOut {
+    channels: Vec<ChannelOut>,
+    laps: Vec<LapOut>,
+    metadata: std::collections::BTreeMap<String, String>,
+}
+
+fn values_to_f64(v: &ChannelValues) -> Vec<f64> {
+    match v {
+        ChannelValues::UInt8(a) => a.iter().map(|&x| x as f64).collect(),
+        ChannelValues::UInt16(a) => a.iter().map(|&x| x as f64).collect(),
+        ChannelValues::Int16(a) => a.iter().map(|&x| x as f64).collect(),
+        ChannelValues::Int32(a) => a.iter().map(|&x| x as f64).collect(),
+        ChannelValues::UInt32(a) => a.iter().map(|&x| x as f64).collect(),
+        ChannelValues::Float32(a) => a.iter().map(|&x| x as f64).collect(),
+        ChannelValues::Float64(a) => a.clone(),
+    }
+}
+
+/// Parse an AiM `.xrk`/`.xrz` file from raw bytes. Returns a JS object:
+/// `{ channels: [{ name, units, interpolate, timecodes, values }], laps, metadata }`.
+/// Throws (rejects) a JS string on any parse error.
+#[wasm_bindgen]
+pub fn parse_xrk(data: &[u8]) -> Result<JsValue, JsValue> {
+    let bytes = decompress_if_zlib(data);
+    let f = read_xrk(&bytes).map_err(|e| JsValue::from_str(&format!("{e}")))?;
+
+    let mut channels: Vec<ChannelOut> = f
+        .channels
+        .iter()
+        .map(|c| ChannelOut {
+            name: c.name.clone(),
+            units: c.units.clone(),
+            interpolate: c.interpolate,
+            timecodes: c.timecodes.iter().map(|&t| t as f64).collect(),
+            values: values_to_f64(&c.values),
+        })
+        .collect();
+
+    // GPS-derived channels live in a separate field on the core result; the
+    // Python layer merges them into `channels`, so we do too. They share one
+    // timebase (the GPS fix timecodes), which the JS resampler uses as its base.
+    if let Some(g) = &f.gps {
+        let tc: Vec<f64> = g.timecodes.iter().map(|&t| t as f64).collect();
+        let mut push = |name: &str, units: &str, vals: Vec<f64>| {
+            channels.push(ChannelOut {
+                name: name.into(),
+                units: units.into(),
+                interpolate: true,
+                timecodes: tc.clone(),
+                values: vals,
+            });
+        };
+        push("GPS Latitude", "deg", g.latitude.clone());
+        push("GPS Longitude", "deg", g.longitude.clone());
+        push("GPS Speed", "m/s", g.speed.clone());
+        push("GPS Altitude", "m", g.altitude.clone());
+        push("GPS_Satellites", "", g.satellites.iter().map(|&x| x as f64).collect());
+        push("GPS_pDOP", "", g.pdop.iter().map(|&x| x as f64).collect());
+        push("GPS_Position_Accuracy", "m", g.position_accuracy.iter().map(|&x| x as f64).collect());
+        push("GPS_Velocity_Accuracy", "m/s", g.velocity_accuracy.iter().map(|&x| x as f64).collect());
+        push("GPS_LateralAcc", "g", g.lateral_acc.iter().map(|&x| x as f64).collect());
+        push("GPS_InlineAcc", "g", g.inline_acc.iter().map(|&x| x as f64).collect());
+        push("GPS_Yaw_Rate", "deg/s", g.yaw_rate.iter().map(|&x| x as f64).collect());
+    }
+
+    let laps = f
+        .laps
+        .iter()
+        .map(|l| LapOut { num: l.num, start: l.start_time as f64, end: l.end_time as f64 })
+        .collect();
+
+    let mut metadata = std::collections::BTreeMap::new();
+    let m = &f.metadata;
+    let mut put = |k: &str, v: &Option<String>| {
+        if let Some(s) = v {
+            if !s.is_empty() {
+                metadata.insert(k.to_string(), s.clone());
+            }
+        }
+    };
+    put("Driver", &m.driver);
+    put("Vehicle", &m.vehicle);
+    put("Venue", &m.venue);
+    put("Log Date", &m.log_date);
+    put("Log Time", &m.log_time);
+    put("Session", &m.session);
+    put("Series", &m.series);
+    put("Device Name", &m.device_name);
+    put("Logger Model", &m.logger_model);
+
+    let out = ParsedOut { channels, laps, metadata };
+    // serialize_maps_as_objects so `metadata` is a plain JS object, not a Map.
+    let ser = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+    out.serialize(&ser).map_err(|e| JsValue::from_str(&format!("{e}")))
+}

--- a/justfile
+++ b/justfile
@@ -51,6 +51,10 @@ rust-build-debug:
     #!/usr/bin/env bash
     source $HOME/.cargo/env && uv run maturin develop
 
+# Build the standalone browser wasm parser (no Python) -> crates/xrk-wasm/pkg/
+wasm-build:
+    ./scripts/build-xrk-wasm.sh
+
 # Install Emscripten SDK for Pyodide 0.27.x
 emsdk-setup:
     #!/usr/bin/env bash

--- a/scripts/build-xrk-wasm.sh
+++ b/scripts/build-xrk-wasm.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Build the standalone libxrk WebAssembly module and write the JS-ready artifacts
+# into crates/xrk-wasm/pkg/. This is the in-browser AiM .xrk/.xrz parser: it
+# compiles libxrk's pure-Rust core (no Python, no Pyodide) to wasm32 via the thin
+# wrapper crate in crates/xrk-wasm/.
+#
+# The wrapper depends on the in-tree libxrk core by path, so the wasm always
+# tracks the parser in this repo — there is nothing to pin or bump.
+#
+# Requirements:
+#   - rustup (stable), with the wasm32-unknown-unknown target
+#   - wasm-bindgen 0.2.122 (auto-downloaded prebuilt if missing)
+#   - wasm-opt (optional; from binaryen — shrinks the module further)
+#
+# Output (crates/xrk-wasm/pkg/, git-ignored):
+#   xrk_wasm.js, xrk_wasm.d.ts, xrk_wasm_bg.wasm, xrk_wasm_bg.wasm.d.ts,
+#   THIRD-PARTY-NOTICES.txt
+#
+# Usage:
+#   just wasm-build        # or: scripts/build-xrk-wasm.sh
+set -euo pipefail
+
+WBG_VERSION="0.2.122"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CRATE="$REPO_ROOT/crates/xrk-wasm"
+OUT="$CRATE/pkg"
+
+# Pick up a rustup-managed toolchain if cargo isn't already on PATH.
+[ -f "$HOME/.cargo/env" ] && source "$HOME/.cargo/env"
+
+echo "==> Ensure wasm32 target"
+rustup target add wasm32-unknown-unknown
+
+echo "==> Ensure wasm-bindgen $WBG_VERSION"
+WBG="$(command -v wasm-bindgen || true)"
+if [ -z "$WBG" ] || ! wasm-bindgen --version 2>/dev/null | grep -q "$WBG_VERSION"; then
+  TMP="$(mktemp -d)"
+  TARBALL="wasm-bindgen-${WBG_VERSION}-x86_64-unknown-linux-musl"
+  curl -sSL -o "$TMP/wbg.tar.gz" \
+    "https://github.com/rustwasm/wasm-bindgen/releases/download/${WBG_VERSION}/${TARBALL}.tar.gz"
+  tar xzf "$TMP/wbg.tar.gz" -C "$TMP"
+  WBG="$TMP/$TARBALL/wasm-bindgen"
+fi
+echo "    using $("$WBG" --version)"
+
+echo "==> cargo build (release, wasm32)"
+( cd "$CRATE" && cargo build --release --target wasm32-unknown-unknown )
+
+echo "==> wasm-bindgen (--target web)"
+mkdir -p "$OUT"
+"$WBG" --target web --out-dir "$OUT" \
+  "$CRATE/target/wasm32-unknown-unknown/release/xrk_wasm.wasm"
+
+if command -v wasm-opt >/dev/null 2>&1; then
+  echo "==> wasm-opt -Oz"
+  # Rust emits these wasm features by default; wasm-opt must be told to allow them.
+  wasm-opt -Oz \
+    --enable-bulk-memory --enable-nontrapping-float-to-int \
+    --enable-sign-ext --enable-mutable-globals --enable-reference-types \
+    "$OUT/xrk_wasm_bg.wasm" -o "$OUT/xrk_wasm_bg.wasm"
+else
+  echo "==> wasm-opt not found — skipping (artifact still valid, just larger)"
+fi
+
+echo "==> Writing THIRD-PARTY-NOTICES.txt"
+cat > "$OUT/THIRD-PARTY-NOTICES.txt" <<'NOTICES'
+Third-party notices for the libxrk AiM XRK/XRZ parser (wasm)
+============================================================
+
+`xrk_wasm_bg.wasm` + `xrk_wasm.js` in this directory are a WebAssembly build of
+libxrk's pure-Rust core, for parsing AiM .xrk/.xrz telemetry files entirely in
+the browser. Built from source by scripts/build-xrk-wasm.sh via the wrapper crate
+in crates/xrk-wasm/. Redistributed under the MIT License.
+
+libxrk
+------
+  https://github.com/m3rlin45/libxrk
+  Incorporates code from TrackDataAnalysis (https://github.com/racer-coder/TrackDataAnalysis).
+
+MIT License
+
+(For components copied from TrackDataAnalysis)
+Copyright (c) 2024 Scott Smith
+
+Copyright (c) 2025 Christopher Dewan
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+The wasm also statically links these MIT/Apache-2.0 Rust crates: binrw, flate2
+(miniz_oxide), wasm-bindgen, serde, serde-wasm-bindgen.
+NOTICES
+
+echo "==> Done. Artifacts:"
+ls -la "$OUT"
+echo
+echo "    gzipped wasm: $(gzip -9 -c "$OUT/xrk_wasm_bg.wasm" | wc -c | awk '{printf "%.0f KB", $1/1024}')"


### PR DESCRIPTION
## Add `xrk-wasm`: a standalone browser WebAssembly parser

This PR adds **`crates/xrk-wasm`**, a thin [`wasm-bindgen`](https://github.com/rustwasm/wasm-bindgen) wrapper over libxrk's pure-Rust core (`crates/libxrk`) that parses AiM `.xrk`/`.xrz` files **entirely in the browser** — with no Pyodide and no Python runtime.

### Why

The existing Pyodide wheels are great when you need the full Python API in the browser, but they pull in a whole Python interpreter. A lot of web applications don't need any of that — they just need to turn a telemetry file into plain channel arrays and get on with rendering. This wrapper is for exactly those cases: it lets a web app be **entirely self-reliant and fully functional offline**, shipping a single ~200 KB wasm module (under 100 KB gzipped) instead of a Python stack. No CDN, no Pyodide download, no network round-trips at parse time.

It exposes one function:

```js
import init, { parse_xrk } from "./pkg/xrk_wasm.js";

await init();
const parsed = parse_xrk(new Uint8Array(await file.arrayBuffer()));
// parsed = { channels: [{ name, units, interpolate, timecodes, values }],
//            laps: [{ num, start, end }], metadata: { Driver, Vehicle, ... } }
```

GPS-derived channels are merged into the channel list at their native GPS-fix timebase, mirroring what libxrk's Python layer does, so the JS side can resample onto whatever timebase it wants.

### This is purely additive
It does not touch the Python package or its Cython/PyO3 backends — it's an additional, optional build target that reuses the same `crates/libxrk` core a second way:
  - **Depends on the in-tree** crates/libxrk by path (Arrow feature off), so the wasm always tracks the parser in this repo — nothing to pin or bump.
  - **Standalone Cargo workspace** (its own [workspace] table + listed under [workspace].exclude in the root manifest), so it keeps its size-optimized release profile and is completely ignored by just check, cargo test, and CI.
  - **Built out-of-band** via scripts/build-xrk-wasm.sh (wired up as just wasm-build): compiles to wasm32-unknown-unknown, runs wasm-bindgen --target web, optionally wasm-opt, and writes JS-ready artifacts + third-party license notices to crates/xrk-wasm/pkg/ (git-ignored). The script auto-downloads the pinned wasm-bindgen CLI if it's missing.

### Docs
Added a crate README plus sections in the top-level README.md and CLAUDE.md.

### Verified
  - cargo check against the in-repo core: clean.
  - Full just wasm-build: succeeds → 214 KB wasm / 79 KB gzipped (smaller with wasm-opt).
  - End-to-end parse of a real .xrk in Node: 33 channels, 13 laps, full metadata, GPS channels merged in — all correct.
  - Root cargo metadata confirms the main workspace is unchanged (still just libxrk + libxrk-python).