### PR TITLE
fix: last-write-wins for channel renames in CNF re-definitions

### DIFF
--- a/crates/libxrk/src/parser.rs
+++ b/crates/libxrk/src/parser.rs
@@ -334,23 +334,16 @@ impl ParserState {
     fn register_chs(&mut self, chs: &ChsPayload) {
         let idx = chs.index as usize;
 
-        // Check for duplicate CHS with different names (D)
-        if let Some(existing) = self.channels.get(&chs.index) {
-            if existing.chs.short_name() != chs.short_name()
-                || existing.chs.long_name() != chs.long_name()
-            {
-                eprintln!(
-                    "Channel name mismatch at index {}: '{}'/'{}' vs '{}'/'{}'. \
-                     Please report at https://github.com/m3rlin45/libxrk/issues",
-                    chs.index,
-                    existing.chs.short_name(),
-                    existing.chs.long_name(),
-                    chs.short_name(),
-                    chs.long_name()
-                );
-                // Skip registration (matches Cython error-recovery behavior)
-                return;
-            }
+        // A later re-definition of an existing index reflects the logger's
+        // current configuration: the last write wins on names. The AIM
+        // official sample renames "Temperature 1" -> "Exhaust Temp" in its
+        // final CNF, and the official DLL exposes the new name carrying
+        // the full data stream. Other CHS fields and the accumulator
+        // layout are assumed stable across re-definitions. Matches the
+        // spec's _merge_cnf_result and the Cython backend.
+        if let Some(existing) = self.channels.get_mut(&chs.index) {
+            existing.chs.short_name_raw = chs.short_name_raw;
+            existing.chs.long_name_raw = chs.long_name_raw;
         }
 
         // Warn for unknown unit types (I)
@@ -867,9 +860,15 @@ fn handle_header_message(msg: &HeaderMessage, state: &mut ParserState) {
         let mut sub_state = ParserState::new();
         scan_stream(&msg.payload, &mut sub_state, None);
 
-        // Merge CHS and GRP from sub-parse
+        // Merge CHS and GRP from sub-parse. A later CNF re-definition wins
+        // on names (matching the AIM DLL, which exposes the renamed channel
+        // carrying the full data stream); other fields and the accumulator
+        // layout stay as first registered.
         for (idx, ch_info) in &sub_state.channels {
-            if !state.channels.contains_key(idx) {
+            if let Some(existing) = state.channels.get_mut(idx) {
+                existing.chs.short_name_raw = ch_info.chs.short_name_raw;
+                existing.chs.long_name_raw = ch_info.chs.long_name_raw;
+            } else {
                 state.register_chs(&ch_info.chs);
             }
         }
@@ -2207,8 +2206,10 @@ mod tests {
     }
 
     #[test]
-    fn test_register_chs_duplicate_different_name_skips() {
-        // Re-registering with a different name at the same index warns and skips
+    fn test_register_chs_redefinition_last_name_wins() {
+        // A later re-definition at the same index wins on names (matching
+        // the AIM DLL, which exposes the renamed channel with the full
+        // data stream); the data itself is unaffected.
         let chs1 = make_chs_bytes(0, "RPM", "Engine RPM", 0, 4, 15, 0);
         let chs2 = make_chs_bytes(0, "SPD", "Speed", 0, 4, 16, 0);
         let f1 = make_header_frame("CHS", 0, &chs1);
@@ -2216,8 +2217,8 @@ mod tests {
         let s_msg = make_s_message(1000, 0, &5000i32.to_le_bytes());
         let stream = build_xrk_stream(&[f1, f2], &[s_msg]);
         let result = parse_xrk(&stream, None).unwrap();
-        // The first registration should stick
-        assert_eq!(result.channels[&0].chs.long_name(), "Engine RPM");
+        assert_eq!(result.channels[&0].chs.long_name(), "Speed");
+        assert!(result.channel_data.contains_key(&0));
     }
 
     // ── V-unit conversion ──────────────────────────────────────────────

--- a/spec/docs/companion.md
+++ b/spec/docs/companion.md
@@ -234,6 +234,21 @@ Both backends implement this convention; the reference mapping is
 `ParseResult.channel_display_names()` in `spec/xrk_format.py`. No duplicate is
 ever collapsed or dropped.
 
+### CNF re-definitions (channel renames)
+
+A file may carry several CNF configuration blocks, and a later CNF may
+re-define an existing channel index under a **new name**: the AIM official
+sample renames index 11 `Temperature 1` → `Exhaust Temp` and index 12
+`Temperature 2` → `Water Temp 2` in its final CNFs. The official DLL applies
+last-write-wins: it exposes only the new names, carrying the channel's full
+data stream (verified via the Wine harness — `Exhaust Temp` / `Water Temp`
+with all 11,971 samples).
+
+The spec (`_merge_cnf_result`) and both backends implement the same rule: a
+re-definition refreshes the channel's names; the data stream is continuous
+across the rename, and other CHS fields plus the accumulator layout are
+assumed stable across re-definitions.
+
 ## 9. Unit Type Map
 
 The CHS `unit_type_byte` (offset [12], lower 7 bits) maps to display units and

--- a/spec/tests/test_spec.py
+++ b/spec/tests/test_spec.py
@@ -108,6 +108,14 @@ class TestParseAllFiles:
         assert len(result.messages_by_token("LAP")) > 0
         assert len(result.gps_payloads) > 0
 
+    def test_cnf_redefinition_last_name_wins(self, aim_official_parsed):
+        """A later CNF re-definition wins on names: test.xrk's final CNFs
+        rename index 11 'Temperature 1' -> 'Exhaust Temp' and index 12
+        'Temperature 2' -> 'Water Temp 2' (null-terminated to 'Water Temp'),
+        which is what the official DLL exposes."""
+        assert aim_official_parsed.channels[11].name == "Exhaust Temp"
+        assert aim_official_parsed.channels[12].name == "Water Temp"
+
     @pytest.mark.parametrize("filepath", ALL_XRK_FILES, ids=lambda p: p.name)
     def test_xrk_xrz_equivalence(self, filepath):
         """XRK and XRZ variants should produce the same channel definitions."""
@@ -1046,6 +1054,19 @@ class TestDLLCrossValidation:
         assert len(dll_laps) == laps.num_rows
         assert [lap["start_ms"] for lap in dll_laps] == laps.column("start_time").to_pylist()
         assert [lap["end_ms"] for lap in dll_laps] == laps.column("end_time").to_pylist()
+
+    def test_aim_official_renamed_channels_match_dll(self, aim_official_dll, aim_official_cython):
+        """Last-write-wins channel renames must match the DLL: test.xrk's
+        final CNFs rename 'Temperature 1'/'Temperature 2' to
+        'Exhaust Temp'/'Water Temp', and the DLL exposes the new names
+        carrying the full data stream."""
+        dll_by_name = {ch["name"]: ch["sample_count"] for ch in aim_official_dll["channels"]}
+        for name in ("Exhaust Temp", "Water Temp"):
+            assert name in dll_by_name
+            assert name in aim_official_cython.channels
+            assert len(aim_official_cython.channels[name]) == dll_by_name[name]
+        assert "Temperature 1" not in aim_official_cython.channels
+        assert "Temperature 2" not in aim_official_cython.channels
 
     def test_metadata(self, parsed_and_dll):
         """Metadata should match DLL."""

--- a/spec/tests/test_spec_rust.py
+++ b/spec/tests/test_spec_rust.py
@@ -92,6 +92,18 @@ class TestLAPVsRust:
         assert [lap["start_ms"] for lap in dll_laps] == laps.column("start_time").to_pylist()
         assert [lap["end_ms"] for lap in dll_laps] == laps.column("end_time").to_pylist()
 
+    def test_aim_official_renamed_channels_match_dll(self, aim_official_dll, aim_official_rust):
+        """Last-write-wins channel renames must match the DLL: the Rust
+        backend exposes 'Exhaust Temp'/'Water Temp' (not the original
+        'Temperature 1'/'Temperature 2') with the full data stream."""
+        dll_by_name = {ch["name"]: ch["sample_count"] for ch in aim_official_dll["channels"]}
+        for name in ("Exhaust Temp", "Water Temp"):
+            assert name in dll_by_name
+            assert name in aim_official_rust.channels
+            assert len(aim_official_rust.channels[name]) == dll_by_name[name]
+        assert "Temperature 1" not in aim_official_rust.channels
+        assert "Temperature 2" not in aim_official_rust.channels
+
 
 class TestGPSVsRust:
     """GPS record counts must match the spec's GPS payload count."""

--- a/spec/xrk_format.py
+++ b/spec/xrk_format.py
@@ -808,6 +808,18 @@ def _merge_cnf_result(sub, result):
     for idx, ch in sub.channels.items():
         if idx not in result.channels:
             _register_chs(ch, result)
+        else:
+            # A later CNF re-definition reflects the logger's current
+            # configuration: the last write wins on names. The AIM official
+            # sample renames "Temperature 1" -> "Exhaust Temp" in its final
+            # CNF, and the official DLL exposes the new name carrying the
+            # full data stream. Other CHS fields are assumed stable across
+            # re-definitions. Both backends implement the same rule.
+            existing = result.channels[idx]
+            existing.short_name = ch.short_name
+            existing.long_name = ch.long_name
+            existing.name = ch.name
+            existing.short_name_str = ch.short_name_str
     for idx, grp in sub.groups.items():
         if idx not in result.groups:
             _register_grp(grp, result)

--- a/src/libxrk/aim_xrk.pyx
+++ b/src/libxrk/aim_xrk.pyx
@@ -561,10 +561,17 @@ def _decode_sequence(s, progress=None):
                                     gc_data[3][m.content.index].Mms = struct.unpack_from(
                                         '<I', m.content.unknown, 64)[0] // 1000
                                 else:
-                                    if channels[m.content.index].short_name != m.content.short_name:
-                                        raise ValueError("Channel short_name mismatch: %s vs %s" % (channels[m.content.index].short_name, m.content.short_name))
-                                    if channels[m.content.index].long_name != m.content.long_name:
-                                        raise ValueError("Channel long_name mismatch: %s vs %s" % (channels[m.content.index].long_name, m.content.long_name))
+                                    # A later CNF re-definition reflects the logger's
+                                    # current configuration: the last write wins on
+                                    # names. The AIM official sample renames
+                                    # "Temperature 1" -> "Exhaust Temp" in its final
+                                    # CNF, and the official DLL exposes the new name
+                                    # carrying the full data stream. Other CHS fields
+                                    # and the accumulator layout are assumed stable
+                                    # across re-definitions. Matches the spec's
+                                    # _merge_cnf_result and the Rust backend.
+                                    channels[m.content.index].short_name = m.content.short_name
+                                    channels[m.content.index].long_name = m.content.long_name
                             for m in data.get(_tokdec('GRP'), []):
                                 groups += [None] * (m.content.index - len(groups) + 1)
                                 groups[m.content.index] = m.content

--- a/tests/test_aim_official_xrk.py
+++ b/tests/test_aim_official_xrk.py
@@ -83,6 +83,19 @@ class TestAIMOfficialXRK(unittest.TestCase):
             f"Last lap end_time ({last_end_time}) is too low - GPS-based detection may have failed",
         )
 
+    def test_cnf_renamed_channels_use_final_names(self):
+        """Last-write-wins channel renames: the file's final CNFs rename
+        'Temperature 1' -> 'Exhaust Temp' and 'Temperature 2' ->
+        'Water Temp 2' (null-terminated to 'Water Temp'). Both backends
+        expose the new names with the full data stream, matching the
+        official AIM DLL."""
+        log = aim_xrk(str(AIM_OFFICIAL_XRK_FILE), progress=None)
+        for name in ("Exhaust Temp", "Water Temp"):
+            self.assertIn(name, log.channels)
+            self.assertGreater(len(log.channels[name]), 10000)
+        self.assertNotIn("Temperature 1", log.channels)
+        self.assertNotIn("Temperature 2", log.channels)
+
     def test_lap_durations_are_reasonable(self):
         """Test that all lap durations are reasonable (not negative or zero)."""
         log = aim_xrk(str(AIM_OFFICIAL_XRK_FILE), progress=None)


### PR DESCRIPTION
A file may carry several CNF configuration blocks, and a later CNF may
re-define an existing channel index under a new name: the AIM official
sample's final CNFs rename index 11 "Temperature 1" to "Exhaust Temp"
and index 12 "Temperature 2" to "Water Temp 2". The official DLL
applies last-write-wins - it exposes only the new names, carrying the
channel's full data stream (verified via the Wine harness: Exhaust
Temp / Water Temp with all 11,971 samples).

Previously each implementation did something different, and none
matched the DLL:

- Cython raised ValueError on the name mismatch, which routed the
  ENTIRE CNF through byte-wise bad-byte recovery: its nested CHS/CDE
  reparsed as stray top-level messages (64 of each on that file) and
  the CNF never appeared in the message dict.
- Rust silently kept the first name.
- The spec's _merge_cnf_result also kept the first registration.

All three now implement the same rule, matching the DLL: a CNF
re-definition refreshes the channel's names (last write wins) while the
data stream stays continuous; other CHS fields and the accumulator
layout are assumed stable across re-definitions. On the AIM official
sample the message dict shows CNF x4 with no leaked messages, and both
backends expose Exhaust Temp / Water Temp - pinned against the DLL by
new tests in spec/tests (both backends) and tests/test_aim_official_xrk.py.
Documented in spec/docs/companion.md ("CNF re-definitions").

Found by the three-way parity audit (finding F4).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
