### PR TITLE
fix: minimize GPS derived-channel float divergence in the Rust backend

### DIFF
--- a/crates/libxrk/src/gps/processing.rs
+++ b/crates/libxrk/src/gps/processing.rs
@@ -291,9 +291,12 @@ pub fn decode_gps(
         inline_acc.push((dv / dt_sec[i] / 9.81) as f32);
     }
 
-    // GPS_Yaw_Rate = d(heading)/dt (deg/s) with ±180° wrap handling
-    let mut yaw_rate = Vec::with_capacity(n);
-    yaw_rate.push(0.0f32);
+    // GPS_Yaw_Rate = d(heading)/dt (deg/s) with ±180° wrap handling.
+    // Kept in float64 for the lateral-acceleration product (matching
+    // Cython, which uses the intermediate float64 yaw rate there); the
+    // yaw-rate channel itself is float32.
+    let mut yaw_rate_f64 = Vec::with_capacity(n);
+    yaw_rate_f64.push(0.0f64);
     for i in 0..dt_sec.len() {
         let mut dh = heading_deg[i + 1] - heading_deg[i];
         if dh > 180.0 {
@@ -302,12 +305,13 @@ pub fn decode_gps(
         if dh < -180.0 {
             dh += 360.0;
         }
-        yaw_rate.push((dh / dt_sec[i]) as f32);
+        yaw_rate_f64.push(dh / dt_sec[i]);
     }
+    let yaw_rate: Vec<f32> = yaw_rate_f64.iter().map(|&v| v as f32).collect();
 
     // GPS_LateralAcc = speed × yaw_rate × π/180 / 9.81 (g)
     let lateral_acc: Vec<f32> = (0..n)
-        .map(|i| (speed[i] * yaw_rate[i] as f64 * (PI / 180.0) / 9.81) as f32)
+        .map(|i| (((speed[i] * yaw_rate_f64[i]) * (PI / 180.0)) / 9.81) as f32)
         .collect();
 
     // Float32 channels from NAV-SOL raw fields

--- a/crates/libxrk/src/gps/utils.rs
+++ b/crates/libxrk/src/gps/utils.rs
@@ -12,27 +12,36 @@ use std::f64::consts::PI;
 /// Input: ECEF coordinates in meters.
 /// Returns (latitude_deg, longitude_deg, altitude_m).
 pub fn ecef2lla_vermeille2003(x: f64, y: f64, z: f64) -> (f64, f64, f64) {
+    // This mirrors gps.py:ecef2lla_vermeille2003 operation for operation —
+    // the same reciprocal-multiply constants, the same left-to-right
+    // association, and pow for the e**n constants (matching CPython's `**`)
+    // — so the two backends agree to within a very few ulp. Bit-exactness
+    // is deliberately NOT a goal: Rust's f64::cbrt/powf come from the
+    // toolchain's vendored libm while numpy's kernels vary with platform,
+    // glibc version, and CPU SIMD dispatch, so the residual 1-ulp-scale
+    // differences (nanometers in position) are bounded by documented
+    // tolerances in tests/test_backend_equivalence.py instead.
     let a: f64 = 6378137.0;
     let e: f64 = 8.181919084261345e-2;
-    let e2 = e * e;
-    let e4 = e2 * e2;
+    let e2 = e.powf(2.0); // Python `e**2`
+    let e4 = e.powf(4.0); // Python `e**4`
 
-    let p = (x * x + y * y) / (a * a);
-    let q = ((1.0 - e2) / (a * a)) * z * z;
-    let r = (p + q - e4) / 6.0;
-    let s = (e4 / 4.0) * p * q / (r * r * r);
+    let p = (x * x + y * y) * (1.0 / (a * a));
+    let q = (((1.0 - e * e) / (a * a)) * z) * z;
+    let r = (p + q - e4) * (1.0 / 6.0);
+    let s = (((e4 / 4.0) * p) * q) / r.powf(3.0); // numpy `r**3` = pow
     let t = (1.0 + s + (s * (2.0 + s)).sqrt()).cbrt();
     let u = r * (1.0 + t + 1.0 / t);
     let v = (u * u + e4 * q).sqrt();
     let u = u + v; // u += v
-    let w = (e2 / 2.0) * (u - q) / v;
+    let w = ((e2 / 2.0) * (u - q)) / v;
     let k = (u + w * w).sqrt() - w;
-    let d = k * (x * x + y * y).sqrt() / (k + e2);
+    let d = (k * (x * x + y * y).sqrt()) / (k + e2);
     let rt_dd_zz = (d * d + z * z).sqrt();
 
-    let lat = (180.0 / PI) * 2.0 * z.atan2(d + rt_dd_zz);
+    let lat = ((180.0 / PI) * 2.0) * z.atan2(d + rt_dd_zz);
     let lon = (180.0 / PI) * y.atan2(x);
-    let alt = (k + e2 - 1.0) / k * rt_dd_zz;
+    let alt = ((k + e2 - 1.0) / k) * rt_dd_zz;
 
     (lat, lon, alt)
 }

--- a/tests/test_backend_equivalence.py
+++ b/tests/test_backend_equivalence.py
@@ -6,24 +6,17 @@ bit-exact timecodes and values, the laps table, and the complete metadata
 dict.  This is deliberately stronger than the per-file CrossBackend classes
 (which check a subset of metadata keys and use loose GPS tolerances).
 
-Documented residual discrepancy (see the xfail test at the bottom, which
-flips visibly when the underlying divergence is fixed):
-
-1. GPS float paths.  Both backends compute GPS-derived channels in float64,
-   but with slightly different operation orders:
-     - GPS Latitude / GPS Altitude: the Rust Vermeille-2003 ECEF->LLA uses
-       ``/ (a*a)`` and ``r*r*r`` where numpy uses ``* (1/(a*a))`` and
-       ``r**3`` (and ``np.cbrt`` vs ``f64::cbrt``); observed diffs are
-       <= 1.5e-14 deg / <= 2.9e-9 m.
-     - GPS_LateralAcc: Rust multiplies the float32-rounded yaw rate where
-       Cython uses the intermediate float64 value; observed <= 5e-7 g.
-     - GPS_Yaw_Rate: rare 1-ulp float32 rounding differences (<= 1e-12).
-     - GPS Longitude: pure atan2; bit-exact on some hosts, but numpy's
-       atan2 kernel varies with glibc version and CPU SIMD dispatch while
-       Rust links a vendored libm, so it can differ by 1 ulp elsewhere.
-   All other GPS channels (Speed, InlineAcc, Satellites, Fix, pDOP,
-   Position/Velocity Accuracy) are pure arithmetic + sqrt and are
-   required to be bit-exact on every platform.
+GPS channels derived through libm transcendentals (atan2, cbrt, pow) —
+Latitude, Longitude, Altitude, and the heading-derived float32 products
+LateralAcc and Yaw_Rate — are compared within a few ulp instead of
+bit-exactly.  numpy's math kernels vary with platform, glibc version, and
+CPU SIMD dispatch, while Rust links a vendored libm, so bit-exactness is
+not portable and deliberately not a goal.  The Rust backend minimizes the
+gap by mirroring numpy's float operation order and keeping the float64
+yaw rate for the lateral product; the residual 1-ulp-scale differences
+are nanometers in physical terms, dwarfed by the wire format's own 1 cm
+quantization.  Everything else — including GPS Speed and InlineAcc (pure
+arithmetic + sqrt) — must be bit-exact on every platform.
 """
 
 from pathlib import Path
@@ -43,8 +36,9 @@ except ImportError:
 pytestmark = pytest.mark.skipif(not _RUST_AVAILABLE, reason="Rust backend not available")
 
 
-# Per-channel float tolerances for known GPS float-path differences
-# (rtol, atol); channels not listed must match bit-exactly.
+# Tight tolerances for GPS channels derived through libm transcendentals
+# (rtol, atol); see the module docstring for why these are not bit-exact
+# across platforms.  Channels not listed must match bit-exactly everywhere.
 _GPS_FLOAT_TOLERANCES = {
     "GPS Latitude": (0.0, 1e-11),
     "GPS Longitude": (0.0, 1e-11),
@@ -166,14 +160,6 @@ def test_backends_equivalent(fixture: Path) -> None:
     assert not errors, f"{fixture.name}: backend divergence:\n" + "\n".join(errors)
 
 
-# ---------------------------------------------------------------------------
-# Probes for documented residual discrepancies.  The strict xfail below
-# turns into an XPASS failure when the underlying divergence is fixed,
-# prompting removal of the marker (and of the corresponding carve-out
-# above).
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize(
     "path",
     [
@@ -214,19 +200,3 @@ def test_duplicate_name_channels_all_exposed(path: Path) -> None:
         assert cy_meta.source_channel_id == src_id, name
         assert rs_meta.source_channel_id == src_id, name
         assert len(cy.channels[name]) == len(rs.channels[name]) > 0, name
-
-
-@pytest.mark.xfail(
-    # Not strict: whether these channels come out bit-identical depends on
-    # the host's numpy kernels (glibc version, SIMD dispatch) — they match
-    # on some machines and differ by 1 ulp on others.
-    strict=False,
-    reason="GPS float paths differ between numpy and Rust at the ulp level "
-    "(module docstring, item 1)",
-)
-def test_gps_channels_bitwise_identical() -> None:
-    cy, rs = _load_both(TEST_DATA_DIR / "SFJ/CMD_SFJ_Fuji GP Sh_Generic testing_a_0033.xrk")
-    for name in ("GPS Latitude", "GPS Altitude", "GPS_LateralAcc"):
-        cy_v = cy.channels[name].column(name).to_numpy()
-        rs_v = rs.channels[name].column(name).to_numpy()
-        np.testing.assert_array_equal(cy_v, rs_v, err_msg=name)


### PR DESCRIPTION
The Rust backend's GPS-derived channels differed from Cython's at the
ulp level on every fixture (Latitude <= 1.5e-14 deg, Altitude <= 2.9e-9 m,
LateralAcc <= 5e-7 g). Two fixes:

1. Operation order. The Rust Vermeille-2003 ECEF->LLA used "/(a*a)",
   "r*r*r" and freely reassociated products where numpy computes
   "*(1/(a*a))", pow(r, 3.0), and strict left-to-right association.
   The conversion now mirrors gps.py operation for operation.

2. Float32-rounded yaw. Lateral acceleration was computed from the
   float32-rounded yaw rate; Cython uses the intermediate float64 value.
   The float64 yaw vector is now kept for that product.

Bit-exactness is deliberately NOT a goal. Rust's f64::cbrt/powf come
from the toolchain's vendored libm (a musl port statically provided by
compiler-builtins) while numpy's math kernels vary with platform, glibc
version, and CPU SIMD dispatch - CI's ubuntu runners produce 1-ulp
differences even in plain atan2 - so cross-runtime bit-equality is not
portable, and chasing it (e.g. dlsym-ing the system libm) only adds
unsafe complexity for nanometer-scale differences dwarfed by the wire
format's own 1 cm quantization.

Instead, tests/test_backend_equivalence.py bounds the five
transcendental-derived GPS channels (Latitude, Longitude, Altitude,
LateralAcc, Yaw_Rate) with tight documented tolerances (1e-11 deg /
1e-6 m / f32-ulp - several hundred times the residuals measured after
these fixes) on every platform, and requires everything else -
including GPS Speed and InlineAcc, which are pure arithmetic plus
sqrt - to match bit-exactly everywhere.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
