### PR TITLE
fix: parse version-2 LAP messages (32-byte payload)

### DIFF
--- a/crates/libxrk/src/messages.rs
+++ b/crates/libxrk/src/messages.rs
@@ -349,10 +349,8 @@ pub fn dispatch_payload(msg: &HeaderMessage) -> Payload {
     }
 
     if token == tokens::lap() {
-        if data.len() >= 20 {
-            if let Ok(lap) = payloads::lap::LapPayload::read(&mut Cursor::new(data)) {
-                return Payload::Lap(lap);
-            }
+        if let Some(lap) = payloads::lap::LapPayload::parse(data) {
+            return Payload::Lap(lap);
         }
         return Payload::Unknown(data.clone());
     }

--- a/crates/libxrk/src/parser.rs
+++ b/crates/libxrk/src/parser.rs
@@ -1512,9 +1512,6 @@ fn parse_lap_messages(
     header_messages: &HashMap<u32, Vec<HeaderMessage>>,
     time_offset: i64,
 ) -> Result<RawLapData, Error> {
-    use binrw::BinRead;
-    use std::io::Cursor;
-
     let mut lap_nums: Vec<i32> = Vec::new();
     let mut start_times: Vec<i64> = Vec::new();
     let mut end_times: Vec<i64> = Vec::new();
@@ -1522,10 +1519,7 @@ fn parse_lap_messages(
 
     if let Some(lap_msgs) = header_messages.get(&tokens::lap()) {
         for m in lap_msgs {
-            if m.payload.len() < 20 {
-                continue;
-            }
-            let Ok(lap) = LapPayload::read(&mut Cursor::new(&m.payload)) else {
+            let Some(lap) = LapPayload::parse(&m.payload) else {
                 continue;
             };
 

--- a/crates/libxrk/src/payloads/lap.rs
+++ b/crates/libxrk/src/payloads/lap.rs
@@ -1,10 +1,10 @@
-//! LAP — Lap Marker (20 bytes).
+//! LAP — Lap Marker (20 bytes for v0/v1, 32 bytes for v2).
 //!
-//! Reference: aim_xrk.pyx:529-531, spec/xrk_format.py:290-297.
+//! Reference: aim_xrk.pyx:529-531, spec/xrk_format.py (LAPPayload).
 
 use binrw::BinRead;
 
-/// LAP payload — 20 bytes.
+/// LAP payload — 20 bytes (v0/v1) or 32 bytes (v2).
 #[derive(Debug, Clone, BinRead)]
 #[br(little)]
 pub struct LapPayload {
@@ -13,5 +13,24 @@ pub struct LapPayload {
     pub lap_num: u16,       // [2:4]   lap number
     pub duration: u32,      // [4:8]   lap duration [ms]
     pub _reserved: [u8; 8], // [8:16] reserved
-    pub end_time: u32,      // [16:20] lap end time [ms]
+    pub end_time: u32,      // [16:20] v1: lap end time [ms]; v2: ~duration
+}
+
+impl LapPayload {
+    /// Length-aware parse handling both LAP layouts.
+    ///
+    /// Version 2 (32-byte payload) moves the absolute lap end time to
+    /// [28:32]; the v1 end-time slot [16:20] instead tracks the duration.
+    /// See spec/docs/unknown_regions.md ("LAP version 2"). Returns None
+    /// for payloads shorter than 20 bytes.
+    pub fn parse(data: &[u8]) -> Option<Self> {
+        if data.len() < 20 {
+            return None;
+        }
+        let mut lap = LapPayload::read(&mut std::io::Cursor::new(data)).ok()?;
+        if data.len() >= 32 {
+            lap.end_time = u32::from_le_bytes([data[28], data[29], data[30], data[31]]);
+        }
+        Some(lap)
+    }
 }

--- a/spec/docs/unknown_regions.md
+++ b/spec/docs/unknown_regions.md
@@ -192,14 +192,9 @@ that file (33 messages, 3 segments × 11 laps):
   `[28:32] - duration` of the first LAP message equals the minimum data
   timecode of the file (verified: 46957 − 46946 = 11 = min data tc),
   i.e. this field plays the role that [16:20] plays in v1.
-
-Neither backend implements v2 yet: Cython's exact-20-byte
-`struct.unpack` drops v2 LAP messages entirely (laps then come from
-GPS-based detection); the Rust backend and this spec parse the first
-20 bytes as if v1, misreading [16:20] as end time. This is the source
-of the constant 18 ms time_offset difference between the backends on
-the aim_official fixture — see tests/test_backend_equivalence.py.
-A proper fix must land here (spec) first, per the project rules.
+  **Status**: decoded; implemented by the spec (`LAPPayload.end_time`
+  Computed field) and by both backends, discriminated by payload length.
+  Round-trip coverage: `TestLAPRoundTrip.test_lap_v2_round_trip`.
 
 ## ODO (Odometer, n×64 bytes)
 

--- a/spec/tests/conftest.py
+++ b/spec/tests/conftest.py
@@ -279,6 +279,14 @@ def issue84_dll_gps():
 
 
 @pytest.fixture(scope="session")
+def aim_official_dll():
+    """Extract aim_official data from the official AIM DLL."""
+    if not _dll_available():
+        pytest.skip("AIM DLL or Wine not available")
+    return _dll_extract(AIM_OFFICIAL_XRK)
+
+
+@pytest.fixture(scope="session")
 def sfj_dll():
     """Extract SFJ data from the official AIM DLL."""
     if not _dll_available():

--- a/spec/tests/test_round_trip.py
+++ b/spec/tests/test_round_trip.py
@@ -90,7 +90,7 @@ class TestGPSRoundTrip:
 
 
 # ---------------------------------------------------------------------------
-# LAP round-trip (20 bytes)
+# LAP round-trip (20 bytes for v0/v1, 32 bytes for v2)
 # ---------------------------------------------------------------------------
 
 
@@ -105,6 +105,20 @@ class TestLAPRoundTrip:
             raw = msg.raw_payload
             assert len(raw) == 20
             parsed = LAPPayload.parse(raw)
+            rebuilt = LAPPayload.build(parsed)
+            assert rebuilt == raw
+
+    def test_lap_v2_round_trip(self, aim_official_parsed):
+        """Every v2 (32-byte) LAP payload should round-trip byte-identically,
+        and the derived end_time must come from offset [28:32]."""
+        lap_msgs = aim_official_parsed.messages_by_token("LAP")
+        assert len(lap_msgs) > 0
+        for msg in lap_msgs:
+            raw = msg.raw_payload
+            assert len(raw) == 32
+            assert msg.version == 2
+            parsed = LAPPayload.parse(raw)
+            assert parsed.end_time == int.from_bytes(raw[28:32], "little")
             rebuilt = LAPPayload.build(parsed)
             assert rebuilt == raw
 

--- a/spec/tests/test_spec.py
+++ b/spec/tests/test_spec.py
@@ -1038,6 +1038,15 @@ class TestDLLCrossValidation:
         unique = _unique_seg0_laps(parsed)
         assert len(unique) == dll_lap_count, f"Lap count: spec={len(unique)} dll={dll_lap_count}"
 
+    def test_aim_official_v2_lap_times(self, aim_official_dll, aim_official_cython):
+        """The v2 LAP interpretation (absolute end time at [28:32]) must
+        reproduce the official DLL's lap table exactly, to the millisecond."""
+        dll_laps = aim_official_dll["laps"]
+        laps = aim_official_cython.laps
+        assert len(dll_laps) == laps.num_rows
+        assert [lap["start_ms"] for lap in dll_laps] == laps.column("start_time").to_pylist()
+        assert [lap["end_ms"] for lap in dll_laps] == laps.column("end_time").to_pylist()
+
     def test_metadata(self, parsed_and_dll):
         """Metadata should match DLL."""
         parsed, dll_data = parsed_and_dll

--- a/spec/tests/test_spec_rust.py
+++ b/spec/tests/test_spec_rust.py
@@ -79,11 +79,18 @@ class TestLAPVsRust:
         assert len(_unique_seg0_laps(file_86_parsed)) == len(file_86_rust.laps)
 
     def test_aim_official_lap_count(self, aim_official_parsed, aim_official_rust):
-        # aim_official carries v2 (32-byte) LAP payloads whose first-20-byte
-        # parse yields degenerate laps; the Rust backend invalidates them and
-        # falls back to GPS-based detection, which finds the same 11 laps as
-        # the file's segment-0 LAP records describe.
+        # aim_official carries v2 (32-byte) LAP payloads; both the spec and
+        # the backends read the absolute end time at [28:32].
         assert len(_unique_seg0_laps(aim_official_parsed)) == len(aim_official_rust.laps)
+
+    def test_aim_official_v2_lap_times_match_dll(self, aim_official_dll, aim_official_rust):
+        """The Rust backend's v2 LAP laps must reproduce the official DLL's
+        lap table exactly, to the millisecond."""
+        dll_laps = aim_official_dll["laps"]
+        laps = aim_official_rust.laps
+        assert len(dll_laps) == laps.num_rows
+        assert [lap["start_ms"] for lap in dll_laps] == laps.column("start_time").to_pylist()
+        assert [lap["end_ms"] for lap in dll_laps] == laps.column("end_time").to_pylist()
 
 
 class TestGPSVsRust:

--- a/spec/xrk_format.py
+++ b/spec/xrk_format.py
@@ -404,15 +404,31 @@ GNFIPayload = Struct(
 )
 
 
-# LAP — Lap Marker (20 bytes)
+# LAP — Lap Marker (20 bytes for version 0/1, 32 bytes for version 2)
 # Reference: aim_xrk.pyx:517-521, 1038-1047
+#
+# Version 2 (observed on the AIM official sample, message version byte = 2)
+# extends the payload to 32 bytes and MOVES the absolute lap end time to
+# [28:32]; the v1 end-time slot [16:20] instead tracks the duration (always
+# a few ms smaller — purpose unknown). The variant is discriminated by
+# payload length. See spec/docs/unknown_regions.md ("LAP version 2").
 LAPPayload = Struct(
     "_pad" / Bytes(1),  # [0]     padding
     "segment" / Int8ul,  # [1]     segment number
     "lap_num" / Int16ul,  # [2:4]   lap number
     "duration" / Int32ul,  # [4:8]   lap duration [ms]
     "_reserved" / Bytes(8),  # [8:16]  reserved
-    "end_time" / Int32ul,  # [16:20] lap end time [ms]
+    "_end_time_v1" / Int32ul,  # [16:20] v1: lap end time [ms]; v2: ~duration
+    # v2 tail (12 bytes): [20:24] zero, [24:28] flags?, [28:32] end time [ms]
+    "_v2_tail" / GreedyBytes,
+    "end_time"
+    / Computed(
+        lambda ctx: (
+            int.from_bytes(ctx._v2_tail[8:12], "little")
+            if len(ctx._v2_tail) >= 12
+            else ctx._end_time_v1
+        )
+    ),
 )
 
 

--- a/src/libxrk/aim_xrk.pyx
+++ b/src/libxrk/aim_xrk.pyx
@@ -689,7 +689,14 @@ def _decode_sequence(s, progress=None):
                             data.sampledata = bytearray()
                         elif tok == _tokdec('LAP'):
                             # cache first time offset for use later
-                            duration, end_time = struct.unpack('4xI8xI', data)
+                            # v0/v1: 20-byte payload, absolute end time at [16:20].
+                            # v2: 32-byte payload, absolute end time at [28:32]
+                            # ([16:20] tracks the duration instead). See
+                            # spec/docs/unknown_regions.md ("LAP version 2").
+                            if len(data) >= 32:
+                                duration, end_time = struct.unpack_from('<4xI20xI', data, 0)
+                            else:
+                                duration, end_time = struct.unpack('<4xI8xI', data)
                             if time_offset is None:
                                 time_offset = end_time - duration
                             last_time = end_time
@@ -1344,7 +1351,12 @@ def _get_laps(lat_ch, lon_ch, msg_by_type, time_offset, last_time):
         has_lap_messages = True
         for m in msg_by_type[_tokdec('LAP')]:
             # 2nd byte is segment #, see M4GT4
-            segment, lap, duration, end_time = struct.unpack('xBHIxxxxxxxxI', m.content)
+            # v2 (32-byte payload) carries the absolute end time at [28:32];
+            # see spec/docs/unknown_regions.md ("LAP version 2").
+            if len(m.content) >= 32:
+                segment, lap, duration, end_time = struct.unpack_from('<xBHI20xI', m.content, 0)
+            else:
+                segment, lap, duration, end_time = struct.unpack('<xBHIxxxxxxxxI', m.content)
             end_time -= time_offset
             if segment:
                 continue

--- a/tests/test_aim_official_xrk.py
+++ b/tests/test_aim_official_xrk.py
@@ -1,10 +1,10 @@
-"""Tests for official AIM test.xrk file - verifies GPS-based lap detection.
+"""Tests for the official AIM test.xrk file.
 
-This file tests the fix for GitHub Issue #2: incorrect lap times when XRK files
-have no embedded LAP messages and rely on GPS-based lap detection.
-
-The official AIM test.xrk file has 0 LAP messages, so lap detection is done via GPS.
-Before the fix, last_time was incorrectly 0, causing the last lap to have end_time=0.
+This file carries version-2 LAP messages (32-byte payload, absolute end time
+at offset [28:32] — see spec/docs/unknown_regions.md "LAP version 2"), which
+historically went unparsed, so laps used to come from GPS-based detection
+(the subject of GitHub Issue #2). With v2 LAP support, lap detection follows
+the LAP messages: 11 segment-0 laps, the first an out-lap starting at t=0.
 """
 
 import gc
@@ -43,25 +43,23 @@ class TestAIMOfficialXRK(unittest.TestCase):
         self.assertIsNotNone(log.metadata, "LogFile.metadata is None")
 
     def test_lap_times_are_valid(self):
-        """Test that lap times are correctly calculated (Issue #2 fix).
-
-        This is the core test for the fix. Before the fix, the last lap had
-        end_time=0 because last_time was not set when there are no LAP messages.
-        """
+        """Test that lap times are correctly calculated from v2 LAP messages."""
         log = aim_xrk(str(AIM_OFFICIAL_XRK_FILE), progress=None)
 
-        # Should have laps detected via GPS (DLL reports 11 laps)
+        # 11 segment-0 LAP messages (the DLL also reports 11 laps)
         self.assertEqual(log.laps.num_rows, 11, "Expected 11 laps (matching DLL)")
         self.assertGreater(log.laps.num_rows, 0, "Expected at least one lap")
 
         # Verify lap_type column exists
         self.assertIn("lap_type", log.laps.column_names, "Laps table missing 'lap_type' column")
 
-        # GPS-detected laps: last is "in", others are "full"
+        # LAP-message laps: first starts at t=0 ("out"), last ends away from
+        # the start/finish line ("in"), the rest are "full"
         lap_types = log.laps.column("lap_type").to_pylist()
-        for i in range(len(lap_types) - 1):
-            self.assertEqual(lap_types[i], "full", f"GPS lap {i} should be 'full'")
-        self.assertEqual(lap_types[-1], "in", "Last GPS lap should be 'in'")
+        self.assertEqual(lap_types[0], "out", "First lap should be 'out' (starts at t=0)")
+        for i in range(1, len(lap_types) - 1):
+            self.assertEqual(lap_types[i], "full", f"Lap {i} should be 'full'")
+        self.assertEqual(lap_types[-1], "in", "Last lap should be 'in'")
 
         # Get lap data as Python lists for easier assertions
         lap_nums = log.laps.column("num").to_pylist()
@@ -171,16 +169,11 @@ class TestAIMOfficialCrossBackend(unittest.TestCase):
             )
 
     def test_non_gps_channel_values_match(self) -> None:
-        """Non-GPS CHS channels should produce matching values.
+        """Non-GPS CHS channels should produce identical timecodes and values.
 
-        Note: This file carries version-2 LAP messages with a 32-byte payload.
-        Cython's exact-20-byte struct.unpack drops all of them (no LAP-derived
-        time_offset candidate), while Rust parses the first 20 bytes as if v1
-        and derives a different candidate, so the backends' time_offsets differ
-        by a constant 18ms. Timecodes are therefore compared modulo a uniform
-        shift; values (which are offset-independent) must match exactly.
-        See tests/test_backend_equivalence.py and spec/docs/unknown_regions.md
-        ("LAP version 2").
+        Both backends parse the file's version-2 LAP messages (32-byte
+        payload, absolute end time at [28:32]) and derive the same
+        time_offset, so timecodes match exactly.
         """
         gps_prefixes = ("GPS ", "GPS_")
         for name in self.rust_log.channels:
@@ -188,13 +181,7 @@ class TestAIMOfficialCrossBackend(unittest.TestCase):
                 continue
             rust_tc = self.rust_log.channels[name].column("timecodes").to_numpy()
             cython_tc = self.cython_log.channels[name].column("timecodes").to_numpy()
-            # Timecodes may have a constant offset; check they differ uniformly
-            tc_diffs = rust_tc - cython_tc
-            np.testing.assert_array_equal(
-                tc_diffs,
-                tc_diffs[0],
-                err_msg=f"{name} timecodes have non-uniform offset",
-            )
+            np.testing.assert_array_equal(rust_tc, cython_tc, err_msg=f"{name} timecodes")
             rust_vals = self.rust_log.channels[name].column(name).to_numpy(zero_copy_only=False)
             cython_vals = self.cython_log.channels[name].column(name).to_numpy(zero_copy_only=False)
             np.testing.assert_array_equal(rust_vals, cython_vals, err_msg=f"{name} values")
@@ -220,21 +207,15 @@ class TestAIMOfficialCrossBackend(unittest.TestCase):
         cython_types = self.cython_log.laps.column("lap_type").to_pylist()
         self.assertEqual(rust_types, cython_types)
 
-    def test_lap_durations_match(self) -> None:
-        """Lap durations should match between backends.
-
-        Note: This file has no LAP messages (GPS-based lap detection), so
-        absolute lap times may differ by a constant time_offset between backends.
-        Durations are offset-independent and should match exactly.
-        """
-        rust_starts = np.array(self.rust_log.laps.column("start_time").to_pylist())
-        rust_ends = np.array(self.rust_log.laps.column("end_time").to_pylist())
-        cython_starts = np.array(self.cython_log.laps.column("start_time").to_pylist())
-        cython_ends = np.array(self.cython_log.laps.column("end_time").to_pylist())
-        np.testing.assert_array_equal(
-            rust_ends - rust_starts,
-            cython_ends - cython_starts,
-            err_msg="Lap durations differ between backends",
+    def test_lap_times_match(self) -> None:
+        """Lap start/end times should match exactly between backends."""
+        self.assertEqual(
+            self.rust_log.laps.column("start_time").to_pylist(),
+            self.cython_log.laps.column("start_time").to_pylist(),
+        )
+        self.assertEqual(
+            self.rust_log.laps.column("end_time").to_pylist(),
+            self.cython_log.laps.column("end_time").to_pylist(),
         )
 
     def test_channel_metadata_match(self) -> None:

--- a/tests/test_backend_equivalence.py
+++ b/tests/test_backend_equivalence.py
@@ -6,8 +6,8 @@ bit-exact timecodes and values, the laps table, and the complete metadata
 dict.  This is deliberately stronger than the per-file CrossBackend classes
 (which check a subset of metadata keys and use loose GPS tolerances).
 
-Documented residual discrepancies (see the xfail tests at the bottom, which
-flip visibly when the underlying divergence is fixed):
+Documented residual discrepancy (see the xfail test at the bottom, which
+flips visibly when the underlying divergence is fixed):
 
 1. GPS float paths.  Both backends compute GPS-derived channels in float64,
    but with slightly different operation orders:
@@ -24,19 +24,8 @@ flip visibly when the underlying divergence is fixed):
    All other GPS channels (Speed, InlineAcc, Satellites, Fix, pDOP,
    Position/Velocity Accuracy) are pure arithmetic + sqrt and are
    required to be bit-exact on every platform.
-
-2. aim_official/test.xrk carries version-2 LAP messages with a 32-byte
-   payload.  Cython's ``struct.unpack`` requires exactly 20 bytes and drops
-   all 33 LAP messages (losing the LAP-derived time_offset candidate);
-   Rust parses the first 20 bytes as if v1, misreading a duration-like
-   field as end_time and deriving a bogus time_offset of -7 (proper v2
-   parsing -- absolute end time at offset [28:32] -- yields 11, which is
-   what Cython arrives at from data timecodes).  Net effect: every
-   timecode and lap boundary in the file differs by a constant 18 ms
-   between backends.  Values are unaffected.
 """
 
-from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
@@ -65,29 +54,18 @@ _GPS_FLOAT_TOLERANCES = {
 }
 
 
-@dataclass(frozen=True)
-class Fixture:
-    path: Path
-    # True when all timecodes/lap times differ by one constant offset
-    # between backends (module docstring, item 2).
-    allow_uniform_time_shift: bool = False
-
-
 FIXTURES = [
-    Fixture(TEST_DATA_DIR / "SFJ/CMD_SFJ_Fuji GP Sh_Generic testing_a_0033.xrk"),
-    Fixture(TEST_DATA_DIR / "SFJ/CMD_SFJ_Fuji GP Sh_Generic testing_a_0033.xrz"),
-    Fixture(TEST_DATA_DIR / "SFJ/CMD_SFJ_Fuji GP Sh_Generic testing_a_0101.xrk"),
-    Fixture(TEST_DATA_DIR / "SFJ/CMD_SFJ_Fuji GP Sh_Generic testing_a_0101.xrz"),
-    Fixture(TEST_DATA_DIR / "SFJ/CMD_SFJ_Suzuka Car_Generic testing_a_0090.xrk"),
-    Fixture(TEST_DATA_DIR / "86/CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrk"),
-    Fixture(TEST_DATA_DIR / "86/CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz"),
-    Fixture(
-        TEST_DATA_DIR / "aim_official/test.xrk",
-        allow_uniform_time_shift=True,
-    ),
-    Fixture(TEST_DATA_DIR / "issue49/badGPSdata.xrk"),
-    Fixture(TEST_DATA_DIR / "issue68/CMD_KK-SII_Tsukuba_Car_Generic testing_a_0101.xrz"),
-    Fixture(TEST_DATA_DIR / "issue84/CMD_KK-SII_Tsukuba_Car_Qualifying testing_a_0159.xrz"),
+    TEST_DATA_DIR / "SFJ/CMD_SFJ_Fuji GP Sh_Generic testing_a_0033.xrk",
+    TEST_DATA_DIR / "SFJ/CMD_SFJ_Fuji GP Sh_Generic testing_a_0033.xrz",
+    TEST_DATA_DIR / "SFJ/CMD_SFJ_Fuji GP Sh_Generic testing_a_0101.xrk",
+    TEST_DATA_DIR / "SFJ/CMD_SFJ_Fuji GP Sh_Generic testing_a_0101.xrz",
+    TEST_DATA_DIR / "SFJ/CMD_SFJ_Suzuka Car_Generic testing_a_0090.xrk",
+    TEST_DATA_DIR / "86/CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrk",
+    TEST_DATA_DIR / "86/CMD_Inferno 86_Fuji GP Sh_Generic testing_a_2248.xrz",
+    TEST_DATA_DIR / "aim_official/test.xrk",
+    TEST_DATA_DIR / "issue49/badGPSdata.xrk",
+    TEST_DATA_DIR / "issue68/CMD_KK-SII_Tsukuba_Car_Generic testing_a_0101.xrz",
+    TEST_DATA_DIR / "issue84/CMD_KK-SII_Tsukuba_Car_Qualifying testing_a_0159.xrz",
 ]
 
 
@@ -103,17 +81,7 @@ def _field_metadata(table, name: str) -> dict:
     return {k.decode(): v.decode() for k, v in md.items()}
 
 
-def _compute_shift(cy, rs) -> int:
-    """The single constant offset between the two backends' timecodes."""
-    for name in sorted(cy.channels):
-        cy_tc = cy.channels[name].column("timecodes").to_numpy()
-        rs_tc = rs.channels[name].column("timecodes").to_numpy()
-        if len(cy_tc) and len(cy_tc) == len(rs_tc):
-            return int(rs_tc[0] - cy_tc[0])
-    return 0
-
-
-def _compare_channel(name: str, cy_t, rs_t, shift: int, errors: list) -> None:
+def _compare_channel(name: str, cy_t, rs_t, errors: list) -> None:
     cy_f = cy_t.schema.field(name)
     rs_f = rs_t.schema.field(name)
     if cy_f.type != rs_f.type:
@@ -132,11 +100,10 @@ def _compare_channel(name: str, cy_t, rs_t, shift: int, errors: list) -> None:
     if len(cy_tc) != len(rs_tc):
         errors.append(f"{name}: sample count cython={len(cy_tc)} rust={len(rs_tc)}")
         return
-    if not np.array_equal(cy_tc + shift, rs_tc):
-        i = int(np.argmax((cy_tc + shift) != rs_tc))
+    if not np.array_equal(cy_tc, rs_tc):
+        i = int(np.argmax(cy_tc != rs_tc))
         errors.append(
-            f"{name}: timecodes differ (first at {i}: "
-            f"cython={cy_tc[i]}+{shift} != rust={rs_tc[i]})"
+            f"{name}: timecodes differ (first at {i}: cython={cy_tc[i]} != rust={rs_tc[i]})"
         )
 
     cy_v = cy_t.column(name).to_numpy(zero_copy_only=False)
@@ -163,10 +130,10 @@ def _compare_channel(name: str, cy_t, rs_t, shift: int, errors: list) -> None:
             )
 
 
-@pytest.mark.parametrize("fixture", FIXTURES, ids=lambda f: f.path.name)
-def test_backends_equivalent(fixture: Fixture) -> None:
+@pytest.mark.parametrize("fixture", FIXTURES, ids=lambda p: p.name)
+def test_backends_equivalent(fixture: Path) -> None:
     """Cython and Rust must agree on everything except documented gaps."""
-    cy, rs = _load_both(fixture.path)
+    cy, rs = _load_both(fixture)
     errors: list = []
 
     cy_names = set(cy.channels)
@@ -177,18 +144,12 @@ def test_backends_equivalent(fixture: Fixture) -> None:
             f"only-rust={sorted(rs_names - cy_names)}"
         )
 
-    shift = _compute_shift(cy, rs) if fixture.allow_uniform_time_shift else 0
-    if not fixture.allow_uniform_time_shift:
-        assert _compute_shift(cy, rs) == 0, "unexpected global time shift"
-
     for name in sorted(cy_names & rs_names):
-        _compare_channel(name, cy.channels[name], rs.channels[name], shift, errors)
+        _compare_channel(name, cy.channels[name], rs.channels[name], errors)
 
-    # Laps: exact, modulo the documented uniform shift
+    # Laps: exact
     cy_laps = cy.laps.to_pydict()
     rs_laps = rs.laps.to_pydict()
-    for col in ("start_time", "end_time"):
-        cy_laps[col] = [t + shift for t in cy_laps[col]]
     if cy_laps != rs_laps:
         errors.append(f"laps differ: cython={cy_laps} rust={rs_laps}")
 
@@ -202,29 +163,15 @@ def test_backends_equivalent(fixture: Fixture) -> None:
                     f"rust={rs.metadata.get(k)!r}"
                 )
 
-    assert not errors, f"{fixture.path.name}: backend divergence:\n" + "\n".join(errors)
+    assert not errors, f"{fixture.name}: backend divergence:\n" + "\n".join(errors)
 
 
 # ---------------------------------------------------------------------------
-# Probes for the documented residual discrepancies.  Each is expected to
-# fail today; when the underlying divergence is fixed, the strict xfails
-# turn into XPASS failures, prompting removal of the marker (and of the
-# corresponding carve-out above).
+# Probes for documented residual discrepancies.  The strict xfail below
+# turns into an XPASS failure when the underlying divergence is fixed,
+# prompting removal of the marker (and of the corresponding carve-out
+# above).
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.xfail(
-    strict=True,
-    reason="LAP v2 (32-byte payload): Cython drops all LAP messages while Rust "
-    "misparses the first 20 bytes as v1, so time_offset differs by 18 ms on "
-    "aim_official/test.xrk (see module docstring, item 2)",
-)
-def test_aim_official_absolute_times_match() -> None:
-    cy, rs = _load_both(TEST_DATA_DIR / "aim_official/test.xrk")
-    name = "RPM"
-    cy_tc = cy.channels[name].column("timecodes").to_numpy()
-    rs_tc = rs.channels[name].column("timecodes").to_numpy()
-    np.testing.assert_array_equal(cy_tc, rs_tc)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION

The AIM official sample (tests/test_data/aim_official/test.xrk) carries
33 LAP messages with version=2 and a 32-byte payload. Neither backend
handled them: Cython's exact-20-byte struct.unpack silently dropped
every LAP message (losing the LAP-derived time_offset candidate and
falling back to GPS lap detection), while Rust and the spec parsed the
first 20 bytes as if v1, misreading a duration-like field at [16:20] as
the end time and deriving a bogus offset. Net effect: every timecode
and lap boundary in that file differed by a constant 18ms between
backends, and neither lap table matched the official AIM DLL.

Reverse engineering shows v2 moves the absolute lap end time to
[28:32]; [16:20] instead tracks the duration (purpose unknown). With
that field, "end - duration" of the first LAP equals the file's minimum
data timecode (46957 - 46946 = 11), and the resulting lap table matches
the official AIM MatLabXRK DLL exactly - all 11 lap start/end times to
the millisecond (verified via the Wine DLL harness).

Per the project rules the layout lands in the spec first:

- spec/xrk_format.py: LAPPayload is now length-discriminated; end_time
  is a Computed field reading [28:32] when the v2 tail is present. The
  raw tail is kept so v2 payloads round-trip byte-identically
  (TestLAPRoundTrip.test_lap_v2_round_trip).
- src/libxrk/aim_xrk.pyx and crates/libxrk (LapPayload::parse): both
  backends read the end time length-aware in the same way.
- spec/docs/unknown_regions.md: [28:32] marked decoded.
- New DLL ground-truth tests pin the v2 lap table to the official DLL
  for both backends (skip when the DLL harness is not installed).
- tests/test_aim_official_xrk.py: laps on this file are now LAP-derived
  (11 laps, first 'out' at t=0, last 'in'), identical across backends;
  the uniform-time-shift accommodations are removed here and in
  tests/test_backend_equivalence.py, along with the strict xfail probe.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/libxrk/pull/93).
* #96
* #95
* #94
* __->__ #93
* #92
* #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)
