### PR TITLE
test: add exhaustive three-way equivalence suites (spec/Cython/Rust)

### DIFF
--- a/spec/docs/unknown_regions.md
+++ b/spec/docs/unknown_regions.md
@@ -175,6 +175,32 @@ The SRC message wraps an embedded idn with a 6-byte header:
 ### [62:end] Remaining bytes
 - **Status**: Not used
 
+## LAP version 2 (32 bytes)
+
+The spec's LAPPayload models the 20-byte version-0/1 layout. The AIM
+official sample (`tests/test_data/aim_official/test.xrk`) carries LAP
+messages with `version=2` and a **32-byte** payload. Observations from
+that file (33 messages, 3 segments × 11 laps):
+
+- [0:20]: Same field positions as v1, **except** [16:20] is *not* the
+  absolute lap end time — its value tracks the lap duration [4:8]
+  (always a few ms smaller), purpose unknown.
+- [20:24]: uint32, always 0. **Status**: not decoded.
+- [24:28]: uint32, small bit patterns (`0x0103`, `0x0203`, `0x010203`,
+  `0x0306`). **Hypothesis**: per-segment flags. **Status**: not decoded.
+- [28:32]: uint32, **absolute lap end time [ms]** on the logger clock.
+  `[28:32] - duration` of the first LAP message equals the minimum data
+  timecode of the file (verified: 46957 − 46946 = 11 = min data tc),
+  i.e. this field plays the role that [16:20] plays in v1.
+
+Neither backend implements v2 yet: Cython's exact-20-byte
+`struct.unpack` drops v2 LAP messages entirely (laps then come from
+GPS-based detection); the Rust backend and this spec parse the first
+20 bytes as if v1, misreading [16:20] as end time. This is the source
+of the constant 18 ms time_offset difference between the backends on
+the aim_official fixture — see tests/test_backend_equivalence.py.
+A proper fix must land here (spec) first, per the project rules.
+
 ## ODO (Odometer, n×64 bytes)
 
 Each 64-byte record:

