### PR TITLE
Progress callback that actually fires, and a callable aim_xrk under the Rust backend

### DIFF
--- a/crates/libxrk-python/src/lib.rs
+++ b/crates/libxrk-python/src/lib.rs
@@ -57,6 +57,16 @@ fn read_source_bytes(_py: Python<'_>, source: &Bound<'_, PyAny>) -> PyResult<Vec
     })
 }
 
+/// Bytes between two progress callbacks, overridable without rebuilding through
+/// the `LIBXRK_PROGRESS_INTERVAL` environment variable (same knob as the Cython
+/// backend). Values below the parser's floor are clamped by the parser.
+fn progress_interval() -> usize {
+    std::env::var("LIBXRK_PROGRESS_INTERVAL")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(libxrk::parser::DEFAULT_PROGRESS_INTERVAL)
+}
+
 /// Parse an AIM XRK/XRZ file and return a LogFile.
 #[pyfunction]
 #[pyo3(signature = (fname, progress=None))]
@@ -79,8 +89,12 @@ fn aim_xrk(py: Python<'_>, fname: Py<PyAny>, progress: Option<Py<PyAny>>) -> PyR
         closure
     });
 
-    let mut result = libxrk::parser::parse_xrk(&data, progress_cb.as_ref().map(|cb| cb.as_ref()))
-        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+    let mut result = libxrk::parser::parse_xrk_with_interval(
+        &data,
+        progress_cb.as_ref().map(|cb| cb.as_ref()),
+        progress_interval(),
+    )
+    .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
 
     // Compute non-GPS max end time before moving channel_data out
     let non_gps_max_end_time: Option<i64> = result

