### PR TITLE
test: make the shock-pot DLL ground-truth test self-contained

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "pyyaml>=6.0",
     "pytest-xdist>=3.8.0",
     "maturin>=1.11.5",
+    "filelock>=3.32.3",
 ]
 
 [tool.setuptools.packages.find]

--- a/spec/tests/test_spec.py
+++ b/spec/tests/test_spec.py
@@ -1179,41 +1179,44 @@ class TestIssue68CVariants:
         that we cannot replicate without its internal clock model; in
         practice we hit ≥99.9% on this fixture.
         """
-        import subprocess
         import json
+        import shutil
+        import subprocess
+        import tempfile
+        from pathlib import Path
+
+        import filelock
         import numpy as np
-        import os
+        import pytest
+
+        from spec.tests.conftest import ISSUE68_XRZ, REFERENCE_DLL_DIR, _dll_available
 
         # Pull full DLL LR_Shock_Pot samples (only if Wine/DLL available).
+        if not _dll_available():
+            pytest.skip("AIM DLL or Wine not available")
         wine = "/usr/lib/wine/wine64"
-        if not os.path.exists(wine):
-            import pytest
-
-            pytest.skip("Wine not installed")
-        script = "Z:/home/m3rlin45/code/libxrk-3/tests/reference_dll/wine_full_extract.py"
-        dll_path = "/home/m3rlin45/code/libxrk-3/tests/reference_dll/MatLabXRK-2017-64-ReleaseU.dll"
-        if not os.path.exists(dll_path):
-            import pytest
-
-            pytest.skip("AIM DLL not installed")
-        py = "/home/m3rlin45/code/libxrk-3/tests/reference_dll/.setup/python-embed/python.exe"
-        xrz_win = (
-            "Z:/home/m3rlin45/code/libxrk-3/tests/test_data/issue68/"
-            "CMD_KK-SII_Tsukuba_Car_Generic testing_a_0101.xrz"
-        )
-        env = {"WINEDEBUG": "-all", "HOME": "/home/m3rlin45/code", "PATH": "/usr/bin:/bin"}
-        wine_all_script = "Z:/home/m3rlin45/code/libxrk-3/tests/reference_dll/wine_all_samples.py"
-        if not os.path.exists(wine_all_script.replace("Z:", "")):
-            import pytest
-
-            pytest.skip("wine_all_samples.py helper not present")
-        proc = subprocess.run(
-            [wine, py, wine_all_script, xrz_win, "LR_Shock_Pot"],
-            capture_output=True,
-            text=True,
-            timeout=600,
-            env=env,
-        )
+        py = str(REFERENCE_DLL_DIR / ".setup" / "python-embed" / "python.exe")
+        wine_all_script = "Z:" + str(REFERENCE_DLL_DIR / "wine_all_samples.py")
+        env = {
+            "WINELOADER": wine,
+            "WINEDEBUG": "-all",
+            "HOME": str(Path.home()),
+            "PATH": "/usr/bin:/bin",
+        }
+        # The DLL writes scratch files next to its input (an .xrz gets a
+        # sibling .xrk), so hand it a copy in a temp directory.
+        lock = filelock.FileLock(Path(__file__).parent / ".wine_extract.lock")
+        with tempfile.TemporaryDirectory(prefix="libxrk-dll-") as tmp:
+            scratch = Path(tmp) / ISSUE68_XRZ.name
+            shutil.copy2(ISSUE68_XRZ, scratch)
+            with lock:
+                proc = subprocess.run(
+                    [wine, py, wine_all_script, "Z:" + str(scratch), "LR_Shock_Pot"],
+                    capture_output=True,
+                    text=True,
+                    timeout=600,
+                    env=env,
+                )
         dll = json.loads(proc.stdout)
         dll_map = {int(round(t)): v for t, v in zip(dll["t_ms"], dll["v"])}
 

--- a/tests/reference_dll/wine_all_samples.py
+++ b/tests/reference_dll/wine_all_samples.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+"""Dump the full sample array of one channel from the official AIM DLL.
+
+Designed to run in Wine Python (no external dependencies).
+
+Usage:
+    WINEDEBUG=-all wine python.exe Z:/.../wine_all_samples.py Z:/path/file.xrk <channel_name> [dll_path]
+
+Output is JSON to stdout: {"t_ms": [...], "v": [...]} with times in
+milliseconds (the DLL reports seconds).
+
+NOTE: the DLL writes scratch files next to its input (an .xrz input gets a
+sibling .xrk); callers should point it at a copy in a temp directory.
+"""
+
+import ctypes
+from ctypes import POINTER, c_char_p, c_double, c_int
+import json
+import os
+import sys
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(json.dumps({"error": "Usage: wine_all_samples.py <xrk_file> <channel> [dll_path]"}))
+        sys.exit(1)
+
+    xrk_path = sys.argv[1]
+    channel_name = sys.argv[2]
+
+    if len(sys.argv) >= 4:
+        dll_path = sys.argv[3]
+    else:
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        dll_path = os.path.join(script_dir, "MatLabXRK-2017-64-ReleaseU.dll")
+
+    try:
+        dll = ctypes.CDLL(dll_path)
+    except Exception as e:
+        print(json.dumps({"error": "Failed to load DLL: %s" % e}))
+        sys.exit(1)
+
+    dll.open_file.argtypes = [c_char_p]
+    dll.open_file.restype = c_int
+    dll.close_file_i.argtypes = [c_int]
+    dll.close_file_i.restype = None
+    dll.get_channels_count.argtypes = [c_int]
+    dll.get_channels_count.restype = c_int
+    dll.get_channel_name.argtypes = [c_int, c_int]
+    dll.get_channel_name.restype = c_char_p
+    dll.get_channel_samples_count.argtypes = [c_int, c_int]
+    dll.get_channel_samples_count.restype = c_int
+    dll.get_channel_samples.argtypes = [c_int, c_int, POINTER(c_double), POINTER(c_double), c_int]
+    dll.get_channel_samples.restype = c_int
+
+    idx = dll.open_file(os.path.abspath(xrk_path).encode("utf-8"))
+    if idx < 0:
+        print(json.dumps({"error": "Failed to open file: %s" % xrk_path}))
+        sys.exit(1)
+
+    try:
+        target = None
+        for ch in range(dll.get_channels_count(idx)):
+            name_bytes = dll.get_channel_name(idx, ch)
+            name = name_bytes.decode("latin-1") if name_bytes else ""
+            if name == channel_name:
+                target = ch
+                break
+        if target is None:
+            print(json.dumps({"error": "Channel not found: %s" % channel_name}))
+            sys.exit(1)
+
+        count = dll.get_channel_samples_count(idx, target)
+        times = (c_double * count)()
+        values = (c_double * count)()
+        if count > 0 and dll.get_channel_samples(idx, target, times, values, count) == 0:
+            print(json.dumps({"error": "Failed to get samples"}))
+            sys.exit(1)
+
+        print(json.dumps({"t_ms": [t * 1000.0 for t in times], "v": list(values)}))
+    finally:
+        dll.close_file_i(idx)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -143,6 +143,15 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.32.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/64/a02e6765de08964ed371eca577870593245afc9dfac16d037de7c10d18e6/filelock-3.32.3.tar.gz", hash = "sha256:0ffa185a3540854c95caa7fa76b76cb219d907415e2c5dc9af25fd970563487f", size = 218135, upload-time = "2026-08-13T16:00:05.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/8e/50f46a9c0ce8d2861a394c1347caae037ea0431d2f67d7feb151cbc4649a/filelock-3.32.3-py3-none-any.whl", hash = "sha256:7f0ca4bcc0e181c60dbbd8aa9ab5b120ebb99e4e064e83636340056f833a1f09", size = 98901, upload-time = "2026-08-13T16:00:03.974Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -257,6 +266,7 @@ test = [
 dev = [
     { name = "black" },
     { name = "construct" },
+    { name = "filelock" },
     { name = "maturin" },
     { name = "mypy" },
     { name = "parameterized" },
@@ -284,6 +294,7 @@ provides-extras = ["test"]
 dev = [
     { name = "black", specifier = ">=25.11.0,<26.0.0" },
     { name = "construct", specifier = ">=2.10.0" },
+    { name = "filelock", specifier = ">=3.32.3" },
     { name = "maturin", specifier = ">=1.11.5" },
     { name = "mypy", specifier = ">=1.18.2" },
     { name = "parameterized", specifier = ">=0.9.0" },


### PR DESCRIPTION

spec/tests/test_spec.py::test_lr_shock_pot_samples_match_dll - the
authoritative spec correctness check for issue #68 - hardcoded absolute
paths into a sibling checkout (~/code/libxrk-3) for the Wine harness,
the AIM DLL, the fixture, and a wine_all_samples.py helper that did not
exist in this repository at all.

The test now resolves everything from this repo (REFERENCE_DLL_DIR /
conftest helpers), takes the shared wine-extract file lock, and hands
the DLL a temp-directory copy of the fixture so it cannot litter
tests/test_data/ with its scratch files. The missing helper is added:
tests/reference_dll/wine_all_samples.py dumps one channel's full sample
array (t_ms, v) as JSON via the DLL's get_channel_samples API.

With the DLL harness installed (tests/reference_dll/
setup_dll_comparison.sh), the whole spec suite now runs its DLL
ground-truth checks from this checkout alone; without it they skip as
before.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/m3rlin45/libxrk/pull/96).
* __->__ #96
* #95
* #94
* #93
* #92
* #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)
