### PR TITLE
ci: drop Pyodide 0.27 support

### DIFF
--- a/.github/workflows/pyodide.yml
+++ b/.github/workflows/pyodide.yml
@@ -19,11 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - pyodide-version: "0.27.3"
-            python-version: "3.12"
-            emscripten-version: "3.1.58"
-            artifact-suffix: "-0.27"
-            rust-flags: "-C target-feature=-exception-handling -C panic=abort"
           - pyodide-version: "0.29.3"
             python-version: "3.13"
             emscripten-version: "4.0.9"
@@ -101,10 +96,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - pyodide-version: "0.27.3"
-            npm-package: "pyodide-0.27@npm:pyodide@0.27.3"
-            artifact-suffix: "-0.27"
-            version-arg: "0.27"
           - pyodide-version: "0.29.3"
             npm-package: "pyodide-0.29@npm:pyodide@0.29.3"
             artifact-suffix: "-0.29"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,12 +75,15 @@ Test data: `tests/test_data/` contains real XRK/XRZ files (SFJ and 86 vehicles).
 
 ## Pyodide (WebAssembly) Builds
 
-The library supports running in the browser via Pyodide. Two versions are supported:
+The library supports running in the browser via Pyodide. One runtime is supported:
 
 | Version | Python | Emscripten | ABI Tag |
 |---------|--------|------------|---------|
-| Pyodide 0.27.x | 3.12 | 3.1.58 | `pyodide_2024_0` |
 | Pyodide 0.29.x | 3.13 | 4.0.9 | `pyodide_2025_0` |