--- a/spec/tests/test_spec_rust.py
+++ b/spec/tests/test_spec_rust.py
@@ -1,0 +1,168 @@
+"""Spec <-> Rust backend cross-validation.
+
+Mirrors the spec <-> Cython checks in test_spec.py for the Rust backend, so
+that both backends are validated directly against the Construct reference
+spec (not merely against each other):
+
+  * every decoded sample of every channel (exhaustive, 3 fixtures)
+  * lap counts
+  * key metadata (logger identity, GPS receiver, venue, VET, race mode,
+    odometer, calibrations)
+
+The issue68 fixture's spec-vs-Rust check (expansion V2/V3 channels) already
+lives in test_spec.py:TestIssue68SpecVsBackends.
+"""
+
+import pytest
+
+from spec.tests.conftest import (
+    AIM_OFFICIAL_XRK,
+    FILE_86_XRK,
+    SFJ_XRK,
+)
+from spec.tests.test_spec import TestExhaustiveChannelValues, _unique_seg0_laps
+
+
+def _rust_load(path):
+    try:
+        from libxrk._aim_xrk_rs import aim_xrk as rust_aim_xrk
+    except ImportError:
+        pytest.skip("Rust backend not available")
+    return rust_aim_xrk(str(path))
+
+
+@pytest.fixture(scope="session")
+def sfj_rust():
+    return _rust_load(SFJ_XRK)
+
+
+@pytest.fixture(scope="session")
+def file_86_rust():
+    return _rust_load(FILE_86_XRK)
+
+
+@pytest.fixture(scope="session")
+def aim_official_rust():
+    return _rust_load(AIM_OFFICIAL_XRK)
+
+
+class TestExhaustiveChannelValuesVsRust:
+    """Every decoded channel value must match the spec's canonical decode."""
+
+    def test_sfj_every_value(self, sfj_parsed, sfj_rust):
+        checked, errors = TestExhaustiveChannelValues()._compare_all_values(sfj_parsed, sfj_rust)
+        assert checked > 0, "No channels were cross-validated"
+        assert not errors, "Value mismatches:\n" + "\n".join(errors)
+
+    def test_86_every_value(self, file_86_parsed, file_86_rust):
+        checked, errors = TestExhaustiveChannelValues()._compare_all_values(
+            file_86_parsed, file_86_rust
+        )
+        assert checked > 0, "No channels were cross-validated"
+        assert not errors, "Value mismatches:\n" + "\n".join(errors)
+
+    def test_aim_official_every_value(self, aim_official_parsed, aim_official_rust):
+        checked, errors = TestExhaustiveChannelValues()._compare_all_values(
+            aim_official_parsed, aim_official_rust
+        )
+        assert checked > 0, "No channels were cross-validated"
+        assert not errors, "Value mismatches:\n" + "\n".join(errors)
+
+
+class TestLAPVsRust:
+    """Lap counts must match the spec's segment-0 LAP messages."""
+
+    def test_sfj_lap_count(self, sfj_parsed, sfj_rust):
+        assert len(_unique_seg0_laps(sfj_parsed)) == len(sfj_rust.laps)
+
+    def test_86_lap_count(self, file_86_parsed, file_86_rust):
+        assert len(_unique_seg0_laps(file_86_parsed)) == len(file_86_rust.laps)
+
+    def test_aim_official_lap_count(self, aim_official_parsed, aim_official_rust):
+        # aim_official carries v2 (32-byte) LAP payloads whose first-20-byte
+        # parse yields degenerate laps; the Rust backend invalidates them and
+        # falls back to GPS-based detection, which finds the same 11 laps as
+        # the file's segment-0 LAP records describe.
+        assert len(_unique_seg0_laps(aim_official_parsed)) == len(aim_official_rust.laps)
+
+
+class TestGPSVsRust:
+    """GPS record counts must match the spec's GPS payload count."""
+
+    def test_sfj_gps_count(self, sfj_parsed, sfj_rust):
+        assert len(sfj_parsed.gps_payloads) == len(sfj_rust.channels["GPS Speed"])
+
+    def test_86_gps_count(self, file_86_parsed, file_86_rust):
+        assert len(file_86_parsed.gps_payloads) == len(file_86_rust.channels["GPS Speed"])
+
+
+class TestMetadataVsRust:
+    """Key metadata must match the spec's message payloads."""
+
+    def test_sfj_string_metadata(self, sfj_parsed, sfj_rust):
+        string_checks = {
+            "RCR": "Driver",
+            "VEH": "Vehicle",
+            "TMD": "Log Date",
+            "TMT": "Log Time",
+            "VTY": "Session",
+            "CMP": "Series",
+            "NTE": "Long Comment",
+            "NDV": "Device Name",
+        }
+        for tok_str, meta_key in string_checks.items():
+            msgs = sfj_parsed.messages_by_token(tok_str)
+            if not msgs:
+                continue
+            if meta_key in sfj_rust.metadata:
+                assert msgs[-1].payload == sfj_rust.metadata[meta_key], meta_key
+
+    def test_sfj_logger_identity(self, sfj_parsed, sfj_rust):
+        src = sfj_parsed.messages_by_token("SRC")[-1].payload
+        assert src["logger_id"] == sfj_rust.metadata["Logger ID"]
+        assert src["model_id"] == sfj_rust.metadata["Logger Model ID"]
+
+    def test_86_logger_identity(self, file_86_parsed, file_86_rust):
+        idn_msgs = file_86_parsed.messages_by_token("idn")
+        src_msgs = file_86_parsed.messages_by_token("SRC")
+        found = None
+        if idn_msgs:
+            found = idn_msgs[-1].payload
+        elif src_msgs and src_msgs[-1].payload:
+            found = src_msgs[-1].payload
+        assert found is not None
+        assert found["logger_id"] == file_86_rust.metadata["Logger ID"]
+        assert found["model_id"] == file_86_rust.metadata["Logger Model ID"]
+
+    def test_sfj_gps_receiver(self, sfj_parsed, sfj_rust):
+        gpsr = sfj_parsed.messages_by_token("GPSR")[-1].payload
+        assert gpsr["type"] == sfj_rust.metadata["GPS Receiver"]
+
+    def test_sfj_venue(self, sfj_parsed, sfj_rust):
+        trk = sfj_parsed.messages_by_token("TRK")[-1].payload
+        assert trk["name"] == sfj_rust.metadata["Venue"]
+
+    def test_sfj_vet(self, sfj_parsed, sfj_rust):
+        vet = sfj_parsed.messages_by_token("VET")[-1].payload
+        assert vet.value == sfj_rust.metadata["Vehicle Electronics Type"]
+
+    def test_sfj_race_mode(self, sfj_parsed, sfj_rust):
+        found_string_mode = None
+        for m in sfj_parsed.messages_by_token("RACM"):
+            if m.payload and m.payload["mode"] == "string":
+                found_string_mode = m.payload["value"]
+        assert found_string_mode == sfj_rust.metadata.get("Race Mode")
+
+    def test_sfj_odo(self, sfj_parsed, sfj_rust):
+        odo = sfj_parsed.messages_by_token("ODO")[-1].payload
+        expected_km = sfj_rust.metadata["Odo/System Distance (km)"]
+        assert abs(odo["System"]["dist"] / 1000 - expected_km) < 0.01
+
+    def test_sfj_calibrations(self, sfj_parsed, sfj_rust):
+        cal_msgs = sfj_parsed.messages_by_token("CAL")
+        rust_cals = sfj_rust.metadata.get("Calibrations", [])
+        assert len(cal_msgs) == len(rust_cals)
+        for msg, cal in zip(cal_msgs, rust_cals):
+            assert msg.payload["type"] == cal["type"]
+            assert abs(msg.payload["raw_1"] - cal["raw_1"]) < 1e-6
+            assert abs(msg.payload["raw_2"] - cal["raw_2"]) < 1e-6

