### PR TITLE
ci: repair the Pyodide builds (stale build tool, removed rustc flag)

### DIFF
--- a/.github/workflows/pyodide.yml
+++ b/.github/workflows/pyodide.yml
@@ -3,10 +3,20 @@ name: Pyodide (WebAssembly) Tests
 on:
   workflow_call:
 
+env:
+  # Version of the pyodide-build TOOL. Deliberately not tied to the Pyodide
+  # runtime versions in the matrix below — see the "Install pyodide-build" step.
+  # Keep in step with the `pyodide-build` pin in uv.lock so CI and local builds
+  # use the same tool.
+  PYODIDE_BUILD_VERSION: "0.32.0"
+
 jobs:
   pyodide-build:
     runs-on: ubuntu-latest
     strategy:
+      # Report both runtimes independently. With fail-fast on, a failure in
+      # one entry cancels the other mid-compile, which reads as "both broken".
+      fail-fast: false
       matrix:
         include:
           - pyodide-version: "0.27.3"
@@ -18,7 +28,7 @@ jobs:
             python-version: "3.13"
             emscripten-version: "4.0.9"
             artifact-suffix: "-0.29"
-            rust-flags: "-Zemscripten-wasm-eh"
+            rust-flags: ""
     name: Build wheel for Pyodide ${{ matrix.pyodide-version }}
 
     steps:
@@ -51,10 +61,20 @@ jobs:
         mv "$WASM_OPT" "${WASM_OPT}.real"
         cp scripts/wasm-opt-wrapper.sh "$WASM_OPT"
 
+    # pyodide-build is a BUILD TOOL and its version is independent of the
+    # Pyodide RUNTIME version being targeted. Pinning it to the runtime version
+    # (pyodide-build==0.27.3 / ==0.29.3) is what broke this workflow: those
+    # releases hardcode a cross-build-environment metadata URL,
+    # https://raw.githubusercontent.com/pyodide/pyodide/main/pyodide-cross-build-environments.json
+    # which upstream has since removed, so `xbuildenv install` died on a 404.
+    #
+    # One current pyodide-build serves every runtime; the runtime is selected by
+    # the argument to `xbuildenv install` below. Keep this pinned (for
+    # reproducibility) and independent of matrix.pyodide-version.
     - name: Install pyodide-build
       run: |
         uv pip install --system --prerelease=allow "wheel<0.44.0"