+
+Pyodide 0.27.x (Python 3.12, `pyodide_2024_0`) was dropped: it has no known
+consumer, and PEP 783 starts at the 2025 ABI, so a 2024-ABI wheel can never be
+published to PyPI.
 
 **`pyodide-build` version is independent of the Pyodide runtime version.** It is
 a build tool: one current version (pinned to `0.32.0` in `uv.lock`, the justfile
@@ -93,26 +96,24 @@ metadata URL that upstream has since removed, so `xbuildenv install` fails with 
 404. The *host Python* still has to match the runtime (the 0.29.x xbuildenv
 refuses to install under Python 3.12), which is why the 0.29 recipes use pyenv.
 
-### Pyodide 0.27.x (default)
+### Building (requires Python 3.13 via pyenv)
 
 ```bash
-just emsdk-setup      # Install Emscripten SDK (first time only)
+just emsdk-setup      # Install Emscripten SDK 4.0.9 (first time only)
 just pyodide-setup    # Install Pyodide npm package (first time only)
-just pyodide-build    # Build Pyodide wheel
+just pyodide-build    # Build the Pyodide wheel
 just pyodide-test     # Build and run tests in Pyodide
-just build-all        # Build CPython wheel, sdist, and Pyodide wheel
+just build-all        # Build CPython wheel, sdist, and the Pyodide wheel
 ```
 
-### Pyodide 0.29.x (requires Python 3.13 via pyenv)
+Pyodide test scripts are in `scripts/run_pyodide_tests*.mjs`. They take
+`--pyodide-version=` (default `0.29`); `ABI_TAG` in each script maps a runtime
+version to the wheel ABI tag to look for.
 
-```bash
-just emsdk-setup-0-29      # Install Emscripten SDK 4.0.9
-just pyodide-setup-0-29    # Install Pyodide 0.29.x npm package
-just pyodide-build-0-29    # Build Pyodide 0.29.x wheel
-just pyodide-test-0-29     # Build and run tests in Pyodide 0.29.x
-```
-
-Pyodide test scripts are in `scripts/run_pyodide_tests*.mjs`. They accept `--pyodide-version=0.27` or `--pyodide-version=0.29` to select the version.
+`scripts/emcc-no-wasm-exceptions.sh`, `scripts/wasm-opt-wrapper.sh` and the
+`build-std` setting in `.cargo/config.toml` were all added for Emscripten 3.1.58
+(Pyodide 0.27) but are still applied to the 0.29 build. Whether 0.29 still needs
+them is untested — check before removing.
 
 ## Cython Rebuild
 

--- a/README.md
+++ b/README.md
@@ -184,14 +184,11 @@ You can test the library in a WebAssembly environment using Pyodide.
 This requires Node.js to be installed.
 
 ```bash
-# Build and run tests in Pyodide 0.27.x (Python 3.12)
-just pyodide-test
-
 # Build and run tests in Pyodide 0.29.x (Python 3.13, requires pyenv)
-just pyodide-test-0-29
+just pyodide-test
 ```
 
-Note: Pyodide tests for both 0.27.x and 0.29.x run automatically in CI via GitHub Actions.
+Note: Pyodide tests run automatically in CI via GitHub Actions.
 
 ### Building
 

--- a/justfile
+++ b/justfile
@@ -51,58 +51,13 @@ rust-build-debug:
     #!/usr/bin/env bash
     source $HOME/.cargo/env && uv run maturin develop
 
-# Install Emscripten SDK for Pyodide 0.27.x
-emsdk-setup:
-    #!/usr/bin/env bash
-    EMSDK_VERSION=$(uv run pyodide config get emscripten_version) && \
-    mkdir -p build && \
-    ([ -d build/emsdk ] || (git clone https://github.com/emscripten-core/emsdk.git build/emsdk && cd build/emsdk && git config core.autocrlf false && git checkout -- .)) && \
-    ./build/emsdk/emsdk install $EMSDK_VERSION && \
-    ./build/emsdk/emsdk activate $EMSDK_VERSION && \
-    WASM_OPT=build/emsdk/upstream/bin/wasm-opt && \
-    ([ -f ${WASM_OPT}.real ] || mv $WASM_OPT ${WASM_OPT}.real) && \
-    sed 's/\r$//' scripts/wasm-opt-wrapper.sh > $WASM_OPT && chmod +x $WASM_OPT
-
-# Install Pyodide 0.27.x npm package
-pyodide-setup:
-    npm install pyodide-0.27@npm:pyodide@0.27.3
-
-# Build Pyodide 0.27.x wheel (Cython + Rust for WASM)
-pyodide-build: emsdk-setup
-    #!/usr/bin/env bash
-    _bak=/tmp/_libxrk_native_$$ && mkdir -p "$_bak" && \
-    find src/libxrk -maxdepth 1 -name '*linux-gnu.so' -exec mv {} "$_bak/" \; && \
-    source $HOME/.cargo/env && \
-    export RUSTUP_TOOLCHAIN=nightly && \
-    source ./build/emsdk/emsdk_env.sh && \
-    export RUSTFLAGS="-C target-feature=-exception-handling -C panic=abort" && \
-    export CARGO_BUILD_TARGET=wasm32-unknown-emscripten && \
-    uv run pyodide build --exports whole_archive; \
-    _rc=$?; mv "$_bak"/*.so src/libxrk/ 2>/dev/null; rm -rf "$_bak"; exit $_rc
-
-# Build and run tests in Pyodide 0.27.x (WebAssembly)
-pyodide-test: emsdk-setup pyodide-setup
-    #!/usr/bin/env bash
-    _bak=/tmp/_libxrk_native_$$ && mkdir -p "$_bak" && \
-    find src/libxrk -maxdepth 1 -name '*linux-gnu.so' -exec mv {} "$_bak/" \; && \
-    rm -f dist/*pyodide_2024*.whl && \
-    source $HOME/.cargo/env && \
-    export RUSTUP_TOOLCHAIN=nightly && \
-    source ./build/emsdk/emsdk_env.sh && \
-    export RUSTFLAGS="-C target-feature=-exception-handling -C panic=abort" && \
-    export CARGO_BUILD_TARGET=wasm32-unknown-emscripten && \
-    uv run pyodide build --exports whole_archive && \
-    node scripts/run_pyodide_tests.mjs --dist-dir=./dist --pyodide-version=0.27 && \
-    node scripts/run_pyodide_tests_idbfs.mjs --dist-dir=./dist --pyodide-version=0.27; \
-    _rc=$?; mv "$_bak"/*.so src/libxrk/ 2>/dev/null; rm -rf "$_bak"; exit $_rc
-
 # pyodide-build is a BUILD TOOL; its version is independent of the Pyodide
 # RUNTIME version. Pinning it to the runtime version (==0.29.3) broke builds:
 # those releases hardcode a cross-build-env metadata URL upstream has removed.
 # One current pyodide-build serves every runtime. The runtime still dictates the
 # host Python (0.29.x xbuildenv refuses to install under 3.12), hence pyenv 3.13.
-# Install Emscripten SDK for Pyodide 0.29.x (requires Python 3.13 via pyenv)
-emsdk-setup-0-29:
+# Install Emscripten SDK for Pyodide (requires Python 3.13 via pyenv)
+emsdk-setup:
     #!/usr/bin/env bash
     export PATH="$HOME/.pyenv/versions/3.13.12/bin:$PATH" && \
     uv pip install --python "$HOME/.pyenv/versions/3.13.12/bin/python" pyodide-build==0.32.0 "wheel<0.44" && \
@@ -114,12 +69,12 @@ emsdk-setup-0-29:
     WASM_OPT=upstream/bin/wasm-opt && ([ -f ${WASM_OPT}.real ] || mv $WASM_OPT ${WASM_OPT}.real) && \
     sed 's/\r$//' ../../scripts/wasm-opt-wrapper.sh > $WASM_OPT && chmod +x $WASM_OPT
 
-# Install Pyodide 0.29.x npm package
-pyodide-setup-0-29:
+# Install Pyodide npm package
+pyodide-setup:
     npm install pyodide-0.29@npm:pyodide@0.29.3
 
-# Build Pyodide 0.29.x wheel (requires Python 3.13 via pyenv)
-pyodide-build-0-29: emsdk-setup-0-29
+# Build the Pyodide wheel (requires Python 3.13 via pyenv)
+pyodide-build: emsdk-setup
     #!/usr/bin/env bash
     _bak=/tmp/_libxrk_native_$$ && mkdir -p "$_bak" && \
     find src/libxrk -maxdepth 1 -name '*linux-gnu.so' -exec mv {} "$_bak/" \; && \
@@ -132,8 +87,8 @@ pyodide-build-0-29: emsdk-setup-0-29
     pyodide build --exports whole_archive; \
     _rc=$?; mv "$_bak"/*.so src/libxrk/ 2>/dev/null; rm -rf "$_bak"; exit $_rc
 
-# Build and test with Pyodide 0.29.x (requires Python 3.13 via pyenv)
-pyodide-test-0-29: emsdk-setup-0-29 pyodide-setup-0-29
+# Build and test with Pyodide (requires Python 3.13 via pyenv)
+pyodide-test: emsdk-setup pyodide-setup
     #!/usr/bin/env bash
     _bak=/tmp/_libxrk_native_$$ && mkdir -p "$_bak" && \
     find src/libxrk -maxdepth 1 -name '*linux-gnu.so' -exec mv {} "$_bak/" \; && \
@@ -149,7 +104,7 @@ pyodide-test-0-29: emsdk-setup-0-29 pyodide-setup-0-29
     node scripts/run_pyodide_tests_idbfs.mjs --dist-dir=./dist --pyodide-version=0.29; \
     _rc=$?; mv "$_bak"/*.so src/libxrk/ 2>/dev/null; rm -rf "$_bak"; exit $_rc
 
-# Build CPython wheel, sdist, and Pyodide 0.27.x wheel
+# Build CPython wheel, sdist, and the Pyodide wheel
 build-all: emsdk-setup
     #!/usr/bin/env bash
     _bak=/tmp/_libxrk_native_$$ && mkdir -p "$_bak" && \
@@ -157,10 +112,12 @@ build-all: emsdk-setup
     source $HOME/.cargo/env && \
     uv build && \
     find src/libxrk -maxdepth 1 -name '*linux-gnu.so' -exec mv {} "$_bak/" \; && \
+    EMSDK=$PWD/build/emsdk-0.29 && \
+    export PATH="$HOME/.pyenv/versions/3.13.12/bin:$HOME/.cargo/bin:$EMSDK/upstream/emscripten:$PATH" && \
+    export EMSDK EM_CONFIG=$EMSDK/.emscripten EMSDK_NODE=$EMSDK/node/22.16.0_64bit/bin/node && \
     export RUSTUP_TOOLCHAIN=nightly && \
-    source ./build/emsdk/emsdk_env.sh && \
-    export RUSTFLAGS="-C target-feature=-exception-handling -C panic=abort" && \
     export CARGO_BUILD_TARGET=wasm32-unknown-emscripten && \
-    uv run pyodide build --exports whole_archive; \
+    uv pip install --python "$HOME/.pyenv/versions/3.13.12/bin/python" pyodide-build==0.32.0 "wheel<0.44" && \
+    pyodide build --exports whole_archive; \
     _rc=$?; mv "$_bak"/*.so src/libxrk/ 2>/dev/null; rm -rf "$_bak"; \
     [ $_rc -eq 0 ] && ls -la dist/; exit $_rc

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "packages": {
     "": {
       "dependencies": {
-        "pyodide-0.27": "npm:pyodide@^0.27.3",
         "pyodide-0.29": "npm:pyodide@^0.29.3"
       }
     },
@@ -13,19 +12,6 @@
       "version": "1.41.5",
       "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
       "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q=="
-    },
-    "node_modules/pyodide-0.27": {
-      "name": "pyodide",
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.27.3.tgz",
-      "integrity": "sha512-6NwKEbPk0M3Wic2T1TCZijgZH9VE4RkHp1VGljS1sou0NjGdsmY2R/fG5oLmdDkjTRMI1iW7WYaY9pofX8gg1g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ws": "^8.5.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
     },
     "node_modules/pyodide-0.29": {
       "name": "pyodide",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "pyodide-0.27": "npm:pyodide@^0.27.3",
     "pyodide-0.29": "npm:pyodide@^0.29.3"
   }
 }

--- a/scripts/run_pyodide_tests.mjs
+++ b/scripts/run_pyodide_tests.mjs
@@ -1,7 +1,7 @@
 /**
  * Run libxrk tests in Pyodide (WebAssembly) environment.
  *
- * Usage: node scripts/run_pyodide_tests.mjs [--dist-dir=./dist] [--pyodide-version=0.27]
+ * Usage: node scripts/run_pyodide_tests.mjs [--dist-dir=./dist] [--pyodide-version=0.29]
  */
 
 import * as fs from "fs";
@@ -41,10 +41,13 @@ function copyDirToFs(pyodide, srcDir, dstDir) {
   }
 }
 
+// Pyodide runtime version -> wheel ABI tag. One entry per supported runtime.
+const ABI_TAG = { "0.29": "pyodide_2025" };
+
 /**
  * Find the Pyodide-compatible wheel file in the dist directory.
  * @param {string} distDir - Directory containing wheel files
- * @param {string} pyodideVersion - Pyodide version (e.g., "0.27" or "0.29")
+ * @param {string} pyodideVersion - Pyodide version (e.g., "0.29")
  */
 function findWheel(distDir, pyodideVersion) {
   if (!fs.existsSync(distDir)) {
@@ -57,8 +60,7 @@ function findWheel(distDir, pyodideVersion) {
   }
 
   // Determine ABI tag based on version
-  const abiYear = pyodideVersion.startsWith("0.27") ? "2024" : "2025";
-  const abiTag = `pyodide_${abiYear}`;
+  const abiTag = ABI_TAG[pyodideVersion.substring(0, 4)] ?? "pyodide_2025";
 
   // Find wheel matching the ABI tag
   const matchingWheel = wheels.find((w) => w.includes(abiTag));
@@ -89,7 +91,7 @@ function findWheel(distDir, pyodideVersion) {
 function parseArgs() {
   const args = {
     distDir: path.join(projectRoot, "dist"),
-    pyodideVersion: "0.27",
+    pyodideVersion: "0.29",
     backend: "",
   };
 
@@ -108,10 +110,10 @@ function parseArgs() {
 
 /**
  * Dynamically load the appropriate Pyodide module based on version.
- * @param {string} version - Pyodide version (e.g., "0.27" or "0.29")
+ * @param {string} version - Pyodide version (e.g., "0.29")
  */
 async function loadPyodideModule(version) {
-  const majorMinor = version.substring(0, 4); // "0.27" or "0.29"
+  const majorMinor = version.substring(0, 4); // e.g. "0.29"
   const mod = await import(`pyodide-${majorMinor}`);
   return mod.loadPyodide;
 }

--- a/scripts/run_pyodide_tests_idbfs.mjs
+++ b/scripts/run_pyodide_tests_idbfs.mjs
@@ -4,7 +4,7 @@
  * JupyterLite uses IDBFS (IndexedDB Filesystem) which doesn't support mmap.
  * This test demonstrates the failure and tests potential fixes.
  *
- * Usage: node scripts/run_pyodide_tests_idbfs.mjs [--dist-dir=./dist] [--pyodide-version=0.27]
+ * Usage: node scripts/run_pyodide_tests_idbfs.mjs [--dist-dir=./dist] [--pyodide-version=0.29]
  */
 
 import * as fs from "fs";
@@ -15,10 +15,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, "..");
 const pyodideTestsDir = path.join(__dirname, "pyodide_tests");
 
+// Pyodide runtime version -> wheel ABI tag. One entry per supported runtime.
+const ABI_TAG = { "0.29": "pyodide_2025" };
+
 /**
  * Find the Pyodide-compatible wheel file in the dist directory.
  * @param {string} distDir - Directory containing wheel files
- * @param {string} pyodideVersion - Pyodide version (e.g., "0.27" or "0.29")
+ * @param {string} pyodideVersion - Pyodide version (e.g., "0.29")
  */
 function findWheel(distDir, pyodideVersion) {
   if (!fs.existsSync(distDir)) {
@@ -31,8 +34,7 @@ function findWheel(distDir, pyodideVersion) {
   }
 
   // Determine ABI tag based on version
-  const abiYear = pyodideVersion.startsWith("0.27") ? "2024" : "2025";
-  const abiTag = `pyodide_${abiYear}`;
+  const abiTag = ABI_TAG[pyodideVersion.substring(0, 4)] ?? "pyodide_2025";
 
   // Find wheel matching the ABI tag
   const matchingWheel = wheels.find((w) => w.includes(abiTag));
@@ -63,7 +65,7 @@ function findWheel(distDir, pyodideVersion) {
 function parseArgs() {
   const args = {
     distDir: path.join(projectRoot, "dist"),
-    pyodideVersion: "0.27",
+    pyodideVersion: "0.29",
     backend: "",
   };
 
@@ -82,10 +84,10 @@ function parseArgs() {
 
 /**
  * Dynamically load the appropriate Pyodide module based on version.
- * @param {string} version - Pyodide version (e.g., "0.27" or "0.29")
+ * @param {string} version - Pyodide version (e.g., "0.29")
  */
 async function loadPyodideModule(version) {
-  const majorMinor = version.substring(0, 4); // "0.27" or "0.29"
+  const majorMinor = version.substring(0, 4); // e.g. "0.29"
   const mod = await import(`pyodide-${majorMinor}`);
   return mod.loadPyodide;
 }


### PR DESCRIPTION

Pyodide 0.27.x (Python 3.12, Emscripten 3.1.58, ABI tag pyodide_2024_0) has no
known consumer, and PEP 783 starts at the 2025 ABI, so a 2024-ABI wheel can
never be published to PyPI. Keeping it means maintaining a second Emscripten
toolchain from 2024 for nobody.

Evidence it is unused: the one known downstream consumer,
m3rlin45/motorsports_data_notebook, is on 0.29 —
jupyterlite-pyodide-kernel==0.7.0 loads Pyodide 0.29.0 in-browser, its
pyproject pins pyodide-build==0.29.3, its CI hard-fails if that version differs,
and its release-asset selection (`ls -v | tail -1`) resolves to the
cp313/pyodide_2025_0 wheel. A full-repo search there finds no 2024_0 reference.

Release download counts do not contradict this: the 0.27 and 0.29 wheels sit at
205 vs 206 on v0.12.0 because that same consumer's glob (`*pyodide*wasm32.whl`)
downloads both and then discards the 0.27 one. Near-identical counts are the
signature of one consumer, not two.

Changes:
  * pyodide.yml: drop the 0.27.3 entry from the build and test matrices
  * justfile: delete the four 0.27 recipes; the -0-29 recipes lose their suffix
    and become the defaults; build-all now uses the 0.29 environment
  * package.json: drop the pyodide-0.27 npm dependency
  * run_pyodide_tests{,_idbfs}.mjs: default to 0.29; the runtime -> ABI tag
    mapping moves to an ABI_TAG table so adding a runtime is a one-line change
  * CLAUDE.md / README.md: updated

Deliberately NOT removed: scripts/emcc-no-wasm-exceptions.sh,
scripts/wasm-opt-wrapper.sh, and build-std in .cargo/config.toml. All three were
added for Emscripten 3.1.58, but all three are still wired into the 0.29 build
(justfile emsdk-setup, and the linker env in pyodide.yml). Whether 0.29 needs
them is untested and settling it requires a full Pyodide build, so they stay
here and are flagged in CLAUDE.md as pending review.

Note: scripts/benchmark_pyodide.mjs and scripts/debug_pyodide_load.mjs are
untracked local scratch scripts that import "pyodide-0.27"; they will need
updating out-of-tree.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/libxrk/pull/88).
* #89
* __->__ #88