--- a/tests/test_aim_official_xrk.py
+++ b/tests/test_aim_official_xrk.py
@@ -173,10 +173,14 @@ class TestAIMOfficialCrossBackend(unittest.TestCase):
     def test_non_gps_channel_values_match(self) -> None:
         """Non-GPS CHS channels should produce matching values.
 
-        Note: This file has no LAP messages, so time_offset is computed from
-        the first data message timecode. The backends may differ by a small
-        constant offset (~18ms), so timecodes are compared with tolerance.
-        Values (which are offset-independent) should match exactly.
+        Note: This file carries version-2 LAP messages with a 32-byte payload.
+        Cython's exact-20-byte struct.unpack drops all of them (no LAP-derived
+        time_offset candidate), while Rust parses the first 20 bytes as if v1
+        and derives a different candidate, so the backends' time_offsets differ
+        by a constant 18ms. Timecodes are therefore compared modulo a uniform
+        shift; values (which are offset-independent) must match exactly.
+        See tests/test_backend_equivalence.py and spec/docs/unknown_regions.md
+        ("LAP version 2").
         """
         gps_prefixes = ("GPS ", "GPS_")
         for name in self.rust_log.channels:

--- a/tests/test_backend_equivalence.py
+++ b/tests/test_backend_equivalence.py
@@ -1,0 +1,296 @@
+"""Exhaustive Cython vs Rust backend equivalence tests.
+
+Every test fixture is loaded with both backends and compared at full
+strictness: channel name sets, Arrow types, all 11 field-metadata keys,
+bit-exact timecodes and values, the laps table, and the complete metadata
+dict.  This is deliberately stronger than the per-file CrossBackend classes
+(which check a subset of metadata keys and use loose GPS tolerances).
+
+Documented residual discrepancies (see the xfail tests at the bottom, which
+flip visibly when the underlying divergence is fixed):
+
+1. GPS float paths.  Both backends compute GPS-derived channels in float64,
+   but with slightly different operation orders:
+     - GPS Latitude / GPS Altitude: the Rust Vermeille-2003 ECEF->LLA uses
+       ``/ (a*a)`` and ``r*r*r`` where numpy uses ``* (1/(a*a))`` and
+       ``r**3`` (and ``np.cbrt`` vs ``f64::cbrt``); observed diffs are
+       <= 1.5e-14 deg / <= 2.9e-9 m.
+     - GPS_LateralAcc: Rust multiplies the float32-rounded yaw rate where
+       Cython uses the intermediate float64 value; observed <= 5e-7 g.
+     - GPS_Yaw_Rate: rare 1-ulp float32 rounding differences (<= 1e-12).
+     - GPS Longitude: pure atan2; bit-exact on some hosts, but numpy's
+       atan2 kernel varies with glibc version and CPU SIMD dispatch while
+       Rust links a vendored libm, so it can differ by 1 ulp elsewhere.
+   All other GPS channels (Speed, InlineAcc, Satellites, Fix, pDOP,
+   Position/Velocity Accuracy) are pure arithmetic + sqrt and are
+   required to be bit-exact on every platform.
+
+2. Duplicate CHS long_names (issue68/issue84 fixtures define e.g.
+   RotaryMiddle_led three times at different channel indices).  Cython's
+   ``{ch.long_name: ch}`` dict deterministically keeps the *last* CHS index;
+   the Rust backend builds its channels dict while iterating a HashMap, so
+   which CHS index wins is nondeterministic per run (observed: different
+   source_channel_id, sample counts, and even Arrow dtype across runs).
+
+3. aim_official/test.xrk carries version-2 LAP messages with a 32-byte
+   payload.  Cython's ``struct.unpack`` requires exactly 20 bytes and drops
+   all 33 LAP messages (losing the LAP-derived time_offset candidate);
+   Rust parses the first 20 bytes as if v1, misreading a duration-like
+   field as end_time and deriving a bogus time_offset of -7 (proper v2
+   parsing -- absolute end time at offset [28:32] -- yields 11, which is
+   what Cython arrives at from data timecodes).  Net effect: every
+   timecode and lap boundary in the file differs by a constant 18 ms
+   between backends.  Values are unaffected.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+TEST_DATA_DIR = Path(__file__).parent / "test_data"
+
+try:
+    import libxrk._aim_xrk_rs  # noqa: F401
+
+    _RUST_AVAILABLE = True
+except ImportError:
+    _RUST_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not _RUST_AVAILABLE, reason="Rust backend not available")
+
+
+# Per-channel float tolerances for known GPS float-path differences
+# (rtol, atol); channels not listed must match bit-exactly.
+_GPS_FLOAT_TOLERANCES = {
+    "GPS Latitude": (0.0, 1e-11),
+    "GPS Longitude": (0.0, 1e-11),
+    "GPS Altitude": (0.0, 1e-6),
+    "GPS_LateralAcc": (1e-4, 1e-7),
+    "GPS_Yaw_Rate": (1e-4, 1e-9),
+}
+
+
+@dataclass(frozen=True)
+class Fixture:
+    path: Path
+    # Channel long_names defined by more than one CHS entry in this file.
+    # Cython deterministically exposes the last CHS index with that name;
+    # Rust exposes a nondeterministic one (see module docstring, item 2).
+    duplicate_name_channels: frozenset = field(default_factory=frozenset)
+    # True when all timecodes/lap times differ by one constant offset
+    # between backends (module docstring, item 3).
+    allow_uniform_time_shift: bool = False
+
+
+FIXTURES = [
+    Fixture(TEST_DATA_DIR / "SFJ/CMD_SFJ_Fuji GP Sh_Generic testing_a_0033.xrk"),
+    Fixture(TEST_DATA_DIR / "SFJ/CMD_SFJ_Fuji GP Sh_Generic testing_a_0033.xrz"),
+    Fixture(TEST_DATA_DIR / "SFJ/CMD_SFJ_Fuji GP Sh_Generic testing_a_0101.xrk"),
+    Fixture(TEST_DATA_DIR / "SFJ/CMD_SFJ_Fuji GP Sh_Generic testing_a_0101.xrz"),
+    Fixture(TEST_DATA_DIR / "SFJ/CMD_SFJ_Suzuka Car_Generic testing_a_0090.xrk"),
+    Fixture(TEST_DATA_DIR / "86/CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrk"),
+    Fixture(TEST_DATA_DIR / "86/CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz"),
+    Fixture(
+        TEST_DATA_DIR / "aim_official/test.xrk",
+        allow_uniform_time_shift=True,
+    ),
+    Fixture(TEST_DATA_DIR / "issue49/badGPSdata.xrk"),
+    Fixture(
+        TEST_DATA_DIR / "issue68/CMD_KK-SII_Tsukuba_Car_Generic testing_a_0101.xrz",
+        duplicate_name_channels=frozenset(
+            {"RotaryLeft_led", "RotaryMiddle_led", "RotaryRight_led", "Right_Btn_4_led"}
+        ),
+    ),
+    Fixture(
+        TEST_DATA_DIR / "issue84/CMD_KK-SII_Tsukuba_Car_Qualifying testing_a_0159.xrz",
+        duplicate_name_channels=frozenset(
+            {"RotaryLeft_led", "RotaryMiddle_led", "RotaryRight_led", "Right_Btn_4_led"}
+        ),
+    ),
+]
+
+
+def _load_both(path: Path):
+    from libxrk._aim_xrk_rs import aim_xrk as rust_aim_xrk
+    from libxrk.aim_xrk import aim_xrk as cython_aim_xrk
+
+    return cython_aim_xrk(str(path)), rust_aim_xrk(str(path))
+
+
+def _field_metadata(table, name: str) -> dict:
+    md = table.schema.field(name).metadata or {}
+    return {k.decode(): v.decode() for k, v in md.items()}
+
+
+def _compute_shift(cy, rs) -> int:
+    """The single constant offset between the two backends' timecodes."""
+    for name in sorted(cy.channels):
+        cy_tc = cy.channels[name].column("timecodes").to_numpy()
+        rs_tc = rs.channels[name].column("timecodes").to_numpy()
+        if len(cy_tc) and len(cy_tc) == len(rs_tc):
+            return int(rs_tc[0] - cy_tc[0])
+    return 0
+
+
+def _compare_channel(name: str, cy_t, rs_t, shift: int, errors: list) -> None:
+    cy_f = cy_t.schema.field(name)
+    rs_f = rs_t.schema.field(name)
+    if cy_f.type != rs_f.type:
+        errors.append(f"{name}: arrow type cython={cy_f.type} rust={rs_f.type}")
+        return
+    cy_md = _field_metadata(cy_t, name)
+    rs_md = _field_metadata(rs_t, name)
+    for key in sorted(set(cy_md) | set(rs_md)):
+        if cy_md.get(key) != rs_md.get(key):
+            errors.append(
+                f"{name}: metadata {key} cython={cy_md.get(key)!r} rust={rs_md.get(key)!r}"
+            )
+
+    cy_tc = cy_t.column("timecodes").to_numpy()
+    rs_tc = rs_t.column("timecodes").to_numpy()
+    if len(cy_tc) != len(rs_tc):
+        errors.append(f"{name}: sample count cython={len(cy_tc)} rust={len(rs_tc)}")
+        return
+    if not np.array_equal(cy_tc + shift, rs_tc):
+        i = int(np.argmax((cy_tc + shift) != rs_tc))
+        errors.append(
+            f"{name}: timecodes differ (first at {i}: "
+            f"cython={cy_tc[i]}+{shift} != rust={rs_tc[i]})"
+        )
+
+    cy_v = cy_t.column(name).to_numpy(zero_copy_only=False)
+    rs_v = rs_t.column(name).to_numpy(zero_copy_only=False)
+    tol = _GPS_FLOAT_TOLERANCES.get(name)
+    if tol is not None:
+        rtol, atol = tol
+        if not np.allclose(cy_v, rs_v, rtol=rtol, atol=atol, equal_nan=True):
+            maxdiff = float(np.nanmax(np.abs(cy_v - rs_v)))
+            errors.append(
+                f"{name}: values exceed documented float tolerance "
+                f"(rtol={rtol}, atol={atol}), max abs diff {maxdiff:.3e}"
+            )
+    else:
+        cy_f64 = cy_v.astype(np.float64)
+        rs_f64 = rs_v.astype(np.float64)
+        equal = (cy_v == rs_v) | (np.isnan(cy_f64) & np.isnan(rs_f64))
+        if not bool(np.all(equal)):
+            i = int(np.argmax(~equal))
+            errors.append(
+                f"{name}: values differ bit-exactly at {i}: "
+                f"cython={cy_v[i]!r} rust={rs_v[i]!r} "
+                f"({int(np.sum(~equal))}/{len(cy_v)} samples)"
+            )
+
+
+@pytest.mark.parametrize("fixture", FIXTURES, ids=lambda f: f.path.name)
+def test_backends_equivalent(fixture: Fixture) -> None:
+    """Cython and Rust must agree on everything except documented gaps."""
+    cy, rs = _load_both(fixture.path)
+    errors: list = []
+
+    cy_names = set(cy.channels)
+    rs_names = set(rs.channels)
+    if cy_names != rs_names:
+        errors.append(
+            f"channel sets differ: only-cython={sorted(cy_names - rs_names)} "
+            f"only-rust={sorted(rs_names - cy_names)}"
+        )
+
+    shift = _compute_shift(cy, rs) if fixture.allow_uniform_time_shift else 0
+    if not fixture.allow_uniform_time_shift:
+        assert _compute_shift(cy, rs) == 0, "unexpected global time shift"
+
+    for name in sorted(cy_names & rs_names):
+        if name in fixture.duplicate_name_channels:
+            continue  # documented discrepancy 2 (see module docstring)
+        _compare_channel(name, cy.channels[name], rs.channels[name], shift, errors)
+
+    # Laps: exact, modulo the documented uniform shift
+    cy_laps = cy.laps.to_pydict()
+    rs_laps = rs.laps.to_pydict()
+    for col in ("start_time", "end_time"):
+        cy_laps[col] = [t + shift for t in cy_laps[col]]
+    if cy_laps != rs_laps:
+        errors.append(f"laps differ: cython={cy_laps} rust={rs_laps}")
+
+    # Full metadata dict: exact
+    if cy.metadata != rs.metadata:
+        keys = sorted(set(cy.metadata) | set(rs.metadata))
+        for k in keys:
+            if cy.metadata.get(k) != rs.metadata.get(k):
+                errors.append(
+                    f"metadata[{k!r}]: cython={cy.metadata.get(k)!r} "
+                    f"rust={rs.metadata.get(k)!r}"
+                )
+
+    assert not errors, f"{fixture.path.name}: backend divergence:\n" + "\n".join(errors)
+
+
+# ---------------------------------------------------------------------------
+# Probes for the documented residual discrepancies.  Each is expected to
+# fail today; when the underlying divergence is fixed, the strict xfails
+# turn into XPASS failures, prompting removal of the marker (and of the
+# corresponding carve-out above).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="LAP v2 (32-byte payload): Cython drops all LAP messages while Rust "
+    "misparses the first 20 bytes as v1, so time_offset differs by 18 ms on "
+    "aim_official/test.xrk (see module docstring, item 3)",
+)
+def test_aim_official_absolute_times_match() -> None:
+    cy, rs = _load_both(TEST_DATA_DIR / "aim_official/test.xrk")
+    name = "RPM"
+    cy_tc = cy.channels[name].column("timecodes").to_numpy()
+    rs_tc = rs.channels[name].column("timecodes").to_numpy()
+    np.testing.assert_array_equal(cy_tc, rs_tc)
+
+
+@pytest.mark.xfail(
+    strict=False,  # Rust picks a random CHS index per run; may match by chance
+    reason="Duplicate CHS long_names: Rust exposes a nondeterministic CHS index "
+    "per run where Cython deterministically keeps the last (module docstring, item 2)",
+)
+@pytest.mark.parametrize(
+    "path, dup_channels",
+    [
+        (
+            TEST_DATA_DIR / "issue68/CMD_KK-SII_Tsukuba_Car_Generic testing_a_0101.xrz",
+            ("RotaryLeft_led", "RotaryMiddle_led", "RotaryRight_led", "Right_Btn_4_led"),
+        ),
+        (
+            TEST_DATA_DIR / "issue84/CMD_KK-SII_Tsukuba_Car_Qualifying testing_a_0159.xrz",
+            ("RotaryLeft_led", "RotaryMiddle_led", "RotaryRight_led", "Right_Btn_4_led"),
+        ),
+    ],
+    ids=["issue68", "issue84"],
+)
+def test_duplicate_name_channels_match(path: Path, dup_channels: tuple) -> None:
+    from libxrk.base import ChannelMetadata
+
+    cy, rs = _load_both(path)
+    for name in dup_channels:
+        cy_meta = ChannelMetadata.from_channel_table(cy.channels[name])
+        rs_meta = ChannelMetadata.from_channel_table(rs.channels[name])
+        assert cy_meta.source_channel_id == rs_meta.source_channel_id, name
+        assert len(cy.channels[name]) == len(rs.channels[name]), name
+
+
+@pytest.mark.xfail(
+    # Not strict: whether these channels come out bit-identical depends on
+    # the host's numpy kernels (glibc version, SIMD dispatch) — they match
+    # on some machines and differ by 1 ulp on others.
+    strict=False,
+    reason="GPS float paths differ between numpy and Rust at the ulp level "
+    "(module docstring, item 1)",
+)
+def test_gps_channels_bitwise_identical() -> None:
+    cy, rs = _load_both(TEST_DATA_DIR / "SFJ/CMD_SFJ_Fuji GP Sh_Generic testing_a_0033.xrk")
+    for name in ("GPS Latitude", "GPS Altitude", "GPS_LateralAcc"):
+        cy_v = cy.channels[name].column(name).to_numpy()
+        rs_v = rs.channels[name].column(name).to_numpy()
+        np.testing.assert_array_equal(cy_v, rs_v, err_msg=name)


