### PR TITLE
fix: expose duplicate-name channels with the AIM DLL's "dup N" convention

### DIFF
--- a/crates/libxrk-python/src/lib.rs
+++ b/crates/libxrk-python/src/lib.rs
@@ -89,13 +89,29 @@ fn aim_xrk(py: Python<'_>, fname: Py<PyAny>, progress: Option<Py<PyAny>>) -> PyR
         .filter_map(|ch| ch.timecodes.last().copied())
         .max();
 
+    // Build metadata while channel_data is still populated (calibration
+    // attribution only considers channels that carry data, like Cython).
+    let metadata_struct = libxrk::metadata::extract_metadata(&result);
+
     // Move channel_data out of result (avoids cloning every channel)
     let channel_data = std::mem::take(&mut result.channel_data);
 
-    // Build Arrow RecordBatches using the core crate's arrow module
+    // Build Arrow RecordBatches using the core crate's arrow module.
+    // When the file carries GPS data, the 12 synthesized GPS channel names
+    // are reserved so a CHS channel colliding with one is exposed as
+    // "<name> dup 2" instead of being shadowed by the GPS channel.
+    let gps_reserved: Vec<&str> = if result.gps_data.is_empty() {
+        Vec::new()
+    } else {
+        libxrk::gps::GPS_CHANNEL_DEFS
+            .iter()
+            .map(|d| d.name)
+            .collect()
+    };
     let channel_batches = libxrk::arrow::build_all_channel_batches(
         channel_data,
         &result.channels,
+        &gps_reserved,
         arrow_bridge::format_float,
     )
     .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
@@ -147,8 +163,7 @@ fn aim_xrk(py: Python<'_>, fname: Py<PyAny>, progress: Option<Py<PyAny>>) -> PyR
         }
     }
 
-    // Build metadata
-    let metadata_struct = libxrk::metadata::extract_metadata(&result);
+    // Convert metadata (extracted above, before channel_data was moved out)
     let metadata_dict = metadata_bridge::metadata_to_pydict(py, &metadata_struct)?;
 
     // Determine file_name