--- a/crates/libxrk/src/lib.rs
+++ b/crates/libxrk/src/lib.rs
@@ -87,11 +87,23 @@ pub fn read_xrk_with_progress(
     data: &[u8],
     progress: Option<&dyn Fn(usize, usize)>,
 ) -> Result<XrkFile> {
+    read_xrk_with_options(data, progress, parser::DEFAULT_PROGRESS_INTERVAL)
+}
+
+/// Parse with an optional progress callback, choosing how often it is called.
+///
+/// `progress_interval` is a number of input bytes, clamped to
+/// [`parser::MIN_PROGRESS_INTERVAL`].
+pub fn read_xrk_with_options(
+    data: &[u8],
+    progress: Option<&dyn Fn(usize, usize)>,
+    progress_interval: usize,
+) -> Result<XrkFile> {
     // Decompress if XRZ (zlib-compressed XRK)
     let data = decompress_if_zlib(data);
 
     // Parse with the Rust streaming parser
-    let mut result = parser::parse_xrk(&data, progress)?;
+    let mut result = parser::parse_xrk_with_interval(&data, progress, progress_interval)?;
 
     // Compute non-GPS max end time before moving channel_data out
     let non_gps_max_end_time: Option<i64> = result

--- a/crates/libxrk/src/parser.rs
+++ b/crates/libxrk/src/parser.rs
@@ -187,6 +187,17 @@ pub struct LapInfo {
     pub end_time: u32,
 }
 
+/// Default number of bytes between two progress callbacks.
+///
+/// The previous value, 8 MB, meant no callback at all fired for any file
+/// smaller than 8 MB — which is most single-session logs. 256 KB gives ~20
+/// callbacks on a 5 MB file and ~160 on a 42 MB one, for no measurable cost.
+pub const DEFAULT_PROGRESS_INTERVAL: usize = 262_144;
+
+/// Lower bound on the progress interval, to keep a caller from asking for a
+/// callback on every byte.
+pub const MIN_PROGRESS_INTERVAL: usize = 4096;
+
 /// Parse an XRK byte stream.
 ///
 /// This is the main entry point equivalent to `_decode_sequence()`.
@@ -194,6 +205,18 @@ pub fn parse_xrk(
     data: &[u8],
     progress: Option<&dyn Fn(usize, usize)>,
 ) -> Result<ParseResult, Error> {
+    parse_xrk_with_interval(data, progress, DEFAULT_PROGRESS_INTERVAL)
+}
+
+/// Parse an XRK byte stream, choosing how often `progress` is called.
+///
+/// `progress_interval` is clamped to [`MIN_PROGRESS_INTERVAL`].
+pub fn parse_xrk_with_interval(
+    data: &[u8],
+    progress: Option<&dyn Fn(usize, usize)>,
+    progress_interval: usize,
+) -> Result<ParseResult, Error> {
+    let progress_interval = progress_interval.max(MIN_PROGRESS_INTERVAL);
     let mut state = ParserState::new();
 
     // Pre-scan: learn channel structure from headers and count data sizes.
@@ -202,7 +225,7 @@ pub fn parse_xrk(
     let hints = prescan(data, &mut state);
     state.apply_prescan_hints(&hints);
 
-    let final_pos = scan_stream(data, &mut state, progress);
+    let final_pos = scan_stream(data, &mut state, progress, progress_interval);
     if final_pos != data.len() {
         return Err(Error::InvalidData(format!(
             "Parser did not consume entire input: pos={}, len={}",
@@ -692,7 +715,7 @@ fn prescan_header_message(msg: &HeaderMessage, state: &mut ParserState, hints: &
     if token == tokens::cnf() {
         // Recursively discover channels from CNF payload.
         let mut sub_state = ParserState::new();
-        scan_stream(&msg.payload, &mut sub_state, None);
+        scan_stream(&msg.payload, &mut sub_state, None, DEFAULT_PROGRESS_INTERVAL);
         for ch_info in sub_state.channels.values() {
             if !state.channels.contains_key(&ch_info.chs.index) {
                 state.register_chs(&ch_info.chs);
@@ -737,12 +760,12 @@ fn scan_stream(
     data: &[u8],
     state: &mut ParserState,
     progress: Option<&dyn Fn(usize, usize)>,
+    progress_interval: usize,
 ) -> usize {
     let len = data.len();
     let mut pos: usize = 0;
     let mut bad_pos: usize = 0;
     let mut bad_count: usize = 0;
-    let progress_interval: usize = 8_000_000;
     let mut next_progress: usize = progress_interval;
 
     while pos < len {
@@ -858,7 +881,7 @@ fn handle_header_message(msg: &HeaderMessage, state: &mut ParserState) {
 
         // Recursively parse the CNF payload
         let mut sub_state = ParserState::new();
-        scan_stream(&msg.payload, &mut sub_state, None);
+        scan_stream(&msg.payload, &mut sub_state, None, DEFAULT_PROGRESS_INTERVAL);
 
         // Merge CHS and GRP from sub-parse. A later CNF re-definition wins
         // on names (matching the AIM DLL, which exposes the renamed channel
@@ -887,7 +910,7 @@ fn handle_header_message(msg: &HeaderMessage, state: &mut ParserState) {
     // ENF: recursive parse — store sub-messages separately per ENF
     if token == tokens::enf() {
         let mut sub_state = ParserState::new();
-        scan_stream(&msg.payload, &mut sub_state, None);
+        scan_stream(&msg.payload, &mut sub_state, None, DEFAULT_PROGRESS_INTERVAL);
         // Store each ENF's sub-messages separately for expansion device extraction
         state.enf_sub_messages.push(sub_state.header_messages);
         return;

--- a/src/libxrk/__init__.py
+++ b/src/libxrk/__init__.py
@@ -26,6 +26,15 @@ import os as _os
 _backend = _os.environ.get("LIBXRK_BACKEND", "").lower()
 
 if _backend == "rust":
+    # Import the Cython submodule FIRST, then rebind the name. `libxrk.aim_xrk`
+    # is both a submodule and an exported function: whichever module imports
+    # `libxrk.aim_xrk` first makes the import machinery set the submodule as an
+    # attribute of the package, which shadows the function exported here. On the
+    # Cython path the two are the same object, so nothing shows; on the Rust path
+    # `from libxrk import aim_xrk` then yields a module and calling it raises
+    # "TypeError: 'module' object is not callable" — depending on import order,
+    # which makes it look like a random failure.
+    from . import aim_xrk as _aim_xrk_cython_module  # noqa: F401
     from ._aim_xrk_rs import aim_xrk, aim_track_dbg
 else:
     from .aim_xrk import aim_xrk, aim_track_dbg

--- a/src/libxrk/aim_xrk.pyx
+++ b/src/libxrk/aim_xrk.pyx
@@ -30,6 +30,24 @@ from . import base
 # units
 # dec ptr
 
+# Bytes between two progress callbacks. The previous value, 8_000_000, meant no
+# callback fired at all for any file under 8 MB — which is most single-session
+# logs. 256 KB gives ~20 callbacks on a 5 MB file and ~160 on a 42 MB one, for
+# no measurable cost. Overridable without rebuilding through the
+# LIBXRK_PROGRESS_INTERVAL environment variable (same knob as the Rust backend).
+try:
+    _PROGRESS_INTERVAL = max(4096, int(os.environ.get('LIBXRK_PROGRESS_INTERVAL', 262_144)))
+except ValueError:
+    _PROGRESS_INTERVAL = 262_144
+
+# The parallel path below is only attempted where the platform can start
+# threads. Pyodide/WebAssembly cannot: there, passing a progress callback made
+# the decode fail with "RuntimeError: can't start new thread" — the same file
+# decoded fine without a callback and failed with one. The sequential path
+# invokes the callback the same way, so nothing is lost but the parallelism,
+# which does not exist on that platform anyway.
+_THREADS_AVAILABLE = sys.platform not in ('emscripten', 'wasi')
+
 dc_slots = {'slots': True} if sys.version_info.minor >= 10 else {}
 
 @dataclass(**dc_slots)
@@ -329,7 +347,7 @@ def _decode_sequence(s, progress=None):
     tok_GPS: cython.uint = _tokdec('GPS')
     tok_GPS1: cython.uint = _tokdec('GPS1')
     tok_GNFI: cython.uint = _tokdec('GNFI')
-    progress_interval: cython.Py_ssize_t = 8_000_000
+    progress_interval: cython.Py_ssize_t = _PROGRESS_INTERVAL
     next_progress: cython.Py_ssize_t = progress_interval
     pos: cython.Py_ssize_t = 0
     oldpos: cython.Py_ssize_t = pos
@@ -1019,7 +1037,7 @@ def _decode_sequence(s, progress=None):
     if not channels:
         t4 = time.perf_counter()
         pass # nothing to do
-    elif progress:
+    elif progress and _THREADS_AVAILABLE:
         with concurrent.futures.ThreadPoolExecutor(max_workers=min(2, os.cpu_count())) as worker:
             bg_work = worker.submit(_bg_gps_laps, <cython.uchar[:gpsmsg.size()]> &gpsmsg[0],
                                     <cython.uchar[:gnfimsg.size()]> &gnfimsg[0] if gnfimsg.size() else None,


### PR DESCRIPTION
<!--
CORPS DE LA PULL REQUEST — tout ce fichier se copie tel quel dans la zone
"Add a description" de GitHub. Ce bloc-ci est un commentaire HTML : il ne
s'affiche pas dans la PR publiée.

Titre à mettre :
Progress callback that actually fires, and a callable aim_xrk under the Rust backend

Lien direct pour ouvrir la PR :
https://github.com/m3rlin45/libxrk/compare/master...tothemoonsarl:libxrk:feat/progress-interval-and-wasm?expand=1
-->

Two fixes found while validating the Rust backend against the Cython one on a
12-file corpus (3.1 to 41.8 MB, 5 logger models), from the point of view of a
browser/mobile consumer. Both extensions were imported side by side in one
process, so no environment or state difference between the two measurements.

First, a thank-you and a confirmation. We hit the random channel order, the
duplicate-name collisions and the 18 ms offset on `test.xrk` on `v0.13.0`, and
had patches for the first two. `5742ee3`, `b4a89e6` and `fe0f907` landed before
we could send them, and they are better than what we had — in particular pinning
the v2 LAP layout against the official DLL rather than guessing. Independently
re-measured on `4e44d38`, over the same corpus: **12/12 files equivalent**,
identical channel order, identical lap tables, identical session and channel
metadata, and the largest float divergence on any derived GPS channel down from
4.8e-07 to 3.7e-09. On `test.xrk` both backends now start at timecode 0 and
return the same 11 laps. Nothing left to report on decoding.

What follows is what is still open.

### 1. `feat: progress callback that actually fires, and no thread pool on wasm`

Two problems, one commit, no decoding logic touched.

**The callback never fires.** `progress_interval` is `8_000_000` bytes in both
backends. A file under 8 MB — the typical kart session — decodes without a
single call. Measured on `4e44d38`: **0 calls** on 5.2 MB, both backends. The
commit lowers the default to 262 144 (19 calls on that file, ~160 on 41.8 MB),
overridable with `LIBXRK_PROGRESS_INTERVAL` (floor 4096), and adds
`parse_xrk_with_interval` / `read_xrk_with_options` so Rust callers can pass it
explicitly. Existing signatures are unchanged.

Cost of the more frequent callback, same binary, `LIBXRK_PROGRESS_INTERVAL` at
`8_000_000` then `262_144`, median of 3 runs: **0.97 s vs 0.93 s** — inside the
measurement noise.

**Asking for progress breaks decoding under WebAssembly.** `aim_xrk.pyx` tests
`elif progress:` and, in that branch only, opens a `ThreadPoolExecutor`. Pyodide
has no threads:

```
RuntimeError: can't start new thread
```

The same file decodes fine without a callback and fails with one, which makes
the feature unusable on the browser target — where a progress bar matters most.
The guard becomes `elif progress and _THREADS_AVAILABLE:` with
`_THREADS_AVAILABLE = sys.platform not in ('emscripten', 'wasi')`. The
sequential path already calls the callback the same way, so wasm loses a
parallelism it never had and gains the progress reporting.

### 2. `fix: keep libxrk.aim_xrk callable when the Rust backend is selected`

With `LIBXRK_BACKEND=rust`, `libxrk/__init__.py` binds the name `aim_xrk` to the
Rust function, but importing the `libxrk.aim_xrk` **submodule** anywhere later
rebinds that attribute to the module object. Whether `from libxrk import
aim_xrk` gives you a callable then depends on import order:

```python
>>> import libxrk; callable(libxrk.aim_xrk)
True
>>> import libxrk.aim_xrk; callable(libxrk.aim_xrk)
False
```

On `v0.13.0` this produced 36 failures in the test suite under the Rust backend
while every test file passed in isolation. The commit re-binds the attribute
after the submodule import, and documents why.

## Evidence

Run on `4e44d38` with the two commits applied:

| | result |
|---|---|
| `cargo test` | 132 passed |
| `pytest tests` (Cython) | 286 passed |
| `LIBXRK_BACKEND=rust pytest tests` | 286 passed |
| progress calls, 5.2 MB file | 0 → **19**, both backends |
| decode output | unchanged — same channels, same values, same laps |

Happy to split the two commits into separate PRs, drop the environment variable,
or use a different default interval if 262 144 is not to your taste.