-        uv pip install --system --prerelease=allow pyodide-build==${{ matrix.pyodide-version }}
+        uv pip install --system --prerelease=allow pyodide-build==${{ env.PYODIDE_BUILD_VERSION }}
 
     - name: Install Pyodide xbuildenv
       run: pyodide xbuildenv install ${{ matrix.pyodide-version }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,17 @@ The library supports running in the browser via Pyodide. Two versions are suppor
 | Pyodide 0.27.x | 3.12 | 3.1.58 | `pyodide_2024_0` |
 | Pyodide 0.29.x | 3.13 | 4.0.9 | `pyodide_2025_0` |
 
+**`pyodide-build` version is independent of the Pyodide runtime version.** It is
+a build tool: one current version (pinned to `0.32.0` in `uv.lock`, the justfile
+and `PYODIDE_BUILD_VERSION` in `.github/workflows/pyodide.yml`) builds for every
+runtime, and the runtime is chosen by the argument to `pyodide xbuildenv install`.
+
+Do not pin `pyodide-build` to the runtime version. Doing so previously broke all
+Pyodide builds: `pyodide-build` 0.27.3/0.29.3 hardcode a cross-build-environment
+metadata URL that upstream has since removed, so `xbuildenv install` fails with a
+404. The *host Python* still has to match the runtime (the 0.29.x xbuildenv
+refuses to install under Python 3.12), which is why the 0.29 recipes use pyenv.
+
 ### Pyodide 0.27.x (default)
 
 ```bash

--- a/justfile
+++ b/justfile
@@ -96,11 +96,16 @@ pyodide-test: emsdk-setup pyodide-setup
     node scripts/run_pyodide_tests_idbfs.mjs --dist-dir=./dist --pyodide-version=0.27; \
     _rc=$?; mv "$_bak"/*.so src/libxrk/ 2>/dev/null; rm -rf "$_bak"; exit $_rc
 
+# pyodide-build is a BUILD TOOL; its version is independent of the Pyodide
+# RUNTIME version. Pinning it to the runtime version (==0.29.3) broke builds:
+# those releases hardcode a cross-build-env metadata URL upstream has removed.
+# One current pyodide-build serves every runtime. The runtime still dictates the
+# host Python (0.29.x xbuildenv refuses to install under 3.12), hence pyenv 3.13.
 # Install Emscripten SDK for Pyodide 0.29.x (requires Python 3.13 via pyenv)
 emsdk-setup-0-29:
     #!/usr/bin/env bash
     export PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" && \
-    pip install pyodide-build==0.29.3 "wheel<0.44" && \
+    uv pip install --python "$HOME/.pyenv/versions/3.13.12/bin/python" pyodide-build==0.32.0 "wheel<0.44" && \
     EMSDK_VERSION=$(pyodide config get emscripten_version) && \
     mkdir -p build/emsdk-0.29 && \
     ([ -d build/emsdk-0.29/.git ] || git clone https://github.com/emscripten-core/emsdk.git build/emsdk-0.29) && \
@@ -121,9 +126,9 @@ pyodide-build-0-29: emsdk-setup-0-29
     EMSDK=$PWD/build/emsdk-0.29 && \
     export PATH="$HOME/.pyenv/versions/3.13.12/bin:$HOME/.cargo/bin:$EMSDK/upstream/emscripten:$PATH" && \
     export EMSDK EM_CONFIG=$EMSDK/.emscripten EMSDK_NODE=$EMSDK/node/22.16.0_64bit/bin/node && \
-    export RUSTUP_TOOLCHAIN=nightly RUSTFLAGS="-Zemscripten-wasm-eh" && \
+    export RUSTUP_TOOLCHAIN=nightly && \
     export CARGO_BUILD_TARGET=wasm32-unknown-emscripten && \
-    pip install pyodide-build==0.29.3 "wheel<0.44" && \
+    uv pip install --python "$HOME/.pyenv/versions/3.13.12/bin/python" pyodide-build==0.32.0 "wheel<0.44" && \
     pyodide build --exports whole_archive; \
     _rc=$?; mv "$_bak"/*.so src/libxrk/ 2>/dev/null; rm -rf "$_bak"; exit $_rc
 
@@ -135,10 +140,10 @@ pyodide-test-0-29: emsdk-setup-0-29 pyodide-setup-0-29
     EMSDK=$PWD/build/emsdk-0.29 && \
     export PATH="$HOME/.pyenv/versions/3.13.12/bin:$HOME/.cargo/bin:$EMSDK/upstream/emscripten:$PATH" && \
     export EMSDK EM_CONFIG=$EMSDK/.emscripten EMSDK_NODE=$EMSDK/node/22.16.0_64bit/bin/node && \
-    export RUSTUP_TOOLCHAIN=nightly RUSTFLAGS="-Zemscripten-wasm-eh" && \
+    export RUSTUP_TOOLCHAIN=nightly && \
     export CARGO_BUILD_TARGET=wasm32-unknown-emscripten && \
     rm -f dist/*pyodide_2025*.whl && \
-    pip install pyodide-build==0.29.3 "wheel<0.44" && \
+    uv pip install --python "$HOME/.pyenv/versions/3.13.12/bin/python" pyodide-build==0.32.0 "wheel<0.44" && \
     pyodide build --exports whole_archive && \
     node scripts/run_pyodide_tests.mjs --dist-dir=./dist --pyodide-version=0.29 && \
     node scripts/run_pyodide_tests_idbfs.mjs --dist-dir=./dist --pyodide-version=0.29; \


### PR DESCRIPTION

All Pyodide wheel builds fail on every branch. Two independent pieces of
upstream drift, plus a matrix setting that hid the second behind the first.

1. pyodide-build was pinned to the Pyodide RUNTIME version
-----------------------------------------------------------
    HTTPError: 404 Client Error: Not Found for url:
    https://raw.githubusercontent.com/pyodide/pyodide/main/pyodide-cross-build-environments.json

The workflow installed `pyodide-build==${{ matrix.pyodide-version }}`, pinning
the build TOOL to the runtime it targets. Those are independent axes.
pyodide-build 0.27.3 and 0.29.3 both hardcode the metadata URL above, which
upstream removed, so `xbuildenv install` died on a 404 before compiling
anything. The justfile's 0.29 recipes had the same pin.

One current pyodide-build serves every runtime; the runtime is selected by the
argument to `xbuildenv install`. Install 0.32.0 (already locked in uv.lock, and
what the 0.27 justfile path has used via `uv run` all along).

Deliberately NOT worked around with PYODIDE_CROSS_BUILD_ENV_METADATA_URL: that
would paper over the dead URL while leaving the tool pinned to a stale release.

Verified locally with pyodide-build 0.32.0:

    xbuildenv install 0.27.3  (Python 3.12) -> ok, emscripten 3.1.58
    xbuildenv install 0.29.3  (Python 3.13) -> ok, emscripten 4.0.9

Both match the emscripten versions pinned in the matrix. The runtime still
dictates the HOST Python — installing the 0.29.x xbuildenv under 3.12 is
refused — which is why the matrix uses 3.13 there and the justfile's 0.29
recipes use pyenv. Unchanged.

2. rustc removed -Zemscripten-wasm-eh
--------------------------------------
    error: unknown unstable option: `emscripten-wasm-eh`

With (1) fixed, the 0.29 build got as far as compiling the Cython extension to
wasm and then died linking the Rust one. rust-lang/rust#156928 ("Remove
-Zemscripten-wasm-eh", merged 2026-06-03) deleted the flag: wasm exception
handling is now unconditional on Emscripten, so opting in is meaningless.

Dropped from the 0.29 matrix entry and the two justfile 0.29 recipes.
Reproduced and verified against nightly-2026-08-15 (rustc 1.99.0-nightly):

    -Zemscripten-wasm-eh                  -> unknown unstable option
    (no flag)                             -> panic="unwind"  (wasm EH default)
    0.27's -C panic=abort opt-out         -> panic="abort"   (still accepted)

The 0.27 entry is left alone: its flags are still valid. Note the upstream PR
says JS exception handling on Emscripten is no longer supported, so the 0.27
path (Emscripten 3.1.58, no __cpp_exception tag) may need its own follow-up if
it fails at link time — it had not reached linking before being cancelled.

3. fail-fast hid the second failure behind the first
-----------------------------------------------------
The matrix defaulted to fail-fast, so when 0.29 failed, 0.27 was cancelled
mid-compile and reported as "fail". That made one broken runtime look like two
and sent the first round of debugging at the wrong job. Set fail-fast: false so
each runtime reports independently.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/libxrk/pull/86).
* #85
* __->__ #86