--- a/crates/libxrk/src/arrow.rs
+++ b/crates/libxrk/src/arrow.rs
@@ -136,13 +136,25 @@ pub fn build_channel_batch(
 pub fn build_all_channel_batches(
     channel_data: HashMap<u16, ChannelData>,
     channels: &HashMap<u16, ChannelInfo>,
+    reserved_names: &[&str],
     format_f32: impl Fn(f32) -> String,
 ) -> arrow::error::Result<Vec<(String, RecordBatch)>> {
     let mut batches = Vec::new();
 
-    for (ch_idx, ch_data) in channel_data.into_iter() {
+    // Duplicate long_names are distinct channels; expose every one, with
+    // later occurrences renamed "<name> dup <k>" per the AIM DLL
+    // convention (see parser::channel_display_names). Iterate in ascending
+    // channel-index order for deterministic output.
+    let display_names = crate::parser::channel_display_names(channels, reserved_names);
+    let mut entries: Vec<(u16, ChannelData)> = channel_data.into_iter().collect();
+    entries.sort_by_key(|(idx, _)| *idx);
+
+    for (ch_idx, ch_data) in entries {
         if let Some(ch_info) = channels.get(&ch_idx) {
-            let name = ch_info.chs.long_name();
+            let name = display_names
+                .get(&ch_idx)
+                .cloned()
+                .unwrap_or_else(|| ch_info.chs.long_name());
             let metadata = ChannelMetadata::from_channel_info(ch_info).to_hashmap(&format_f32);
             let batch = build_channel_batch(&name, ch_data, metadata)?;
             batches.push((name, batch));

--- a/crates/libxrk/src/lib.rs
+++ b/crates/libxrk/src/lib.rs
@@ -100,10 +100,26 @@ pub fn read_xrk_with_progress(
         .filter_map(|ch| ch.timecodes.last().copied())
         .max();
 
+    // Build metadata while channel_data is still populated (calibration
+    // attribution only considers channels that carry data, like Cython).
+    let metadata = metadata::extract_metadata(&result);
+
     // Move channel_data out of result (avoids cloning every channel)
     let channel_data = std::mem::take(&mut result.channel_data);
 
-    // Build Channel structs from channel_data + channel info
+    // Build Channel structs from channel_data + channel info, in ascending
+    // channel-index order. Duplicate long_names are exposed with the AIM
+    // DLL's "<name> dup <k>" convention (parser::channel_display_names);
+    // when the file carries GPS data, the 12 synthesized GPS channel names
+    // are reserved so CHS channels colliding with them get the suffix.
+    let gps_reserved: Vec<&str> = if result.gps_data.is_empty() {
+        Vec::new()
+    } else {
+        gps::GPS_CHANNEL_DEFS.iter().map(|d| d.name).collect()
+    };
+    let display_names = parser::channel_display_names(&result.channels, &gps_reserved);
+    let mut channel_data: Vec<(u16, ChannelData)> = channel_data.into_iter().collect();
+    channel_data.sort_by_key(|(idx, _)| *idx);
     let channels: Vec<Channel> = channel_data
         .into_iter()
         .filter_map(|(ch_idx, ch_data)| {
@@ -116,7 +132,10 @@ pub fn read_xrk_with_progress(
             });
             Some(Channel {
                 index: ch_idx,
-                name: ch_info.chs.long_name(),
+                name: display_names
+                    .get(&ch_idx)
+                    .cloned()
+                    .unwrap_or_else(|| ch_info.chs.long_name()),
                 group: group_name,
                 timecodes: ch_data.timecodes,
                 values: ch_data.values,
@@ -168,9 +187,6 @@ pub fn read_xrk_with_progress(
             gps::timing::apply_corrections(&mut gps.timecodes, &corrections);
         }
     }
-
-    // Build metadata
-    let metadata = metadata::extract_metadata(&result);
 
     // Build laps — GPS timing fix was applied above
     let mut processed_laps = parser::get_processed_laps(&result)?;

--- a/crates/libxrk/src/metadata.rs
+++ b/crates/libxrk/src/metadata.rs
@@ -241,20 +241,56 @@ pub fn extract_metadata(result: &ParseResult) -> Metadata {
     // Calibrations (CAL)
     let mut calibrations = Vec::new();
     if let Some(msg_list) = msgs.get(&tokens::cal()) {
-        // Build map from (cal_val_1, cal_val_2) -> channel name via CHS fields
+        // Build map from (cal_val_1, cal_val_2) -> channel display name via
+        // CHS fields. This replicates the Cython backend's semantics:
+        //   - only channels that actually carry data participate
+        //     (Cython builds the map from its data-bearing channels dict);
+        //   - channels are visited in ascending index order with duplicate
+        //     long_names disambiguated to "<name> dup <k>" (see
+        //     parser::channel_display_names), so names are unique and on a
+        //     cal-value collision the later index wins;
+        //   - keys compare like Python floats: -0.0 == 0.0, NaN never matches.
+        let gps_reserved: Vec<&str> = if result.gps_data.is_empty() {
+            Vec::new()
+        } else {
+            crate::gps::GPS_CHANNEL_DEFS
+                .iter()
+                .map(|d| d.name)
+                .collect()
+        };
+        let display_names = crate::parser::channel_display_names(&result.channels, &gps_reserved);
+        let mut data_indices: Vec<u16> = result
+            .channels
+            .keys()
+            .copied()
+            .filter(|idx| result.channel_data.contains_key(idx))
+            .collect();
+        data_indices.sort_unstable();
+
+        let cal_key = |a: f32, b: f32| -> Option<(u32, u32)> {
+            if a.is_nan() || b.is_nan() {
+                return None; // Python dicts never match a distinct NaN key
+            }
+            let norm = |v: f32| (if v == 0.0 { 0.0f32 } else { v }).to_bits();
+            Some((norm(a), norm(b)))
+        };
+
         let mut cal_to_channel: HashMap<(u32, u32), String> = HashMap::new();
-        for ch_info in result.channels.values() {
-            let key = (
-                ch_info.chs.cal_value_1.to_bits(),
-                ch_info.chs.cal_value_2.to_bits(),
-            );
-            cal_to_channel.insert(key, ch_info.chs.long_name());
+        for idx in data_indices {
+            let chs = &result.channels[&idx].chs;
+            if let Some(key) = cal_key(chs.cal_value_1, chs.cal_value_2) {
+                let name = display_names
+                    .get(&idx)
+                    .cloned()
+                    .unwrap_or_else(|| chs.long_name());
+                cal_to_channel.insert(key, name);
+            }
         }
 
         for msg in msg_list {
             if let Payload::Cal(cal) = messages::dispatch_payload(msg) {
-                let key = (cal.raw_1.to_bits(), cal.raw_2.to_bits());
-                let channel = cal_to_channel.get(&key).cloned();
+                let channel =
+                    cal_key(cal.raw_1, cal.raw_2).and_then(|key| cal_to_channel.get(&key).cloned());
                 calibrations.push(Calibration {
                     cal_type: cal.cal_type,
                     raw_1: cal.raw_1,

--- a/crates/libxrk/src/parser.rs
+++ b/crates/libxrk/src/parser.rs
@@ -1627,6 +1627,50 @@ pub struct ProcessedLap {
 }
 
 /// Get processed laps from ParseResult (with proper start/end times).
+/// Map channel index -> user-facing channel name.
+///
+/// A CHS table may define the same long_name at several channel indices,
+/// each a genuinely distinct channel with its own source_channel_id and
+/// data stream. Following the official AIM DLL's convention, the first
+/// occurrence keeps the plain name and the k-th occurrence (k >= 2) is
+/// exposed as `"<name> dup <k>"` (observed on the issue84 fixture:
+/// `Right_Btn_4_led dup 2`). Numbering follows ascending channel index
+/// over ALL CHS entries, whether or not they carry data, matching the
+/// DLL. Mirrors `channel_display_names()` in spec/xrk_format.py and the
+/// Cython backend's rename pass.
+///
+/// `reserved` holds names already claimed outside the CHS table, counted
+/// as occurrence 1: callers pass the 12 synthesized GPS channel names
+/// when the file carries GPS data, so a CHS channel colliding with e.g.
+/// `GPS_InlineAcc` (observed on SFJ/86) becomes `"GPS_InlineAcc dup 2"`
+/// while the synthesized channel keeps its canonical name.
+pub fn channel_display_names(
+    channels: &HashMap<u16, ChannelInfo>,
+    reserved: &[&str],
+) -> HashMap<u16, String> {
+    let mut idxs: Vec<u16> = channels.keys().copied().collect();
+    idxs.sort_unstable();
+    let mut seen: HashMap<String, u32> = HashMap::new();
+    for name in reserved {
+        seen.insert((*name).to_string(), 1);
+    }
+    let mut out = HashMap::new();
+    for idx in idxs {
+        let base = channels[&idx].chs.long_name();
+        let k = seen
+            .entry(base.clone())
+            .and_modify(|k| *k += 1)
+            .or_insert(1);
+        let name = if *k > 1 {
+            format!("{} dup {}", base, k)
+        } else {
+            base
+        };
+        out.insert(idx, name);
+    }
+    out
+}
+
 pub fn get_processed_laps(result: &ParseResult) -> Result<Vec<ProcessedLap>, Error> {
     let raw = parse_lap_messages(&result.header_messages, result.time_offset)?;
 

--- a/spec/docs/companion.md
+++ b/spec/docs/companion.md
@@ -219,6 +219,21 @@ them into a single table:
 
 Reference: `base.py` (`get_channels_as_table`)
 
+### Duplicate channel names
+
+A CHS table may define the same long_name at several channel indices — each a
+genuinely distinct channel with its own `source_channel_id` and data stream
+(the issue68/issue84 fixtures define `RotaryLeft/Middle/Right_led` three times
+each and `Right_Btn_4_led` twice, all data-bearing). The official AIM DLL
+disambiguates positionally: the first occurrence keeps the plain name, and the
+k-th occurrence is exposed as `"<name> dup <k>"` (observed on the issue84
+fixture: `Right_Btn_4_led dup 2`). Numbering follows ascending channel index
+over all CHS entries, whether or not they carry data.
+
+Both backends implement this convention; the reference mapping is
+`ParseResult.channel_display_names()` in `spec/xrk_format.py`. No duplicate is
+ever collapsed or dropped.
+
 ## 9. Unit Type Map
 
 The CHS `unit_type_byte` (offset [12], lower 7 bits) maps to display units and

--- a/spec/tests/test_spec.py
+++ b/spec/tests/test_spec.py
@@ -1324,17 +1324,6 @@ class TestIssue68SpecVsBackends:
     decode of V1/V2/V3 (c)-message samples — byte-for-byte, every sample.
     """
 
-    def _spec_chs_index_for_cython(self, parsed, name):
-        """Find the spec CHS index that matches what the backend exposes.
-
-        CHS may carry duplicate long_names (e.g. RotaryMiddle_led appears
-        thrice on this fixture). Cython's `channels={ch.long_name: ch}`
-        dict-overwrite keeps the last CHS with that name; Rust follows
-        suit. Mirror that by returning the highest matching CHS index.
-        """
-        candidates = sorted(i for i, ch in parsed.channels.items() if ch.name == name)
-        return candidates[-1] if candidates else None
-
     def _decode_spec_channel(self, parsed, ch_idx, expansion_ch_indices, arrays_cache):
         """Produce the spec's canonical samples for one channel.
 
@@ -1362,22 +1351,19 @@ class TestIssue68SpecVsBackends:
         arrays_cache = TestExhaustiveChannelValues()._build_channel_arrays(parsed)
         # CHS names are not always unique — on issue68, RotaryLeft_led,
         # RotaryMiddle_led and RotaryRight_led each have 3 CHS entries.
-        # Cython (Python dict insertion order) and Rust (HashMap iteration
-        # order) may expose different CHS indices for the same name.
-        # This is a pre-existing cross-backend quirk unrelated to issue #68;
-        # skip duplicate-named CHS channels here.
-        name_counts = {}
-        for ch in parsed.channels.values():
-            name_counts[ch.name] = name_counts.get(ch.name, 0) + 1
-        duplicate_names = {n for n, c in name_counts.items() if c > 1}
+        # Both backends expose every entry, disambiguated per the AIM DLL
+        # "<name> dup <k>" convention; the spec's channel_display_names()
+        # defines the same mapping, so display names identify CHS indices
+        # uniquely — duplicate-named channels are compared like any other.
+        spec_index_by_display_name = {
+            name: idx for idx, name in parsed.channel_display_names().items()
+        }
 
         errors = []
         checked = 0
 
         for name in backend_log.channels:
-            if name in duplicate_names:
-                continue
-            ch_idx = self._spec_chs_index_for_cython(parsed, name)
+            ch_idx = spec_index_by_display_name.get(name)
             if ch_idx is None:
                 # GPS-derived channels are synthesized by the backend
                 # outside CHS; they have no spec equivalent here.

--- a/spec/xrk_format.py
+++ b/spec/xrk_format.py
@@ -1221,6 +1221,40 @@ class ParseResult:
             if m.payload is not None
         ]
 
+    def channel_display_names(self, reserved_names=()):
+        """Map channel index -> user-facing channel name.
+
+        A CHS table may define the same long_name at several channel
+        indices (e.g. the issue68/issue84 fixtures define RotaryMiddle_led
+        three times, each with its own source_channel_id and data stream).
+        The official AIM DLL disambiguates these positionally: the first
+        occurrence keeps the plain name and the k-th occurrence (k >= 2)
+        is exposed as ``"<name> dup <k>"`` (observed on the issue84
+        fixture: ``Right_Btn_4_led dup 2``). Numbering follows ascending
+        channel index over ALL CHS entries, whether or not they carry
+        data, matching the DLL. Both backends follow this convention.
+
+        Args:
+            reserved_names: Names already claimed outside the CHS table,
+                counted as occurrence 1. The backends pass their 12
+                synthesized GPS channel names here (when the file carries
+                GPS data), so a CHS channel that collides with e.g.
+                ``GPS_InlineAcc`` — observed on the SFJ and 86 fixtures —
+                is exposed as ``"GPS_InlineAcc dup 2"`` while the
+                synthesized channel keeps its canonical name.
+
+        Returns:
+            dict: {channel_index: display_name}
+        """
+        seen = {name: 1 for name in reserved_names}
+        out = {}
+        for idx in sorted(self.channels):
+            base = self.channels[idx].name
+            k = seen.get(base, 0) + 1
+            seen[base] = k
+            out[idx] = base if k == 1 else f"{base} dup {k}"
+        return out
+
     def get_gps_samples(self):
         """Return parsed GPS samples as list of Containers."""
         return [p for raw in self.gps_payloads if (p := _parse_payload(GPSPayload, raw))]

--- a/src/libxrk/CLAUDE.md
+++ b/src/libxrk/CLAUDE.md
@@ -82,6 +82,13 @@ Each channel table has:
 
 Channels have different sample rates. Use `get_channels_as_table()` to merge.
 
+**Duplicate channel names:** a file's CHS table may define the same long_name
+at several channel indices — each is a genuinely distinct channel with its own
+`source_channel_id` and data stream. Following the official AIM DLL's
+convention, the first occurrence keeps the plain name and the k-th occurrence
+is exposed as `"<name> dup <k>"` (e.g. `"RotaryMiddle_led dup 2"`), numbered
+by ascending channel index. No duplicate is ever dropped.
+
 ## Channel Metadata
 
 Use the `ChannelMetadata` dataclass for typed access to channel metadata:

--- a/src/libxrk/aim_xrk.pyx
+++ b/src/libxrk/aim_xrk.pyx
@@ -1032,6 +1032,30 @@ def _decode_sequence(s, progress=None):
             messages, time_offset, last_time)
         channels.extend(gps_ch)
 
+    # Disambiguate duplicate long_names following the AIM DLL convention:
+    # the first CHS occurrence (by channel index) keeps the plain name and
+    # the k-th occurrence is exposed as "<name> dup <k>". Numbering runs
+    # over ALL CHS entries in index order, data-bearing or not, matching
+    # the DLL (observed: "Right_Btn_4_led dup 2" on the issue84 fixture).
+    # Duplicates are genuinely distinct channels (own source_channel_id and
+    # data stream), so none of them may be dropped. The synthesized GPS
+    # channels (Channel.index == -1) own their canonical names — a CHS
+    # channel colliding with one (e.g. GPS_InlineAcc on SFJ/86) gets the
+    # suffix, keeping GPS_CHANNEL_NAMES semantics stable. Internal channels
+    # keep their base name so the exclusion filter below still applies.
+    # Reference: spec/xrk_format.py ParseResult.channel_display_names().
+    _name_seen = {}
+    for ch in channels:
+        if ch and ch.index < 0:
+            _name_seen[ch.long_name] = 1
+    for ch in channels:
+        if not ch or ch.index < 0:
+            continue
+        _dup_k = _name_seen.get(ch.long_name, 0) + 1
+        _name_seen[ch.long_name] = _dup_k
+        if _dup_k > 1 and ch.long_name not in ('StrtRec', 'Master Clk'):
+            ch.long_name = '%s dup %d' % (ch.long_name, _dup_k)
+
     return DataStream(
         channels={ch.long_name: ch for ch in channels
                   if ch and len(ch.sampledata)

--- a/tests/test_backend_equivalence.py
+++ b/tests/test_backend_equivalence.py
@@ -25,14 +25,7 @@ flip visibly when the underlying divergence is fixed):
    Position/Velocity Accuracy) are pure arithmetic + sqrt and are
    required to be bit-exact on every platform.
 
-2. Duplicate CHS long_names (issue68/issue84 fixtures define e.g.
-   RotaryMiddle_led three times at different channel indices).  Cython's
-   ``{ch.long_name: ch}`` dict deterministically keeps the *last* CHS index;
-   the Rust backend builds its channels dict while iterating a HashMap, so
-   which CHS index wins is nondeterministic per run (observed: different
-   source_channel_id, sample counts, and even Arrow dtype across runs).
-
-3. aim_official/test.xrk carries version-2 LAP messages with a 32-byte
+2. aim_official/test.xrk carries version-2 LAP messages with a 32-byte
    payload.  Cython's ``struct.unpack`` requires exactly 20 bytes and drops
    all 33 LAP messages (losing the LAP-derived time_offset candidate);
    Rust parses the first 20 bytes as if v1, misreading a duration-like
@@ -43,7 +36,7 @@ flip visibly when the underlying divergence is fixed):
    between backends.  Values are unaffected.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
@@ -75,12 +68,8 @@ _GPS_FLOAT_TOLERANCES = {
 @dataclass(frozen=True)
 class Fixture:
     path: Path
-    # Channel long_names defined by more than one CHS entry in this file.
-    # Cython deterministically exposes the last CHS index with that name;
-    # Rust exposes a nondeterministic one (see module docstring, item 2).
-    duplicate_name_channels: frozenset = field(default_factory=frozenset)
     # True when all timecodes/lap times differ by one constant offset
-    # between backends (module docstring, item 3).
+    # between backends (module docstring, item 2).
     allow_uniform_time_shift: bool = False
 
 
@@ -97,18 +86,8 @@ FIXTURES = [
         allow_uniform_time_shift=True,
     ),
     Fixture(TEST_DATA_DIR / "issue49/badGPSdata.xrk"),
-    Fixture(
-        TEST_DATA_DIR / "issue68/CMD_KK-SII_Tsukuba_Car_Generic testing_a_0101.xrz",
-        duplicate_name_channels=frozenset(
-            {"RotaryLeft_led", "RotaryMiddle_led", "RotaryRight_led", "Right_Btn_4_led"}
-        ),
-    ),
-    Fixture(
-        TEST_DATA_DIR / "issue84/CMD_KK-SII_Tsukuba_Car_Qualifying testing_a_0159.xrz",
-        duplicate_name_channels=frozenset(
-            {"RotaryLeft_led", "RotaryMiddle_led", "RotaryRight_led", "Right_Btn_4_led"}
-        ),
-    ),
+    Fixture(TEST_DATA_DIR / "issue68/CMD_KK-SII_Tsukuba_Car_Generic testing_a_0101.xrz"),
+    Fixture(TEST_DATA_DIR / "issue84/CMD_KK-SII_Tsukuba_Car_Qualifying testing_a_0159.xrz"),
 ]
 
 
@@ -203,8 +182,6 @@ def test_backends_equivalent(fixture: Fixture) -> None:
         assert _compute_shift(cy, rs) == 0, "unexpected global time shift"
 
     for name in sorted(cy_names & rs_names):
-        if name in fixture.duplicate_name_channels:
-            continue  # documented discrepancy 2 (see module docstring)
         _compare_channel(name, cy.channels[name], rs.channels[name], shift, errors)
 
     # Laps: exact, modulo the documented uniform shift
@@ -240,7 +217,7 @@ def test_backends_equivalent(fixture: Fixture) -> None:
     strict=True,
     reason="LAP v2 (32-byte payload): Cython drops all LAP messages while Rust "
     "misparses the first 20 bytes as v1, so time_offset differs by 18 ms on "
-    "aim_official/test.xrk (see module docstring, item 3)",
+    "aim_official/test.xrk (see module docstring, item 2)",
 )
 def test_aim_official_absolute_times_match() -> None:
     cy, rs = _load_both(TEST_DATA_DIR / "aim_official/test.xrk")
@@ -250,34 +227,46 @@ def test_aim_official_absolute_times_match() -> None:
     np.testing.assert_array_equal(cy_tc, rs_tc)
 
 
-@pytest.mark.xfail(
-    strict=False,  # Rust picks a random CHS index per run; may match by chance
-    reason="Duplicate CHS long_names: Rust exposes a nondeterministic CHS index "
-    "per run where Cython deterministically keeps the last (module docstring, item 2)",
-)
 @pytest.mark.parametrize(
-    "path, dup_channels",
+    "path",
     [
-        (
-            TEST_DATA_DIR / "issue68/CMD_KK-SII_Tsukuba_Car_Generic testing_a_0101.xrz",
-            ("RotaryLeft_led", "RotaryMiddle_led", "RotaryRight_led", "Right_Btn_4_led"),
-        ),
-        (
-            TEST_DATA_DIR / "issue84/CMD_KK-SII_Tsukuba_Car_Qualifying testing_a_0159.xrz",
-            ("RotaryLeft_led", "RotaryMiddle_led", "RotaryRight_led", "Right_Btn_4_led"),
-        ),
+        TEST_DATA_DIR / "issue68/CMD_KK-SII_Tsukuba_Car_Generic testing_a_0101.xrz",
+        TEST_DATA_DIR / "issue84/CMD_KK-SII_Tsukuba_Car_Qualifying testing_a_0159.xrz",
     ],
     ids=["issue68", "issue84"],
 )
-def test_duplicate_name_channels_match(path: Path, dup_channels: tuple) -> None:
+def test_duplicate_name_channels_all_exposed(path: Path) -> None:
+    """Duplicated CHS long_names are distinct channels (own source_channel_id
+    and data stream); every one must be exposed, with later occurrences
+    renamed "<name> dup <k>" per the AIM DLL convention (the DLL exposes
+    "Right_Btn_4_led dup 2" on the issue84 fixture), identically in both
+    backends."""
     from libxrk.base import ChannelMetadata
 
+    # Both fixtures define these channels 3x/3x/3x/2x with ascending
+    # source_channel_ids; index order fixes the dup numbering.
+    expected = {
+        "RotaryLeft_led": 1003,
+        "RotaryLeft_led dup 2": 1004,
+        "RotaryLeft_led dup 3": 1005,
+        "RotaryMiddle_led": 1006,
+        "RotaryMiddle_led dup 2": 1007,
+        "RotaryMiddle_led dup 3": 1008,
+        "RotaryRight_led": 1009,
+        "RotaryRight_led dup 2": 1010,
+        "RotaryRight_led dup 3": 1011,
+        "Right_Btn_4_led": 1020,
+        "Right_Btn_4_led dup 2": 1270,
+    }
     cy, rs = _load_both(path)
-    for name in dup_channels:
+    for name, src_id in expected.items():
+        assert name in cy.channels, f"cython missing {name!r}"
+        assert name in rs.channels, f"rust missing {name!r}"
         cy_meta = ChannelMetadata.from_channel_table(cy.channels[name])
         rs_meta = ChannelMetadata.from_channel_table(rs.channels[name])
-        assert cy_meta.source_channel_id == rs_meta.source_channel_id, name
-        assert len(cy.channels[name]) == len(rs.channels[name]), name
+        assert cy_meta.source_channel_id == src_id, name
+        assert rs_meta.source_channel_id == src_id, name
+        assert len(cy.channels[name]) == len(rs.channels[name]) > 0, name
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
A CHS table may define the same long_name at several channel indices,
each a genuinely distinct channel with its own source_channel_id and
data stream: the issue68/issue84 fixtures define RotaryLeft/Middle/
Right_led three times each and Right_Btn_4_led twice, all data-bearing.

Previously both backends collapsed these into a name-keyed dict,
silently dropping all but one stream - and the Rust backend picked the
survivor nondeterministically per run (HashMap iteration; observed as
differing source_channel_id, sample counts, and even Arrow dtype across
consecutive loads of the same file).

Now no stream is dropped. Following the official AIM DLL's convention
(verified via the Wine harness - the DLL exposes "Right_Btn_4_led dup 2"
on the issue84 fixture), the first CHS occurrence keeps the plain name
and the k-th occurrence is exposed as "<name> dup <k>", numbered by
ascending channel index over all CHS entries. Implemented identically
in all three places:

- spec/xrk_format.py: ParseResult.channel_display_names() is the
  reference mapping (documented in spec/docs/companion.md).
- Cython: rename pass before the channels dict is built.
- Rust: parser::channel_display_names(), used by the Arrow batches, the
  pure-Rust API, and calibration attribution (which also now replicates
  Cython's float-key semantics: data-bearing channels only, index
  order, -0.0 == 0.0, NaN never matches; metadata extraction moved
  before channel_data is consumed).

The 12 synthesized GPS channel names are reserved as occurrence 1 when
the file carries GPS data, so a CHS channel colliding with e.g.
GPS_InlineAcc (SFJ/86 define empty ones) gets the suffix while the
synthesized channels keep their canonical names - GPS_CHANNEL_NAMES
semantics and the GPS timing fix are unaffected.

The spec-vs-backend issue68 comparison now maps channels through
display names, so duplicate-name channels are cross-checked like any
other instead of being skipped; the equivalence suite asserts all 11
duplicate channels (with expected source_channel_ids) on both fixtures.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