### PR DESCRIPTION

A full parity audit of the three XRK parser implementations found four
fixture-visible divergences (documented below and probed by xfail tests)
and otherwise bit-identical output. This commit locks in the equivalence
that holds today and makes the residual gaps visible:

- tests/test_backend_equivalence.py: strict Cython vs Rust comparison of
  all 11 fixtures — channel sets, Arrow types, all 11 field-metadata
  keys, bit-exact timecodes and values, laps, and the full metadata
  dict. Documented carve-outs: duplicate CHS long_names (Rust picks a
  nondeterministic CHS index per run), a uniform 18ms time shift on
  aim_official (LAP v2 payloads), and ulp-level GPS float tolerances.
  Four xfail probes flip visibly when the underlying issues are fixed.

- spec/tests/test_spec_rust.py: validates the Rust backend directly
  against the Construct reference spec (every decoded sample of every
  channel on SFJ/86/aim_official, plus laps, GPS counts, and metadata),
  mirroring the existing spec-vs-Cython checks.

- spec/docs/unknown_regions.md: new 'LAP version 2 (32 bytes)' section
  recording the reverse-engineered v2 layout — the absolute lap end
  time lives at [28:32] (not [16:20] as in v1).

- tests/test_aim_official_xrk.py: corrected a misdiagnosed comment
  (the file has 33 LAP messages; Cython drops them because the v2
  payload is 32 bytes, not 20).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/libxrk/pull/91).
* #96
* #95
* #94
* #93
* #92
* __->__ #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)
